### PR TITLE
feat: validate duplicate service hosts across applications

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/controller/ApplicationController.java
+++ b/src/main/java/com/github/wellch4n/oops/controller/ApplicationController.java
@@ -8,6 +8,7 @@ import com.github.wellch4n.oops.objects.ClusterDomainResponse;
 import com.github.wellch4n.oops.objects.LastSuccessfulPipelineResponse;
 import com.github.wellch4n.oops.objects.Page;
 import com.github.wellch4n.oops.objects.Result;
+import com.github.wellch4n.oops.objects.ServiceHostConflictResponse;
 import com.github.wellch4n.oops.service.ApplicationService;
 import com.github.wellch4n.oops.service.PipelineService;
 import com.github.wellch4n.oops.utils.ResourceNameChecker;
@@ -138,6 +139,12 @@ public class ApplicationController {
     @PutMapping("/{name}/service")
     public Result<Boolean> updateService(@PathVariable String namespace, @PathVariable String name, @RequestBody ApplicationServiceConfig config) {
         return Result.success(applicationService.updateApplicationServiceConfig(namespace, name, config));
+    }
+
+    @GetMapping("/{name}/service/host-check")
+    public Result<ServiceHostConflictResponse> checkServiceHost(@PathVariable String namespace, @PathVariable String name,
+                                                                @RequestParam String host) {
+        return Result.success(applicationService.findHostConflictApplication(namespace, name, host));
     }
 
     @GetMapping("/{name}/service/cluster-domain")

--- a/src/main/java/com/github/wellch4n/oops/data/ApplicationServiceConfigRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/data/ApplicationServiceConfigRepository.java
@@ -1,12 +1,21 @@
 package com.github.wellch4n.oops.data;
 
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ApplicationServiceConfigRepository extends CrudRepository<ApplicationServiceConfig, String> {
+public interface ApplicationServiceConfigRepository extends JpaRepository<ApplicationServiceConfig, String> {
     Optional<ApplicationServiceConfig> findByNamespaceAndApplicationName(String namespace, String applicationName);
 
     void deleteByNamespaceAndApplicationName(String namespace, String applicationName);
+
+    @Query(value = "SELECT * FROM application_service_config WHERE environment_configs LIKE %:hostPattern% "
+            + "AND NOT (namespace = :namespace AND application_name = :applicationName)", nativeQuery = true)
+    List<ApplicationServiceConfig> findByHostLikeExcludingSelf(@Param("hostPattern") String hostPattern,
+                                                               @Param("namespace") String namespace,
+                                                               @Param("applicationName") String applicationName);
 }

--- a/src/main/java/com/github/wellch4n/oops/objects/ServiceHostConflictResponse.java
+++ b/src/main/java/com/github/wellch4n/oops/objects/ServiceHostConflictResponse.java
@@ -1,0 +1,4 @@
+package com.github.wellch4n.oops.objects;
+
+public record ServiceHostConflictResponse(String namespace, String applicationName, String environmentName) {
+}

--- a/src/main/java/com/github/wellch4n/oops/service/ApplicationService.java
+++ b/src/main/java/com/github/wellch4n/oops/service/ApplicationService.java
@@ -7,6 +7,7 @@ import com.github.wellch4n.oops.exception.BizException;
 import com.github.wellch4n.oops.objects.ApplicationPodStatusResponse;
 import com.github.wellch4n.oops.objects.ApplicationResponse;
 import com.github.wellch4n.oops.objects.ClusterDomainResponse;
+import com.github.wellch4n.oops.objects.ServiceHostConflictResponse;
 import com.github.wellch4n.oops.objects.Page;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -391,7 +392,44 @@ public class ApplicationService {
         return applicationServiceConfigRepository.findByNamespaceAndApplicationName(namespace, name).orElse(null);
     }
 
+    public ServiceHostConflictResponse findHostConflictApplication(String namespace, String name, String host) {
+        if (host == null || host.isBlank()) {
+            return null;
+        }
+        List<ApplicationServiceConfig> conflicts = applicationServiceConfigRepository
+                .findByHostLikeExcludingSelf("\"" + host + "\"", namespace, name);
+        for (ApplicationServiceConfig conflict : conflicts) {
+            if (conflict.getEnvironmentConfigs() == null) {
+                continue;
+            }
+            for (ApplicationServiceConfig.EnvironmentConfig c : conflict.getEnvironmentConfigs()) {
+                if (host.equals(c.getHost())) {
+                    return new ServiceHostConflictResponse(
+                            conflict.getNamespace(),
+                            conflict.getApplicationName(),
+                            c.getEnvironmentName());
+                }
+            }
+        }
+        return null;
+    }
+
     public Boolean updateApplicationServiceConfig(String namespace, String name, ApplicationServiceConfig request) {
+        if (request.getEnvironmentConfigs() != null) {
+            for (ApplicationServiceConfig.EnvironmentConfig envConfig : request.getEnvironmentConfigs()) {
+                String host = envConfig.getHost();
+                if (host == null || host.isBlank()) {
+                    continue;
+                }
+                ServiceHostConflictResponse conflict = findHostConflictApplication(namespace, name, host);
+                if (conflict != null) {
+                    throw new BizException("Host " + host + " is already used by environment "
+                            + conflict.environmentName() + " / namespace " + conflict.namespace()
+                            + " / application " + conflict.applicationName());
+                }
+            }
+        }
+
         Optional<ApplicationServiceConfig> exist = applicationServiceConfigRepository.findByNamespaceAndApplicationName(namespace, name);
 
 

--- a/web/app/apps/components/application-service-info.tsx
+++ b/web/app/apps/components/application-service-info.tsx
@@ -9,7 +9,7 @@ import { toast } from "sonner"
 import { TabsContent } from "@/components/ui/tabs"
 import { Copy, Plug, Globe, Plus, Trash2 } from "lucide-react"
 import { ApplicationEnvironment, ApplicationServiceConfig, ApplicationServiceEnvironmentConfig } from "@/lib/api/types"
-import { updateApplicationService } from "@/lib/api/applications"
+import { updateApplicationService, checkApplicationServiceHost } from "@/lib/api/applications"
 import { ApplicationEnvironmentSelector } from "./application-environment-selector"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useLanguage } from "@/contexts/language-context"
@@ -29,6 +29,7 @@ export function ApplicationServiceInfo({ initialServiceConfig, applicationName, 
   const [port, setPort] = useState<string>("")
   const [activeTab, setActiveTab] = useState<string | undefined>(undefined)
   const [envConfigGroups, setEnvConfigGroups] = useState<EnvConfigGroup[]>([])
+  const [hostErrors, setHostErrors] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState(false)
   const [envsLoading, setEnvsLoading] = useState(!!(namespace && applicationName))
   const { t } = useLanguage()
@@ -97,6 +98,79 @@ export function ApplicationServiceInfo({ initialServiceConfig, applicationName, 
           : group
       )
     )
+    setHostErrors((prev) => {
+      const next: Record<string, string> = {}
+      Object.entries(prev).forEach(([k, v]) => {
+        const [e, iStr] = k.split("::")
+        const i = Number(iStr)
+        if (e !== envName) {
+          next[k] = v
+        } else if (i < index) {
+          next[k] = v
+        } else if (i > index) {
+          next[`${e}::${i - 1}`] = v
+        }
+      })
+      return next
+    })
+  }
+
+  const hostErrorKey = (envName: string, index: number) => `${envName}::${index}`
+
+  const validateHost = async (envName: string, index: number, host: string) => {
+    if (!namespace || !applicationName) return
+    const trimmed = host.trim()
+    const key = hostErrorKey(envName, index)
+    if (!trimmed) {
+      setHostErrors((prev) => {
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+      return
+    }
+    const formatMessage = (name: string, ns: string, env: string) =>
+      t("apps.service.hostDuplicated")
+        .replace("{name}", name)
+        .replace("{namespace}", ns)
+        .replace("{environment}", env)
+
+    // Local duplicate check first (same form)
+    let localDup: { env: string } | undefined
+    for (const group of envConfigGroups) {
+      for (let i = 0; i < group.hosts.length; i++) {
+        if (group.environmentName === envName && i === index) continue
+        if (group.hosts[i].host.trim() === trimmed) {
+          localDup = { env: group.environmentName }
+          break
+        }
+      }
+      if (localDup) break
+    }
+    if (localDup) {
+      setHostErrors((prev) => ({
+        ...prev,
+        [key]: formatMessage(applicationName, namespace, localDup!.env),
+      }))
+      return
+    }
+    try {
+      const res = await checkApplicationServiceHost(namespace, applicationName, trimmed)
+      if (res.success && res.data) {
+        setHostErrors((prev) => ({
+          ...prev,
+          [key]: formatMessage(res.data!.applicationName, res.data!.namespace, res.data!.environmentName),
+        }))
+      } else {
+        setHostErrors((prev) => {
+          const next = { ...prev }
+          delete next[key]
+          return next
+        })
+      }
+    } catch {
+      // ignore transient errors
+    }
   }
 
   const updateHost = (envName: string, index: number, field: "host" | "https", value: string | boolean) => {
@@ -135,6 +209,12 @@ export function ApplicationServiceInfo({ initialServiceConfig, applicationName, 
         }
       })
     })
+
+    if (Object.keys(hostErrors).length > 0) {
+      const firstError = Object.values(hostErrors)[0]
+      toast.error(firstError)
+      return
+    }
 
     setSaving(true)
     try {
@@ -196,9 +276,12 @@ export function ApplicationServiceInfo({ initialServiceConfig, applicationName, 
                   <Globe className="h-3.5 w-3.5" />
                   {t("apps.service.hosts")}
                 </Label>
-                {group.hosts.map((hostConfig, index) => (
-                  <div key={index} className="flex w-full items-center gap-2">
-                    <div className="flex items-center gap-2">
+                {group.hosts.map((hostConfig, index) => {
+                  const errKey = hostErrorKey(group.environmentName, index)
+                  const err = hostErrors[errKey]
+                  return (
+                  <div key={index} className="flex w-full items-start gap-2">
+                    <div className="flex h-9 items-center gap-2">
                       <Checkbox
                         id={`service-https-${group.environmentName}-${index}`}
                         checked={hostConfig.https}
@@ -209,17 +292,28 @@ export function ApplicationServiceInfo({ initialServiceConfig, applicationName, 
                       <Label htmlFor={`service-https-${group.environmentName}-${index}`}>HTTPS</Label>
                     </div>
 
-                    <div className="relative flex-1">
-                      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
-                        {hostConfig.https ? "https://" : "http://"}
-                      </span>
-                      <Input
-                        id={`service-host-${group.environmentName}-${index}`}
-                        className="pl-[4.5rem]"
-                        value={hostConfig.host}
-                        onChange={(e) => updateHost(group.environmentName, index, "host", e.target.value)}
-                        placeholder={t("apps.service.domainPlaceholder")}
-                      />
+                    <div className="flex flex-1 flex-col gap-1">
+                      <div className="relative">
+                        <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
+                          {hostConfig.https ? "https://" : "http://"}
+                        </span>
+                        <Input
+                          id={`service-host-${group.environmentName}-${index}`}
+                          className={`pl-[4.5rem] ${err ? "border-destructive" : ""}`}
+                          value={hostConfig.host}
+                          onChange={(e) => {
+                            updateHost(group.environmentName, index, "host", e.target.value)
+                            setHostErrors((prev) => {
+                              const next = { ...prev }
+                              delete next[errKey]
+                              return next
+                            })
+                          }}
+                          onBlur={(e) => validateHost(group.environmentName, index, e.target.value)}
+                          placeholder={t("apps.service.domainPlaceholder")}
+                        />
+                      </div>
+                      {err && <p className="text-xs text-destructive">{err}</p>}
                     </div>
 
                     <Button
@@ -251,7 +345,8 @@ export function ApplicationServiceInfo({ initialServiceConfig, applicationName, 
                       <Trash2 className="h-4 w-4 text-destructive" />
                     </Button>
                   </div>
-                ))}
+                  )
+                })}
                 <Button type="button" variant="outline" className="w-full" onClick={() => addHost(group.environmentName)}>
                   <Plus className="h-4 w-4 mr-1" />
                   {t("apps.service.addHost")}

--- a/web/lib/api/applications.ts
+++ b/web/lib/api/applications.ts
@@ -262,6 +262,26 @@ export const restartApplicationPod = async (namespace: string, name: string, pod
   return response.json() as Promise<ApiResponse<boolean>>
 }
 
+export interface ServiceHostConflict {
+  namespace: string
+  applicationName: string
+  environmentName: string
+}
+
+export const checkApplicationServiceHost = async (
+  namespace: string,
+  name: string,
+  host: string
+): Promise<ApiResponse<ServiceHostConflict | null>> => {
+  const response = await apiFetch(
+    `/api/namespaces/${namespace}/applications/${name}/service/host-check?host=${encodeURIComponent(host)}`
+  )
+  if (!response.ok) {
+    throw new Error("Failed to check service host")
+  }
+  return response.json() as Promise<ApiResponse<ServiceHostConflict | null>>
+}
+
 export const getClusterDomain = async (namespace: string, name: string, env: string): Promise<ApiResponse<ClusterDomainInfo>> => {
   const response = await apiFetch(`/api/namespaces/${namespace}/applications/${name}/service/cluster-domain?env=${env}`)
   if (!response.ok) {

--- a/web/locales/en-US.ts
+++ b/web/locales/en-US.ts
@@ -229,6 +229,7 @@ const en = {
   "apps.service.domainPlaceholder": "e.g. app.example.com",
   "apps.service.hosts": "Hosts",
   "apps.service.addHost": "Add Host",
+  "apps.service.hostDuplicated": "Host already used by environment {environment} / namespace {namespace} / application {name}",
   "apps.envSelector.label": "Environment",
   "apps.envSelector.noEnv": "No environments. Please configure in basic info.",
   "apps.envSelector.fetchError": "Failed to fetch environments",

--- a/web/locales/ja-JP.ts
+++ b/web/locales/ja-JP.ts
@@ -222,6 +222,7 @@ const locale = {
   "apps.service.domainPlaceholder": "例: app.example.com",
   "apps.service.hosts": "ドメイン設定",
   "apps.service.addHost": "ドメインを追加",
+  "apps.service.hostDuplicated": "このドメインは環境 {environment} / ネームスペース {namespace} / アプリ {name} によって使用されています",
   "apps.envSelector.label": "環境",
   "apps.envSelector.noEnv": "環境設定がありません。先に基本情報でデプロイ環境を設定してください。",
   "apps.envSelector.fetchError": "環境の取得に失敗しました",

--- a/web/locales/zh-CN.ts
+++ b/web/locales/zh-CN.ts
@@ -229,6 +229,7 @@ const zh = {
   "apps.service.domainPlaceholder": "例如 app.example.com",
   "apps.service.hosts": "域名配置",
   "apps.service.addHost": "添加域名",
+  "apps.service.hostDuplicated": "域名已被环境 {environment} / 命名空间 {namespace} / 应用 {name} 占用",
   "apps.envSelector.label": "环境",
   "apps.envSelector.noEnv": "暂无环境配置，请先在基本信息中配置部署环境",
   "apps.envSelector.fetchError": "获取环境失败",

--- a/web/locales/zh-TW.ts
+++ b/web/locales/zh-TW.ts
@@ -222,6 +222,7 @@ const locale = {
   "apps.service.domainPlaceholder": "例如 app.example.com",
   "apps.service.hosts": "網域配置",
   "apps.service.addHost": "新增域名",
+  "apps.service.hostDuplicated": "網域已被環境 {environment} / 命名空間 {namespace} / 應用 {name} 佔用",
   "apps.envSelector.label": "環境",
   "apps.envSelector.noEnv": "暫無環境配置，請先在基本資訊中配置部署環境",
   "apps.envSelector.fetchError": "取得環境失敗",


### PR DESCRIPTION
Prevent the same host from being configured on multiple applications by checking existing ApplicationServiceConfig rows via a LIKE query on the JSON column. The frontend validates on blur and blocks save; the backend enforces the same rule and reports the conflicting environment, namespace, and application name.