### PR TITLE
Fix duplicate pipeline deployments with atomic status locking

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/data/PipelineRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/data/PipelineRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -32,4 +36,11 @@ public interface PipelineRepository extends JpaRepository<Pipeline, String>, Jpa
     Page<Pipeline> findByNamespaceAndApplicationNameAndEnvironment(String namespace, String applicationName, String environment, Pageable pageable);
 
     Pipeline findFirstByNamespaceAndApplicationNameAndStatusOrderByCreatedTimeDesc(String namespace, String applicationName, PipelineStatus status);
+
+    @Modifying
+    @Transactional
+    @Query("update Pipeline p set p.status = :target where p.id = :id and p.status = :expected")
+    int updateStatusIfMatch(@Param("id") String id,
+                            @Param("expected") PipelineStatus expected,
+                            @Param("target") PipelineStatus target);
 }

--- a/src/main/java/com/github/wellch4n/oops/enums/PipelineStatus.java
+++ b/src/main/java/com/github/wellch4n/oops/enums/PipelineStatus.java
@@ -5,7 +5,7 @@ package com.github.wellch4n.oops.enums;
  * @date 2025/7/5
  */
 public enum PipelineStatus {
-    INITIALIZED, PENDING, RUNNING,
-    STOPED,
+    INITIALIZED, RUNNING, DEPLOYING,
+    STOPPED,
     SUCCEEDED, ERROR
 }

--- a/src/main/java/com/github/wellch4n/oops/job/PipelineInstanceScanJob.java
+++ b/src/main/java/com/github/wellch4n/oops/job/PipelineInstanceScanJob.java
@@ -46,7 +46,7 @@ public class PipelineInstanceScanJob {
             try {
 
                 if (PipelineStatus.SUCCEEDED.equals(pipeline.getStatus()) || PipelineStatus.ERROR.equals(pipeline.getStatus())) {
-                    return;
+                    continue;
                 }
 
                 String environmentName = pipeline.getEnvironment();
@@ -55,6 +55,13 @@ public class PipelineInstanceScanJob {
                 try (var client = environment.getKubernetesApiServer().fabric8Client()) {
                     Job job = client.batch().v1().jobs().inNamespace(environment.getWorkNamespace()).withName(pipeline.getName()).get();
                     if (job.getStatus() != null && job.getStatus().getSucceeded() != null && job.getStatus().getSucceeded() == 1) {
+                        int claimed = pipelineRepository.updateStatusIfMatch(
+                                pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.DEPLOYING
+                        );
+                        if (claimed == 0) {
+                            continue;
+                        }
+
                         Application application = applicationRepository.findByNamespaceAndName(pipeline.getNamespace(), pipeline.getApplicationName());
                         ApplicationPerformanceConfig.EnvironmentConfig applicationPerformanceEnvironmentConfig = resolveEnvironmentConfig(
                                 application.getNamespace(), application.getName(), pipeline.getEnvironment());
@@ -68,18 +75,24 @@ public class PipelineInstanceScanJob {
                         );
                         artifactDeployTask.call();
 
-                        pipeline.setStatus(PipelineStatus.SUCCEEDED);
-                        pipelineRepository.save(pipeline);
+                        pipelineRepository.updateStatusIfMatch(
+                                pipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.SUCCEEDED
+                        );
                     } else if (job.getStatus() != null && job.getStatus().getFailed() != null && job.getStatus().getFailed() > 0) {
                         System.err.println("Error processing succeeded pipeline " + pipeline.getId());
-                        pipeline.setStatus(PipelineStatus.ERROR);
-                        pipelineRepository.save(pipeline);
+                        pipelineRepository.updateStatusIfMatch(
+                                pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.ERROR
+                        );
                     }
                 }
             } catch (Exception e) {
                 System.out.println("Error scanning pipeline instance: " + e.getMessage());
-                pipeline.setStatus(PipelineStatus.ERROR);
-                pipelineRepository.save(pipeline);
+                pipelineRepository.updateStatusIfMatch(
+                        pipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.ERROR
+                );
+                pipelineRepository.updateStatusIfMatch(
+                        pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.ERROR
+                );
             }
         }
     }

--- a/src/main/java/com/github/wellch4n/oops/service/PipelineService.java
+++ b/src/main/java/com/github/wellch4n/oops/service/PipelineService.java
@@ -177,7 +177,7 @@ public class PipelineService {
                             .withSuspend(true)
                             .endSpec()
                             .build());
-            pipeline.setStatus(PipelineStatus.STOPED);
+            pipeline.setStatus(PipelineStatus.STOPPED);
             pipelineRepository.save(pipeline);
             return true;
         }

--- a/web/app/pipelines/columns.tsx
+++ b/web/app/pipelines/columns.tsx
@@ -25,9 +25,9 @@ export const getPipelineColumns = (
     cell: ({ row }) => {
       const status = row.original.status
       let variant: "default" | "secondary" | "destructive" | "outline" = "outline"
-      if (status === "RUNNING") variant = "default"
+      if (status === "RUNNING" || status === "DEPLOYING") variant = "default"
       if (status === "SUCCEEDED") variant = "secondary"
-      if (status === "ERROR" || status === "STOPED") variant = "destructive"
+      if (status === "ERROR" || status === "STOPPED") variant = "destructive"
       
       return <Badge variant={variant}>{status}</Badge>
     }
@@ -49,7 +49,7 @@ export const getPipelineColumns = (
             <Eye className="mr-2 h-4 w-4" />
             查看
           </Button>
-          {(row.original.status === "RUNNING" || row.original.status === "PENDING") && (
+          {(row.original.status === "RUNNING" || row.original.status === "DEPLOYING") && (
             <Button variant="destructive" size="sm" onClick={() => onStop(row.original)}>
               <Ban className="mr-2 h-4 w-4" />
               停止

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -83,7 +83,7 @@ export interface ApplicationPodStatus {
   podIP: string
 }
 
-export type PipelineStatus = 'INITIALIZED' | 'PENDING' | 'RUNNING' | 'STOPED' | 'SUCCEEDED' | 'ERROR'
+export type PipelineStatus = 'INITIALIZED' | 'RUNNING' | 'DEPLOYING' | 'STOPPED' | 'SUCCEEDED' | 'ERROR'
 
 export interface Pipeline {
   id: string


### PR DESCRIPTION
### Summary
- Add an atomic status transition method (`updateStatusIfMatch`) in `PipelineRepository` to implement compare-and-set locking for pipeline state changes.
- Prevent duplicate deployments in `PipelineInstanceScanJob` by claiming `RUNNING -> DEPLOYING` before deploy and skipping when claim fails.
- Replace direct status saves with guarded transitions for success/failure paths (`DEPLOYING -> SUCCEEDED`, `RUNNING/DEPLOYING -> ERROR`).
- Fix scan loop control flow from `return` to `continue` so one terminal pipeline does not stop processing others.
- Normalize status naming by replacing `PENDING` with `DEPLOYING` and correcting `STOPED` to `STOPPED` across backend and frontend types/UI behavior.

### Testing
- `./mvnw -q -DskipTests compile`
- Frontend build attempted; blocked by network font fetch errors (`Geist`/`Geist Mono`) rather than code issues