### PR TITLE
refactor: introduce DDD patterns — K8s port, rich model, domain events

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/adapter/kubernetes/Fabric8KubernetesOperations.java
+++ b/src/main/java/com/github/wellch4n/oops/adapter/kubernetes/Fabric8KubernetesOperations.java
@@ -1,0 +1,301 @@
+package com.github.wellch4n.oops.adapter.kubernetes;
+
+import com.github.wellch4n.oops.config.OopsConstants;
+import com.github.wellch4n.oops.crds.IngressRoute;
+import com.github.wellch4n.oops.crds.Middleware;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.pod.PipelineBuildPod;
+import com.github.wellch4n.oops.port.KubernetesOperations;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Fabric8KubernetesOperations implements KubernetesOperations {
+
+    private final KubernetesClient client;
+
+    public Fabric8KubernetesOperations(Environment environment) {
+        var apiServer = environment.getKubernetesApiServer();
+        var config = new io.fabric8.kubernetes.client.ConfigBuilder()
+                .withMasterUrl(apiServer.getUrl())
+                .withOauthToken(apiServer.getToken())
+                .withTrustCerts(false)
+                .build();
+        this.client = new KubernetesClientBuilder()
+                .withConfig(config)
+                .build();
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public KubernetesClient getClient() {
+        return client;
+    }
+
+    // ── Namespace ──
+
+    @Override
+    public void ensureNamespace(String namespace) {
+        client.namespaces()
+                .resource(new NamespaceBuilder()
+                        .withNewMetadata().withName(namespace).endMetadata()
+                        .build())
+                .serverSideApply();
+    }
+
+    @Override
+    public boolean namespaceExists(String namespace) {
+        return client.namespaces().withName(namespace).get() != null;
+    }
+
+    // ── Secrets ──
+
+    @Override
+    public Secret getSecret(String namespace, String name) {
+        return client.secrets().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public void patchSecret(String namespace, Secret secret) {
+        client.secrets().inNamespace(namespace).resource(secret).patch(OopsConstants.PATCH_CONTEXT);
+    }
+
+    @Override
+    public void patchDockerConfigSecret(String namespace, String secretName, String dockerConfigJson) {
+        String encoded = java.util.Base64.getEncoder()
+                .encodeToString(dockerConfigJson.getBytes(StandardCharsets.UTF_8));
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(secretName)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withType("kubernetes.io/dockerconfigjson")
+                .withData(Map.of(".dockerconfigjson", encoded))
+                .build();
+        client.secrets().inNamespace(namespace).resource(secret).patch(OopsConstants.PATCH_CONTEXT);
+    }
+
+    @Override
+    public void copySecret(String sourceNamespace, String targetNamespace, String secretName) {
+        Secret source = client.secrets().inNamespace(sourceNamespace).withName(secretName).get();
+        if (source == null) {
+            return;
+        }
+        Secret copy = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(secretName)
+                    .withNamespace(targetNamespace)
+                .endMetadata()
+                .withType(source.getType())
+                .withData(source.getData())
+                .build();
+        client.secrets().inNamespace(targetNamespace).resource(copy).patch(OopsConstants.PATCH_CONTEXT);
+    }
+
+    // ── StatefulSet ──
+
+    @Override
+    public StatefulSetResult applyStatefulSet(String namespace,
+                                               io.fabric8.kubernetes.api.model.apps.StatefulSet statefulSet) {
+        var created = client.apps().statefulSets()
+                .inNamespace(namespace)
+                .resource(statefulSet)
+                .patch(OopsConstants.PATCH_CONTEXT);
+        return new StatefulSetResult(created.getMetadata().getUid());
+    }
+
+    @Override
+    public io.fabric8.kubernetes.api.model.apps.StatefulSet getStatefulSet(String namespace, String name) {
+        return client.apps().statefulSets().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public List<io.fabric8.kubernetes.api.model.apps.StatefulSet> listStatefulSetsByLabels(
+            String namespace, Map<String, String> labels) {
+        return client.apps().statefulSets().inNamespace(namespace).withLabels(labels).list().getItems();
+    }
+
+    @Override
+    public void deleteStatefulSet(String namespace, String name) {
+        client.apps().statefulSets().inNamespace(namespace).withName(name).delete();
+    }
+
+    @Override
+    public void scaleStatefulSet(String namespace, String name, int replicas) {
+        client.apps().statefulSets().inNamespace(namespace).withName(name).scale(replicas);
+    }
+
+    @Override
+    public void updateStatefulSetResources(String namespace, String name, ResourceRequirements resources) {
+        client.apps().statefulSets().inNamespace(namespace).withName(name)
+                .edit(statefulSet -> {
+                    statefulSet.getSpec().getTemplate().getSpec().getContainers()
+                            .forEach(container -> container.setResources(resources));
+                    return statefulSet;
+                });
+    }
+
+    // ── K8s Service ──
+
+    @Override
+    public io.fabric8.kubernetes.api.model.Service getService(String namespace, String name) {
+        return client.services().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public void deleteService(String namespace, String name) {
+        client.services().inNamespace(namespace).withName(name).delete();
+    }
+
+    @Override
+    public void createService(String namespace, io.fabric8.kubernetes.api.model.Service service) {
+        client.services().inNamespace(namespace).resource(service).create();
+    }
+
+    // ── IngressRoute ──
+
+    @Override
+    public boolean ingressRouteCrdExists() {
+        return client.apiextensions().v1().customResourceDefinitions()
+                .withName(CustomResourceDefinitionContext.fromCustomResourceType(IngressRoute.class).getName())
+                .get() != null;
+    }
+
+    @Override
+    public void applyIngressRoute(String namespace, IngressRoute ingressRoute) {
+        client.resources(IngressRoute.class)
+                .inNamespace(namespace)
+                .resource(ingressRoute)
+                .forceConflicts()
+                .serverSideApply();
+    }
+
+    @Override
+    public List<IngressRoute> listIngressRoutesByLabel(String namespace, String labelKey, String labelValue) {
+        return client.resources(IngressRoute.class)
+                .inNamespace(namespace)
+                .withLabel(labelKey, labelValue)
+                .list().getItems();
+    }
+
+    @Override
+    public void deleteIngressRoute(String namespace, String name) {
+        client.resources(IngressRoute.class)
+                .inNamespace(namespace)
+                .withName(name)
+                .delete();
+    }
+
+    // ── Middleware ──
+
+    @Override
+    public Middleware getMiddleware(String namespace, String name) {
+        return client.resources(Middleware.class)
+                .inNamespace(namespace)
+                .withName(name)
+                .get();
+    }
+
+    @Override
+    public void applyMiddleware(String namespace, Middleware middleware) {
+        client.resources(Middleware.class)
+                .inNamespace(namespace)
+                .resource(middleware)
+                .forceConflicts()
+                .serverSideApply();
+    }
+
+    // ── ConfigMap ──
+
+    @Override
+    public ConfigMap getConfigMap(String namespace, String name) {
+        return client.configMaps().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public void applyConfigMap(String namespace, ConfigMap configMap) {
+        client.configMaps().inNamespace(namespace).resource(configMap).serverSideApply();
+    }
+
+    // ── Pod ──
+
+    @Override
+    public List<Pod> listPodsByLabels(String namespace, Map<String, String> labels) {
+        return client.pods().inNamespace(namespace).withLabels(labels).list().getItems();
+    }
+
+    @Override
+    public void deletePod(String namespace, String podName) {
+        client.pods().inNamespace(namespace).withName(podName).delete();
+    }
+
+    // ── Jobs ──
+
+    @Override
+    public void createJob(String namespace, PipelineBuildPod pipelineBuildPod) {
+        client.batch().v1().jobs().inNamespace(namespace).resource(pipelineBuildPod).create();
+    }
+
+    @Override
+    public Job getJob(String namespace, String name) {
+        return client.batch().v1().jobs().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public void suspendJob(String namespace, String name) {
+        client.batch().v1().jobs().inNamespace(namespace).withName(name)
+                .edit(job -> new JobBuilder(job)
+                        .editSpec()
+                        .withSuspend(true)
+                        .endSpec()
+                        .build());
+    }
+
+    // ── Log streaming ──
+
+    @Override
+    public AutoCloseable watchPodLog(String namespace, String podName, String containerName,
+                                      LogLineCallback callback) {
+        var logWatch = client.pods().inNamespace(namespace).withName(podName)
+                .inContainer(containerName)
+                .watchLog();
+        Thread.startVirtualThread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(logWatch.getOutput(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    callback.onLine(line);
+                }
+            } catch (Exception e) {
+                log.debug("Log watch ended for {}/{}: {}", namespace, podName, e.getMessage());
+            }
+        });
+        return logWatch;
+    }
+
+    @Override
+    public Pod waitUntilPodReady(String namespace, String jobName, long timeoutSeconds) {
+        return client.pods().inNamespace(namespace).withLabel("job-name", jobName)
+                .waitUntilCondition(pod -> pod != null, timeoutSeconds, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/adapter/kubernetes/KubernetesOperationsFactory.java
+++ b/src/main/java/com/github/wellch4n/oops/adapter/kubernetes/KubernetesOperationsFactory.java
@@ -1,0 +1,13 @@
+package com.github.wellch4n.oops.adapter.kubernetes;
+
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.port.KubernetesOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesOperationsFactory {
+
+    public KubernetesOperations create(Environment environment) {
+        return new Fabric8KubernetesOperations(environment);
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/data/Pipeline.java
+++ b/src/main/java/com/github/wellch4n/oops/data/Pipeline.java
@@ -40,6 +40,45 @@ public class Pipeline extends BaseDataObject {
 
     private String operatorId;
 
+
+    // ── 业务方法 ──
+
+    public boolean isDeployable() {
+        return PipelineStatus.BUILD_SUCCEEDED.equals(this.status);
+    }
+
+    public boolean isInFlight() {
+        return PipelineStatus.RUNNING.equals(this.status)
+                || PipelineStatus.DEPLOYING.equals(this.status);
+    }
+
+    public boolean isTerminal() {
+        return PipelineStatus.SUCCEEDED.equals(this.status)
+                || PipelineStatus.ERROR.equals(this.status)
+                || PipelineStatus.STOPPED.equals(this.status);
+    }
+
+    public void transitionTo(PipelineStatus target) {
+        if (!isValidTransition(this.status, target)) {
+            throw new BizException("Invalid pipeline state transition: " + this.status + " → " + target);
+        }
+        this.status = target;
+    }
+
+    private static boolean isValidTransition(PipelineStatus from, PipelineStatus to) {
+        return switch (from) {
+            case INITIALIZED -> to == PipelineStatus.RUNNING;
+            case RUNNING -> to == PipelineStatus.BUILD_SUCCEEDED
+                    || to == PipelineStatus.DEPLOYING
+                    || to == PipelineStatus.ERROR;
+            case BUILD_SUCCEEDED -> to == PipelineStatus.DEPLOYING
+                    || to == PipelineStatus.STOPPED;
+            case DEPLOYING -> to == PipelineStatus.SUCCEEDED
+                    || to == PipelineStatus.ERROR;
+            default -> false;
+        };
+    }
+
     public String getName() {
         return String.format("%s-pipeline-%s", applicationName, getId());
     }

--- a/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationDomainService.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationDomainService.java
@@ -1,0 +1,62 @@
+package com.github.wellch4n.oops.domain.application;
+
+import com.github.wellch4n.oops.objects.ClusterDomainResponse;
+import com.github.wellch4n.oops.objects.ServiceHostConflictResponse;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApplicationDomainService {
+
+    private static final String CLUSTER_SUFFIX = "cluster.local";
+    private static final String CLUSTER_DOMAIN_FORMAT = "%s.%s.svc.%s";
+
+    public ServiceHostConflictResponse findHostConflict(ApplicationServiceConfigRepository serviceConfigRepo,
+                                                        String namespace, String name, String host) {
+        if (host == null || host.isBlank()) {
+            return null;
+        }
+        List<ApplicationServiceConfig> conflicts = serviceConfigRepo
+                .findByHostLikeExcludingSelf("\"" + host + "\"", namespace, name);
+        for (ApplicationServiceConfig conflict : conflicts) {
+            if (conflict.getEnvironmentConfigs() == null) {
+                continue;
+            }
+            for (ApplicationServiceConfig.EnvironmentConfig c : conflict.getEnvironmentConfigs()) {
+                if (host.equals(c.getHost())) {
+                    return new ServiceHostConflictResponse(
+                            conflict.getNamespace(),
+                            conflict.getApplicationName(),
+                            c.getEnvironmentName());
+                }
+            }
+        }
+        return null;
+    }
+
+    public ClusterDomainResponse resolveClusterDomain(ApplicationServiceConfigRepository serviceConfigRepo,
+                                                       String namespace, String name, String environmentName,
+                                                       String internalServiceName) {
+        String internalDomain = null;
+        if (internalServiceName != null) {
+            internalDomain = String.format(CLUSTER_DOMAIN_FORMAT,
+                    internalServiceName, namespace, CLUSTER_SUFFIX);
+        }
+
+        List<String> externalDomains = null;
+        var serviceConfig = serviceConfigRepo.findByNamespaceAndApplicationName(namespace, name);
+        if (serviceConfig.isPresent()) {
+            var envConfigs = serviceConfig.get().getEnvironmentConfigs(environmentName);
+            externalDomains = envConfigs.stream()
+                    .filter(config -> config.getHost() != null && !config.getHost().isBlank())
+                    .map(config -> {
+                        String scheme = Boolean.TRUE.equals(config.getHttps()) ? "https" : "http";
+                        return scheme + "://" + config.getHost();
+                    })
+                    .toList();
+        }
+
+        return new ClusterDomainResponse(internalDomain, externalDomains);
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/event/ApplicationDeletedEvent.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/event/ApplicationDeletedEvent.java
@@ -1,0 +1,10 @@
+package com.github.wellch4n.oops.domain.event;
+
+import java.util.List;
+
+public record ApplicationDeletedEvent(
+        String namespace,
+        String name,
+        List<String> environmentNames
+) implements DomainEvent {
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/event/DomainEvent.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/event/DomainEvent.java
@@ -1,0 +1,7 @@
+package com.github.wellch4n.oops.domain.event;
+
+/**
+ * Marker interface for all domain events.
+ */
+public interface DomainEvent {
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/event/PipelineStateEvent.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/event/PipelineStateEvent.java
@@ -1,0 +1,13 @@
+package com.github.wellch4n.oops.domain.event;
+
+import com.github.wellch4n.oops.enums.PipelineStatus;
+
+public record PipelineStateEvent(
+        String pipelineId,
+        String namespace,
+        String applicationName,
+        PipelineStatus fromStatus,
+        PipelineStatus toStatus,
+        String message
+) implements DomainEvent {
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/event/RuntimeSpecChangedEvent.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/event/RuntimeSpecChangedEvent.java
@@ -1,0 +1,17 @@
+package com.github.wellch4n.oops.domain.event;
+
+import java.util.List;
+
+public record RuntimeSpecChangedEvent(
+        String namespace,
+        String applicationName,
+        List<RuntimeSpecChange> changes
+) implements DomainEvent {
+
+    public record RuntimeSpecChange(
+            String environmentName,
+            boolean replicasChanged,
+            boolean resourcesChanged
+    ) {
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/event/handler/ApplicationDeletedEventHandler.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/event/handler/ApplicationDeletedEventHandler.java
@@ -1,0 +1,43 @@
+package com.github.wellch4n.oops.domain.event.handler;
+
+import com.github.wellch4n.oops.adapter.kubernetes.KubernetesOperationsFactory;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.environment.EnvironmentRepository;
+import com.github.wellch4n.oops.domain.event.ApplicationDeletedEvent;
+import com.github.wellch4n.oops.port.KubernetesOperations;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Slf4j
+@Component
+public class ApplicationDeletedEventHandler {
+
+    private final EnvironmentRepository environmentRepository;
+    private final KubernetesOperationsFactory k8sFactory;
+
+    public ApplicationDeletedEventHandler(EnvironmentRepository environmentRepository,
+                                          KubernetesOperationsFactory k8sFactory) {
+        this.environmentRepository = environmentRepository;
+        this.k8sFactory = k8sFactory;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onApplicationDeleted(ApplicationDeletedEvent event) {
+        for (String environmentName : event.environmentNames()) {
+            Environment environment = environmentRepository.findFirstByName(environmentName);
+            if (environment == null) {
+                continue;
+            }
+            try (KubernetesOperations k8s = k8sFactory.create(environment)) {
+                k8s.deleteStatefulSet(event.namespace(), event.name());
+                log.info("Cleaned up K8s resources for app {}/{} in env {}",
+                        event.namespace(), event.name(), environmentName);
+            } catch (Exception e) {
+                log.error("Failed to clean up K8s resources for app {}/{} in env {}: {}",
+                        event.namespace(), event.name(), environmentName, e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/event/handler/RuntimeSpecChangedEventHandler.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/event/handler/RuntimeSpecChangedEventHandler.java
@@ -1,0 +1,91 @@
+package com.github.wellch4n.oops.domain.event.handler;
+
+import com.github.wellch4n.oops.adapter.kubernetes.KubernetesOperationsFactory;
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpecRepository;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.environment.EnvironmentRepository;
+import com.github.wellch4n.oops.domain.event.RuntimeSpecChangedEvent;
+import com.github.wellch4n.oops.port.KubernetesOperations;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Slf4j
+@Component
+public class RuntimeSpecChangedEventHandler {
+
+    private final EnvironmentRepository environmentRepository;
+    private final ApplicationRuntimeSpecRepository runtimeSpecRepository;
+    private final KubernetesOperationsFactory k8sFactory;
+
+    public RuntimeSpecChangedEventHandler(EnvironmentRepository environmentRepository,
+                                          ApplicationRuntimeSpecRepository runtimeSpecRepository,
+                                          KubernetesOperationsFactory k8sFactory) {
+        this.environmentRepository = environmentRepository;
+        this.runtimeSpecRepository = runtimeSpecRepository;
+        this.k8sFactory = k8sFactory;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRuntimeSpecChanged(RuntimeSpecChangedEvent event) {
+        for (RuntimeSpecChangedEvent.RuntimeSpecChange change : event.changes()) {
+            if (!change.replicasChanged() && !change.resourcesChanged()) {
+                continue;
+            }
+
+            Environment environment = environmentRepository.findFirstByName(change.environmentName());
+            if (environment == null) {
+                continue;
+            }
+
+            try (KubernetesOperations k8s = k8sFactory.create(environment)) {
+                ApplicationRuntimeSpec runtimeSpec = runtimeSpecRepository
+                        .findByNamespaceAndApplicationName(event.namespace(), event.applicationName())
+                        .orElse(null);
+                if (runtimeSpec == null || runtimeSpec.getEnvironmentConfigs() == null) {
+                    continue;
+                }
+
+                ApplicationRuntimeSpec.EnvironmentConfig config = runtimeSpec.getEnvironmentConfigs().stream()
+                        .filter(c -> change.environmentName().equals(c.getEnvironmentName()))
+                        .findFirst().orElse(null);
+                if (config == null) {
+                    continue;
+                }
+
+                if (change.replicasChanged() && config.getReplicas() != null) {
+                    k8s.scaleStatefulSet(event.namespace(), event.applicationName(), config.getReplicas());
+                }
+
+                if (change.resourcesChanged()) {
+                    var resourcesBuilder = new ResourceRequirementsBuilder();
+                    if (StringUtils.isNotBlank(config.getCpuRequest())) {
+                        resourcesBuilder.addToRequests("cpu", new Quantity(config.getCpuRequest()));
+                    }
+                    if (StringUtils.isNotBlank(config.getCpuLimit())) {
+                        resourcesBuilder.addToLimits("cpu", new Quantity(config.getCpuLimit()));
+                    }
+                    if (StringUtils.isNotBlank(config.getMemoryRequest())) {
+                        resourcesBuilder.addToRequests("memory", new Quantity(config.getMemoryRequest() + "Mi"));
+                    }
+                    if (StringUtils.isNotBlank(config.getMemoryLimit())) {
+                        resourcesBuilder.addToLimits("memory", new Quantity(config.getMemoryLimit() + "Mi"));
+                    }
+                    k8s.updateStatefulSetResources(event.namespace(), event.applicationName(),
+                            resourcesBuilder.build());
+                }
+
+                log.info("Applied runtime spec changes for app {}/{} in env {}",
+                        event.namespace(), event.applicationName(), change.environmentName());
+            } catch (Exception e) {
+                log.warn("Failed to apply runtime spec for app={}/{} env={}: {}",
+                        event.namespace(), event.applicationName(), change.environmentName(), e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/pipeline/PipelineDomainService.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/pipeline/PipelineDomainService.java
@@ -1,0 +1,18 @@
+package com.github.wellch4n.oops.domain.pipeline;
+
+import com.github.wellch4n.oops.enums.PipelineStatus;
+import com.github.wellch4n.oops.exception.BizException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PipelineDomainService {
+
+    public void ensureNoInFlightDeployment(PipelineRepository pipelineRepository,
+                                           String namespace, String applicationName) {
+        if (pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(
+                namespace, applicationName, List.of(PipelineStatus.RUNNING, PipelineStatus.DEPLOYING))) {
+            throw new BizException("Application is being deployed");
+        }
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/valueobject/HostConfig.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/valueobject/HostConfig.java
@@ -1,0 +1,14 @@
+package com.github.wellch4n.oops.domain.valueobject;
+
+public record HostConfig(String environmentName, String host, Boolean https) {
+
+    public HostConfig {
+        if (host != null && host.isBlank()) {
+            host = null;
+        }
+    }
+
+    public boolean hasHost() {
+        return host != null && !host.isBlank();
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/valueobject/ImageRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/valueobject/ImageRepository.java
@@ -1,0 +1,65 @@
+package com.github.wellch4n.oops.domain.valueobject;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.wellch4n.oops.converter.EncryptedStringConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embeddable;
+import java.time.Duration;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.commons.lang3.StringUtils;
+
+@Data
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageRepository {
+
+    private static final OkHttpClient HTTP_CLIENT = new OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    @Column(name = "image_repository_url")
+    private String url;
+
+    @Column(name = "image_repository_username")
+    private String username;
+
+    @Column(name = "image_repository_password")
+    @Convert(converter = EncryptedStringConverter.class)
+    private String password;
+
+    public static ImageRepository of(String url, String username, String password) {
+        return new ImageRepository(url, username, password);
+    }
+
+    @JsonIgnore
+    public boolean isValid() {
+        if (StringUtils.isAnyEmpty(this.url, this.username, this.password)) return false;
+
+        HttpUrl httpUrl = HttpUrl.parse(this.url);
+        if (httpUrl == null) return false;
+
+        HttpUrl rootUrl = httpUrl.resolve("/");
+        if (rootUrl == null) return false;
+
+        String credential = Credentials.basic(this.username, this.password);
+        Request request = new Request.Builder()
+                .url(rootUrl)
+                .header("Authorization", credential)
+                .get()
+                .build();
+        try (Response response = HTTP_CLIENT.newCall(request).execute()) {
+            return response.isSuccessful();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/valueobject/KubernetesApiServer.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/valueobject/KubernetesApiServer.java
@@ -1,0 +1,42 @@
+package com.github.wellch4n.oops.domain.valueobject;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.wellch4n.oops.converter.EncryptedStringConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Lob;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class KubernetesApiServer {
+
+    @Getter
+    @Setter
+    @Column(name = "api_server_url")
+    private String url;
+
+    @Getter
+    @Setter
+    @Lob
+    @Column(name = "api_server_token", columnDefinition = "TEXT")
+    @Convert(converter = EncryptedStringConverter.class)
+    private String token;
+
+    public static KubernetesApiServer of(String url, String token) {
+        KubernetesApiServer server = new KubernetesApiServer();
+        server.setUrl(url);
+        server.setToken(token);
+        return server;
+    }
+
+    @JsonIgnore
+    public boolean isValid() {
+        return url != null && !url.isBlank() && token != null && !token.isBlank();
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/port/KubernetesOperations.java
+++ b/src/main/java/com/github/wellch4n/oops/port/KubernetesOperations.java
@@ -1,0 +1,122 @@
+package com.github.wellch4n.oops.port;
+
+import com.github.wellch4n.oops.crds.IngressRoute;
+import com.github.wellch4n.oops.crds.IngressRouteSpec;
+import com.github.wellch4n.oops.crds.Middleware;
+import com.github.wellch4n.oops.pod.PipelineBuildPod;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Port interface for all Kubernetes cluster operations.
+ * Abstracts away the fabric8 KubernetesClient so domain/service layers
+ * depend on this interface rather than on the concrete K8s client.
+ */
+public interface KubernetesOperations extends AutoCloseable {
+
+    @Override
+    void close();
+
+    /**
+     * Provides access to the underlying KubernetesClient for specialized operations
+     * (e.g., terminal exec, pod log streaming) that are not worth abstracting into the port.
+     * Prefer using the typed methods above for standard operations.
+     */
+    io.fabric8.kubernetes.client.KubernetesClient getClient();
+
+    // ── Namespace ──
+
+    void ensureNamespace(String namespace);
+
+    boolean namespaceExists(String namespace);
+
+    // ── Secrets ──
+
+    Secret getSecret(String namespace, String name);
+
+    void patchSecret(String namespace, Secret secret);
+
+    void patchDockerConfigSecret(String namespace, String secretName, String dockerConfigJson);
+
+    void copySecret(String sourceNamespace, String targetNamespace, String secretName);
+
+    // ── StatefulSet ──
+
+    StatefulSetResult applyStatefulSet(String namespace, io.fabric8.kubernetes.api.model.apps.StatefulSet statefulSet);
+
+    io.fabric8.kubernetes.api.model.apps.StatefulSet getStatefulSet(String namespace, String name);
+
+    List<io.fabric8.kubernetes.api.model.apps.StatefulSet> listStatefulSetsByLabels(String namespace, Map<String, String> labels);
+
+    void deleteStatefulSet(String namespace, String name);
+
+    void scaleStatefulSet(String namespace, String name, int replicas);
+
+    void updateStatefulSetResources(String namespace, String name,
+                                    io.fabric8.kubernetes.api.model.ResourceRequirements resources);
+
+    // ── K8s Service ──
+
+    io.fabric8.kubernetes.api.model.Service getService(String namespace, String name);
+
+    void deleteService(String namespace, String name);
+
+    void createService(String namespace, io.fabric8.kubernetes.api.model.Service service);
+
+    // ── IngressRoute (Traefik CRD) ──
+
+    boolean ingressRouteCrdExists();
+
+    void applyIngressRoute(String namespace, IngressRoute ingressRoute);
+
+    List<IngressRoute> listIngressRoutesByLabel(String namespace, String labelKey, String labelValue);
+
+    void deleteIngressRoute(String namespace, String name);
+
+    // ── Middleware (Traefik CRD) ──
+
+    Middleware getMiddleware(String namespace, String name);
+
+    void applyMiddleware(String namespace, Middleware middleware);
+
+    // ── ConfigMap ──
+
+    ConfigMap getConfigMap(String namespace, String name);
+
+    void applyConfigMap(String namespace, ConfigMap configMap);
+
+    // ── Pod ──
+
+    List<Pod> listPodsByLabels(String namespace, Map<String, String> labels);
+
+    void deletePod(String namespace, String podName);
+
+    // ── Jobs (Pipeline builds) ──
+
+    void createJob(String namespace, PipelineBuildPod pipelineBuildPod);
+
+    Job getJob(String namespace, String name);
+
+    void suspendJob(String namespace, String name);
+
+    // ── Log streaming ──
+
+    AutoCloseable watchPodLog(String namespace, String podName, String containerName, LogLineCallback callback);
+
+    Pod waitUntilPodReady(String namespace, String jobName, long timeoutSeconds);
+
+    @FunctionalInterface
+    interface LogLineCallback {
+        void onLine(String line);
+    }
+
+    /**
+     * Result of applying a StatefulSet — carries back the UID needed for ownerReference.
+     */
+    record StatefulSetResult(String uid) {}
+}

--- a/src/main/java/com/github/wellch4n/oops/service/ApplicationConfigService.java
+++ b/src/main/java/com/github/wellch4n/oops/service/ApplicationConfigService.java
@@ -1,0 +1,174 @@
+package com.github.wellch4n.oops.service;
+
+import com.github.wellch4n.oops.domain.application.ApplicationBuildConfig;
+import com.github.wellch4n.oops.domain.application.ApplicationBuildConfigRepository;
+import com.github.wellch4n.oops.domain.application.ApplicationEnvironment;
+import com.github.wellch4n.oops.domain.application.ApplicationEnvironmentRepository;
+import com.github.wellch4n.oops.domain.application.ApplicationServiceConfig;
+import com.github.wellch4n.oops.domain.application.ApplicationServiceConfigRepository;
+import com.github.wellch4n.oops.domain.application.ApplicationDomainService;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.environment.EnvironmentRepository;
+import com.github.wellch4n.oops.enums.ApplicationSourceType;
+import com.github.wellch4n.oops.enums.DockerFileType;
+import com.github.wellch4n.oops.exception.BizException;
+import com.github.wellch4n.oops.objects.ServiceHostConflictResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class ApplicationConfigService {
+
+    private final ApplicationBuildConfigRepository buildConfigRepository;
+    private final ApplicationServiceConfigRepository serviceConfigRepository;
+    private final ApplicationEnvironmentRepository environmentRepository;
+    private final EnvironmentRepository globalEnvironmentRepository;
+    private final ApplicationDomainService domainService;
+
+    public ApplicationConfigService(ApplicationBuildConfigRepository buildConfigRepository,
+                                    ApplicationServiceConfigRepository serviceConfigRepository,
+                                    ApplicationEnvironmentRepository environmentRepository,
+                                    EnvironmentRepository globalEnvironmentRepository,
+                                    ApplicationDomainService domainService) {
+        this.buildConfigRepository = buildConfigRepository;
+        this.serviceConfigRepository = serviceConfigRepository;
+        this.environmentRepository = environmentRepository;
+        this.globalEnvironmentRepository = globalEnvironmentRepository;
+        this.domainService = domainService;
+    }
+
+    @Transactional
+    public Boolean updateApplicationBuildConfig(String namespace, String name, ApplicationBuildConfig request) {
+        ApplicationBuildConfig buildConfig = buildConfigRepository.findByNamespaceAndApplicationName(namespace, name)
+                .orElseGet(() -> {
+                    ApplicationBuildConfig config = new ApplicationBuildConfig();
+                    config.setNamespace(namespace);
+                    config.setApplicationName(name);
+                    return config;
+                });
+
+        ApplicationSourceType sourceType = request.getSourceType() != null ? request.getSourceType() : ApplicationSourceType.GIT;
+        buildConfig.setSourceType(sourceType);
+        if (sourceType == ApplicationSourceType.GIT) {
+            if (StringUtils.isBlank(request.getRepository())) {
+                throw new BizException("Repository is required when source type is GIT");
+            }
+            buildConfig.setRepository(request.getRepository());
+        } else {
+            buildConfig.setRepository(null);
+        }
+        var dockerFileConfig = request.getDockerFileConfig();
+        if (dockerFileConfig != null && dockerFileConfig.getType() == DockerFileType.USER) {
+            if (StringUtils.isBlank(dockerFileConfig.getContent())) {
+                throw new BizException("Dockerfile content is required when type is USER");
+            }
+        }
+        buildConfig.setDockerFileConfig(dockerFileConfig);
+        buildConfig.setBuildImage(request.getBuildImage());
+        buildConfig.setEnvironmentConfigs(request.getEnvironmentConfigs());
+        buildConfigRepository.save(buildConfig);
+        return true;
+    }
+
+    public ApplicationBuildConfig getApplicationBuildConfig(String namespace, String name) {
+        ApplicationBuildConfig buildConfig = buildConfigRepository.findByNamespaceAndApplicationName(namespace, name).orElse(null);
+        if (buildConfig != null && buildConfig.getSourceType() == null) {
+            buildConfig.setSourceType(ApplicationSourceType.GIT);
+        }
+        return buildConfig;
+    }
+
+    public List<ApplicationBuildConfig.EnvironmentConfig> getApplicationBuildEnvironmentConfigs(String namespace, String name) {
+        ApplicationBuildConfig buildConfig = buildConfigRepository.findByNamespaceAndApplicationName(namespace, name).orElse(null);
+        if (buildConfig == null || buildConfig.getEnvironmentConfigs() == null) {
+            return Collections.emptyList();
+        }
+        return buildConfig.getEnvironmentConfigs();
+    }
+
+    @Transactional
+    public Boolean updateApplicationBuildEnvironmentConfigs(String namespace, String appName, List<ApplicationBuildConfig.EnvironmentConfig> configs) {
+        ApplicationBuildConfig buildConfig = buildConfigRepository.findByNamespaceAndApplicationName(namespace, appName)
+                .orElseGet(() -> {
+                    ApplicationBuildConfig config = new ApplicationBuildConfig();
+                    config.setNamespace(namespace);
+                    config.setApplicationName(appName);
+                    return config;
+                });
+
+        buildConfig.setEnvironmentConfigs(configs);
+        buildConfigRepository.save(buildConfig);
+        return true;
+    }
+
+    public ApplicationServiceConfig getApplicationServiceConfig(String namespace, String name) {
+        return serviceConfigRepository.findByNamespaceAndApplicationName(namespace, name).orElse(null);
+    }
+
+    public ServiceHostConflictResponse findHostConflictApplication(String namespace, String name, String host) {
+        return domainService.findHostConflict(serviceConfigRepository, namespace, name, host);
+    }
+
+    public Boolean updateApplicationServiceConfig(String namespace, String name, ApplicationServiceConfig request) {
+        if (request.getEnvironmentConfigs() != null) {
+            for (ApplicationServiceConfig.EnvironmentConfig envConfig : request.getEnvironmentConfigs()) {
+                String host = envConfig.getHost();
+                if (host == null || host.isBlank()) {
+                    continue;
+                }
+                ServiceHostConflictResponse conflict = findHostConflictApplication(namespace, name, host);
+                if (conflict != null) {
+                    throw new BizException("Host " + host + " is already used by environment "
+                            + conflict.environmentName() + " / namespace " + conflict.namespace()
+                            + " / application " + conflict.applicationName());
+                }
+            }
+        }
+
+        var exist = serviceConfigRepository.findByNamespaceAndApplicationName(namespace, name);
+
+        if (exist.isEmpty()) {
+            ApplicationServiceConfig newConfig = new ApplicationServiceConfig();
+            newConfig.setNamespace(namespace);
+            newConfig.setApplicationName(name);
+            newConfig.setPort(request.getPort());
+            newConfig.setEnvironmentConfigs(request.getEnvironmentConfigs());
+            serviceConfigRepository.save(newConfig);
+        } else {
+            ApplicationServiceConfig applicationServiceConfig = exist.get();
+            applicationServiceConfig.setPort(request.getPort());
+            applicationServiceConfig.setEnvironmentConfigs(request.getEnvironmentConfigs());
+            serviceConfigRepository.save(applicationServiceConfig);
+        }
+        return true;
+    }
+
+    public List<ApplicationEnvironment> getApplicationEnvironments(String namespace, String name) {
+        List<ApplicationEnvironment> all = environmentRepository.findByNamespaceAndApplicationName(namespace, name);
+        Set<String> existingEnvNames = globalEnvironmentRepository.findAll().stream()
+                .map(Environment::getName)
+                .collect(Collectors.toSet());
+        return all.stream()
+                .filter(e -> existingEnvNames.contains(e.getEnvironmentName()))
+                .toList();
+    }
+
+    @Transactional
+    public Boolean updateApplicationEnvironments(String namespace, String appName, List<ApplicationEnvironment> configs) {
+        environmentRepository.deleteByNamespaceAndApplicationName(namespace, appName);
+        for (ApplicationEnvironment config : configs) {
+            config.setId(null);
+            config.setNamespace(namespace);
+            config.setApplicationName(appName);
+        }
+        environmentRepository.saveAll(configs);
+        return true;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/service/ApplicationRuntimeService.java
+++ b/src/main/java/com/github/wellch4n/oops/service/ApplicationRuntimeService.java
@@ -1,0 +1,138 @@
+package com.github.wellch4n.oops.service;
+
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpecRepository;
+import com.github.wellch4n.oops.domain.event.RuntimeSpecChangedEvent;
+import com.github.wellch4n.oops.exception.BizException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class ApplicationRuntimeService {
+
+    private final ApplicationRuntimeSpecRepository runtimeSpecRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ApplicationRuntimeService(ApplicationRuntimeSpecRepository runtimeSpecRepository,
+                                     ApplicationEventPublisher eventPublisher) {
+        this.runtimeSpecRepository = runtimeSpecRepository;
+        this.eventPublisher = eventPublisher;
+    }
+
+    public List<ApplicationRuntimeSpec.EnvironmentConfig> getApplicationRuntimeSpecEnvironmentConfigs(String namespace, String name) {
+        ApplicationRuntimeSpec runtimeSpec = runtimeSpecRepository.findByNamespaceAndApplicationName(namespace, name).orElse(null);
+        if (runtimeSpec == null || runtimeSpec.getEnvironmentConfigs() == null) {
+            return Collections.emptyList();
+        }
+        return runtimeSpec.getEnvironmentConfigs();
+    }
+
+    public ApplicationRuntimeSpec getApplicationRuntimeSpec(String namespace, String name) {
+        ApplicationRuntimeSpec runtimeSpec = runtimeSpecRepository.findByNamespaceAndApplicationName(namespace, name).orElse(null);
+        if (runtimeSpec == null) {
+            runtimeSpec = new ApplicationRuntimeSpec();
+            runtimeSpec.setNamespace(namespace);
+            runtimeSpec.setApplicationName(name);
+            runtimeSpec.setEnvironmentConfigs(Collections.emptyList());
+        }
+        runtimeSpec.setHealthCheck(normalizeHealthCheck(runtimeSpec.getHealthCheck()));
+        return runtimeSpec;
+    }
+
+    @Transactional
+    public Boolean updateApplicationRuntimeSpecEnvironmentConfigs(String namespace, String appName, List<ApplicationRuntimeSpec.EnvironmentConfig> configs) {
+        ApplicationRuntimeSpec existing = runtimeSpecRepository.findByNamespaceAndApplicationName(namespace, appName).orElse(null);
+        ApplicationRuntimeSpec request = new ApplicationRuntimeSpec();
+        request.setEnvironmentConfigs(configs);
+        request.setHealthCheck(existing != null ? existing.getHealthCheck() : null);
+        return updateApplicationRuntimeSpec(namespace, appName, request);
+    }
+
+    @Transactional
+    public Boolean updateApplicationRuntimeSpec(String namespace, String appName, ApplicationRuntimeSpec request) {
+        ApplicationRuntimeSpec runtimeSpec = runtimeSpecRepository.findByNamespaceAndApplicationName(namespace, appName)
+                .orElseGet(() -> {
+                    ApplicationRuntimeSpec config = new ApplicationRuntimeSpec();
+                    config.setNamespace(namespace);
+                    config.setApplicationName(appName);
+                    return config;
+                });
+
+        List<ApplicationRuntimeSpec.EnvironmentConfig> configs = request.getEnvironmentConfigs() != null
+                ? request.getEnvironmentConfigs()
+                : Collections.emptyList();
+        List<ApplicationRuntimeSpec.EnvironmentConfig> existingConfigs =
+                runtimeSpec.getEnvironmentConfigs() != null ? runtimeSpec.getEnvironmentConfigs() : Collections.emptyList();
+
+        runtimeSpec.setEnvironmentConfigs(configs);
+        runtimeSpec.setHealthCheck(request.getHealthCheck());
+        runtimeSpecRepository.save(runtimeSpec);
+
+        applyRuntimeSpecEnvironmentConfigUpdates(namespace, appName, configs, existingConfigs);
+
+        return true;
+    }
+
+    private void applyRuntimeSpecEnvironmentConfigUpdates(String namespace,
+                                                          String appName,
+                                                          List<ApplicationRuntimeSpec.EnvironmentConfig> configs,
+                                                          List<ApplicationRuntimeSpec.EnvironmentConfig> existingConfigs) {
+        List<RuntimeSpecChangedEvent.RuntimeSpecChange> changes = new ArrayList<>();
+        for (ApplicationRuntimeSpec.EnvironmentConfig config : configs) {
+            ApplicationRuntimeSpec.EnvironmentConfig existing = existingConfigs.stream()
+                    .filter(c -> c.getEnvironmentName().equals(config.getEnvironmentName()))
+                    .findFirst().orElse(null);
+
+            boolean replicasChanged = config.getReplicas() != null
+                    && !config.getReplicas().equals(existing != null ? existing.getReplicas() : null);
+            boolean resourcesChanged = !StringUtils.equals(config.getCpuRequest(), existing != null ? existing.getCpuRequest() : null)
+                    || !StringUtils.equals(config.getCpuLimit(), existing != null ? existing.getCpuLimit() : null)
+                    || !StringUtils.equals(config.getMemoryRequest(), existing != null ? existing.getMemoryRequest() : null)
+                    || !StringUtils.equals(config.getMemoryLimit(), existing != null ? existing.getMemoryLimit() : null);
+
+            if (replicasChanged || resourcesChanged) {
+                changes.add(new RuntimeSpecChangedEvent.RuntimeSpecChange(
+                        config.getEnvironmentName(), replicasChanged, resourcesChanged));
+            }
+        }
+
+        if (!changes.isEmpty()) {
+            eventPublisher.publishEvent(new RuntimeSpecChangedEvent(namespace, appName, changes));
+        }
+    }
+
+    private ApplicationRuntimeSpec.HealthCheck normalizeHealthCheck(ApplicationRuntimeSpec.HealthCheck healthCheck) {
+        ApplicationRuntimeSpec.HealthCheck normalized = healthCheck != null
+                ? healthCheck
+                : new ApplicationRuntimeSpec.HealthCheck();
+        normalized.setEnabled(Boolean.TRUE.equals(normalized.getEnabled()));
+        if (normalized.getPath() == null || normalized.getPath().isBlank()) {
+            if (Boolean.TRUE.equals(normalized.getEnabled())) {
+                throw new BizException("Health check path is required");
+            }
+            normalized.setPath(ApplicationRuntimeSpec.HealthCheck.DEFAULT_PATH);
+        } else if (!normalized.getPath().startsWith("/")) {
+            normalized.setPath("/" + normalized.getPath());
+        }
+        if (normalized.getInitialDelaySeconds() == null || normalized.getInitialDelaySeconds() < 0) {
+            normalized.setInitialDelaySeconds(ApplicationRuntimeSpec.HealthCheck.DEFAULT_INITIAL_DELAY_SECONDS);
+        }
+        if (normalized.getPeriodSeconds() == null || normalized.getPeriodSeconds() <= 0) {
+            normalized.setPeriodSeconds(ApplicationRuntimeSpec.HealthCheck.DEFAULT_PERIOD_SECONDS);
+        }
+        if (normalized.getTimeoutSeconds() == null || normalized.getTimeoutSeconds() <= 0) {
+            normalized.setTimeoutSeconds(ApplicationRuntimeSpec.HealthCheck.DEFAULT_TIMEOUT_SECONDS);
+        }
+        if (normalized.getFailureThreshold() == null || normalized.getFailureThreshold() <= 0) {
+            normalized.setFailureThreshold(ApplicationRuntimeSpec.HealthCheck.DEFAULT_FAILURE_THRESHOLD);
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/service/ApplicationStatusService.java
+++ b/src/main/java/com/github/wellch4n/oops/service/ApplicationStatusService.java
@@ -1,0 +1,117 @@
+package com.github.wellch4n.oops.service;
+
+import com.github.wellch4n.oops.adapter.kubernetes.KubernetesOperationsFactory;
+import com.github.wellch4n.oops.domain.application.ApplicationDomainService;
+import com.github.wellch4n.oops.domain.application.ApplicationServiceConfigRepository;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.environment.EnvironmentRepository;
+import com.github.wellch4n.oops.enums.OopsTypes;
+import com.github.wellch4n.oops.objects.ApplicationPodStatusResponse;
+import com.github.wellch4n.oops.objects.ClusterDomainResponse;
+import com.github.wellch4n.oops.port.KubernetesOperations;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ApplicationStatusService {
+
+    private final EnvironmentRepository environmentRepository;
+    private final ApplicationServiceConfigRepository serviceConfigRepository;
+    private final ApplicationDomainService domainService;
+    private final KubernetesOperationsFactory k8sFactory;
+
+    public ApplicationStatusService(EnvironmentRepository environmentRepository,
+                                    ApplicationServiceConfigRepository serviceConfigRepository,
+                                    ApplicationDomainService domainService,
+                                    KubernetesOperationsFactory k8sFactory) {
+        this.environmentRepository = environmentRepository;
+        this.serviceConfigRepository = serviceConfigRepository;
+        this.domainService = domainService;
+        this.k8sFactory = k8sFactory;
+    }
+
+    public List<ApplicationPodStatusResponse> getApplicationStatus(String namespace, String name, String environmentName) {
+        try {
+            Environment environment = environmentRepository.findFirstByName(environmentName);
+            if (environment == null) {
+                throw new IllegalArgumentException("Environment not found: " + environmentName);
+            }
+
+            try (KubernetesOperations k8s = k8sFactory.create(environment)) {
+                var pods = k8s.listPodsByLabels(namespace, Map.of(
+                        "oops.type", OopsTypes.APPLICATION.name(),
+                        "oops.app.name", name));
+                return pods.stream().map(pod -> {
+                    var status = new ApplicationPodStatusResponse();
+                    status.setName(pod.getMetadata().getName());
+                    status.setNamespace(pod.getMetadata().getNamespace());
+                    status.setPodIP(pod.getStatus().getPodIP());
+                    status.setStatus(pod.getStatus().getPhase());
+                    status.setNodeName(pod.getSpec().getNodeName());
+                    var containerStatuses = pod.getStatus().getContainerStatuses();
+                    List<ApplicationPodStatusResponse.ContainerStatus> containers = new ArrayList<>();
+                    if (containerStatuses != null) {
+                        for (var containerStatus : containerStatuses) {
+                            var container = new ApplicationPodStatusResponse.ContainerStatus();
+                            container.setName(containerStatus.getName());
+                            container.setImage(containerStatus.getImage());
+                            container.setReady(containerStatus.getReady());
+                            container.setRestartCount(containerStatus.getRestartCount());
+                            if (containerStatus.getState() != null && containerStatus.getState().getRunning() != null) {
+                                container.setStartedAt(containerStatus.getState().getRunning().getStartedAt());
+                            }
+                            containers.add(container);
+                        }
+                    }
+                    status.setContainers(containers);
+                    return status;
+                }).toList();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get application status: " + e.getMessage(), e);
+        }
+    }
+
+    public Boolean restartApplication(String namespace, String name, String podName, String environmentName) {
+        try {
+            Environment environment = environmentRepository.findFirstByName(environmentName);
+            if (environment == null) {
+                throw new IllegalArgumentException("Environment not found: " + environmentName);
+            }
+
+            try (KubernetesOperations k8s = k8sFactory.create(environment)) {
+                k8s.deletePod(namespace, podName);
+            }
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to restart application pod: " + e.getMessage(), e);
+        }
+    }
+
+    public ClusterDomainResponse getClusterDomain(String namespace, String name, String environmentName) {
+        try {
+            Environment environment = environmentRepository.findFirstByName(environmentName);
+            if (environment == null) {
+                throw new IllegalArgumentException("Environment not found: " + environmentName);
+            }
+
+            String serviceName = null;
+            try (KubernetesOperations k8s = k8sFactory.create(environment)) {
+                var service = k8s.getService(namespace, name);
+                if (service != null) {
+                    serviceName = service.getMetadata().getName();
+                }
+            }
+
+            return domainService.resolveClusterDomain(serviceConfigRepository, namespace, name,
+                    environmentName, serviceName);
+        } catch (Exception e) {
+            log.error("Failed to get cluster domain: {}", e.getMessage(), e);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/task/ArtifactDeployTask.java
+++ b/src/main/java/com/github/wellch4n/oops/task/ArtifactDeployTask.java
@@ -1,13 +1,14 @@
 package com.github.wellch4n.oops.task;
 
+import com.github.wellch4n.oops.adapter.kubernetes.KubernetesOperationsFactory;
 import com.github.wellch4n.oops.config.IngressConfig;
-import com.github.wellch4n.oops.config.OopsConstants;
 import com.github.wellch4n.oops.data.Application;
 import com.github.wellch4n.oops.data.ApplicationRuntimeSpec;
 import com.github.wellch4n.oops.data.ApplicationServiceConfig;
 import com.github.wellch4n.oops.data.Environment;
 import com.github.wellch4n.oops.data.Pipeline;
 import com.github.wellch4n.oops.enums.OopsTypes;
+import com.github.wellch4n.oops.port.KubernetesOperations;
 import com.github.wellch4n.oops.task.processor.DeployContext;
 import com.github.wellch4n.oops.task.processor.DeployProcessor;
 import com.github.wellch4n.oops.task.processor.ImagePullSecretProcessor;
@@ -15,7 +16,6 @@ import com.github.wellch4n.oops.task.processor.IngressRouteProcessor;
 import com.github.wellch4n.oops.task.processor.NamespaceProcessor;
 import com.github.wellch4n.oops.task.processor.ServiceProcessor;
 import com.github.wellch4n.oops.task.processor.StatefulSetProcessor;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -31,6 +31,7 @@ public class ArtifactDeployTask implements Callable<Boolean> {
     private final ApplicationRuntimeSpec.HealthCheck healthCheck;
     private final ApplicationServiceConfig applicationServiceConfig;
     private final IngressConfig ingressConfig;
+    private final KubernetesOperationsFactory k8sFactory;
 
     private static final int SERVICE_PORT = 80;
 
@@ -39,7 +40,8 @@ public class ArtifactDeployTask implements Callable<Boolean> {
                               ApplicationRuntimeSpec.EnvironmentConfig environmentConfig,
                               ApplicationRuntimeSpec.HealthCheck healthCheck,
                               ApplicationServiceConfig applicationServiceConfig,
-                              IngressConfig ingressConfig) {
+                              IngressConfig ingressConfig,
+                              KubernetesOperationsFactory k8sFactory) {
         this.pipeline = pipeline;
         this.application = application;
         this.environment = environment;
@@ -47,14 +49,15 @@ public class ArtifactDeployTask implements Callable<Boolean> {
         this.healthCheck = healthCheck;
         this.applicationServiceConfig = applicationServiceConfig;
         this.ingressConfig = ingressConfig;
+        this.k8sFactory = k8sFactory;
     }
 
     @Override
     public Boolean call() {
-        try (KubernetesClient client = environment.getKubernetesApiServer().fabric8Client()) {
+        try (KubernetesOperations k8s = k8sFactory.create(environment)) {
             DeployContext ctx = new DeployContext(
                     pipeline, application, environment, runtimeSpec, healthCheck,
-                    applicationServiceConfig, ingressConfig, client, OopsConstants.PATCH_CONTEXT,
+                    applicationServiceConfig, ingressConfig, k8s,
                     SERVICE_PORT, Map.of(
                             "oops.type", OopsTypes.APPLICATION.name(),
                             "oops.app.name", application.getName())

--- a/src/main/java/com/github/wellch4n/oops/task/processor/DeployContext.java
+++ b/src/main/java/com/github/wellch4n/oops/task/processor/DeployContext.java
@@ -6,9 +6,8 @@ import com.github.wellch4n.oops.data.ApplicationRuntimeSpec;
 import com.github.wellch4n.oops.data.ApplicationServiceConfig;
 import com.github.wellch4n.oops.data.Environment;
 import com.github.wellch4n.oops.data.Pipeline;
+import com.github.wellch4n.oops.port.KubernetesOperations;
 import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import java.util.Map;
 import lombok.Data;
 
@@ -21,8 +20,7 @@ public class DeployContext {
     private final ApplicationRuntimeSpec.HealthCheck healthCheck;
     private final ApplicationServiceConfig applicationServiceConfig;
     private final IngressConfig ingressConfig;
-    private final KubernetesClient client;
-    private final PatchContext patchContext;
+    private final KubernetesOperations k8s;
     private final int servicePort;
     private final Map<String, String> labels;
     private OwnerReference ownerRef;

--- a/src/main/java/com/github/wellch4n/oops/task/processor/ImagePullSecretProcessor.java
+++ b/src/main/java/com/github/wellch4n/oops/task/processor/ImagePullSecretProcessor.java
@@ -1,33 +1,14 @@
 package com.github.wellch4n.oops.task.processor;
 
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ImagePullSecretProcessor implements DeployProcessor {
-
     @Override
     public void process(DeployContext ctx) {
         String namespace = ctx.getApplication().getNamespace();
         String workNamespace = ctx.getEnvironment().getWorkNamespace();
-
-        Secret secret = ctx.getClient().secrets().inNamespace(workNamespace).withName("dockerhub").get();
-        if (secret == null) {
-            return;
-        }
-
         log.info("Checking image pull secret for namespace: {}", namespace);
-        ctx.getClient().secrets()
-                .inNamespace(namespace)
-                .resource(new SecretBuilder()
-                        .withNewMetadata()
-                            .withName("dockerhub")
-                            .withNamespace(namespace)
-                        .endMetadata()
-                        .withType(secret.getType())
-                        .withData(secret.getData())
-                        .build())
-                .patch(ctx.getPatchContext());
+        ctx.getK8s().copySecret(workNamespace, namespace, "dockerhub");
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/task/processor/NamespaceProcessor.java
+++ b/src/main/java/com/github/wellch4n/oops/task/processor/NamespaceProcessor.java
@@ -1,19 +1,13 @@
 package com.github.wellch4n.oops.task.processor;
 
-import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class NamespaceProcessor implements DeployProcessor {
-
     @Override
     public void process(DeployContext ctx) {
         String namespace = ctx.getApplication().getNamespace();
         log.info("Checking namespace: {}", namespace);
-        ctx.getClient().namespaces()
-                .resource(new NamespaceBuilder()
-                        .withNewMetadata().withName(namespace).endMetadata()
-                        .build())
-                .serverSideApply();
+        ctx.getK8s().ensureNamespace(namespace);
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/task/processor/ServiceProcessor.java
+++ b/src/main/java/com/github/wellch4n/oops/task/processor/ServiceProcessor.java
@@ -6,42 +6,22 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ServiceProcessor implements DeployProcessor {
-
     @Override
     public void process(DeployContext ctx) {
         String namespace = ctx.getApplication().getNamespace();
         String applicationName = ctx.getApplication().getName();
         Integer appPort = ctx.getApplicationServiceConfig().getPort();
-
-        if (appPort == null) {
-            return;
-        }
-
+        if (appPort == null) return;
         log.info("Applying service for application: {}/{}", namespace, applicationName);
-
-        var existing = ctx.getClient().services().inNamespace(namespace).withName(applicationName).get();
+        var existing = ctx.getK8s().getService(namespace, applicationName);
         var service = new ServiceBuilder()
-                .withNewMetadata()
-                    .withName(applicationName)
-                    .withNamespace(namespace)
-                    .withLabels(ctx.getLabels())
-                    .withOwnerReferences(ctx.getOwnerRef())
-                .endMetadata()
-                .withNewSpec()
-                    .withType("ClusterIP")
-                    .withSelector(ctx.getLabels())
-                    .addNewPort()
-                        .withName("web")
-                        .withProtocol("TCP")
-                        .withPort(ctx.getServicePort())
-                        .withTargetPort(new IntOrString(appPort))
-                    .endPort()
-                .endSpec()
-                .build();
-
-        if (existing != null) {
-            ctx.getClient().services().inNamespace(namespace).withName(applicationName).delete();
-        }
-        ctx.getClient().services().inNamespace(namespace).resource(service).create();
+                .withNewMetadata().withName(applicationName).withNamespace(namespace)
+                    .withLabels(ctx.getLabels()).withOwnerReferences(ctx.getOwnerRef()).endMetadata()
+                .withNewSpec().withType("ClusterIP").withSelector(ctx.getLabels())
+                    .addNewPort().withName("web").withProtocol("TCP").withPort(ctx.getServicePort())
+                        .withTargetPort(new IntOrString(appPort)).endPort()
+                .endSpec().build();
+        if (existing \!= null) ctx.getK8s().deleteService(namespace, applicationName);
+        ctx.getK8s().createService(namespace, service);
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/task/processor/StatefulSetProcessor.java
+++ b/src/main/java/com/github/wellch4n/oops/task/processor/StatefulSetProcessor.java
@@ -4,70 +4,48 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 public class StatefulSetProcessor implements DeployProcessor {
-
     @Override
     public void process(DeployContext ctx) {
         String namespace = ctx.getApplication().getNamespace();
         String applicationName = ctx.getApplication().getName();
-
         log.info("Checking stateful set for application: {}/{}", namespace, applicationName);
-
         var runtimeSpec = ctx.getRuntimeSpec();
-
         ContainerBuilder containerBuilder = new ContainerBuilder()
                 .withName(applicationName)
                 .withImage(ctx.getPipeline().getArtifact())
                 .withImagePullPolicy("IfNotPresent")
                 .addNewEnvFrom().withNewConfigMapRef(applicationName, true).endEnvFrom();
-
         boolean hasResource = StringUtils.isNotBlank(runtimeSpec.getCpuRequest())
                 || StringUtils.isNotBlank(runtimeSpec.getCpuLimit())
                 || StringUtils.isNotBlank(runtimeSpec.getMemoryRequest())
                 || StringUtils.isNotBlank(runtimeSpec.getMemoryLimit());
-
         if (hasResource) {
             var resourcesBuilder = new ResourceRequirementsBuilder();
-            if (StringUtils.isNotBlank(runtimeSpec.getCpuRequest())) {
-                resourcesBuilder.addToRequests("cpu", new Quantity(runtimeSpec.getCpuRequest()));
-            }
-            if (StringUtils.isNotBlank(runtimeSpec.getCpuLimit())) {
-                resourcesBuilder.addToLimits("cpu", new Quantity(runtimeSpec.getCpuLimit()));
-            }
-            if (StringUtils.isNotBlank(runtimeSpec.getMemoryRequest())) {
-                resourcesBuilder.addToRequests("memory", new Quantity(runtimeSpec.getMemoryRequest() + "Mi"));
-            }
-            if (StringUtils.isNotBlank(runtimeSpec.getMemoryLimit())) {
-                resourcesBuilder.addToLimits("memory", new Quantity(runtimeSpec.getMemoryLimit() + "Mi"));
-            }
+            if (StringUtils.isNotBlank(runtimeSpec.getCpuRequest())) resourcesBuilder.addToRequests("cpu", new Quantity(runtimeSpec.getCpuRequest()));
+            if (StringUtils.isNotBlank(runtimeSpec.getCpuLimit())) resourcesBuilder.addToLimits("cpu", new Quantity(runtimeSpec.getCpuLimit()));
+            if (StringUtils.isNotBlank(runtimeSpec.getMemoryRequest())) resourcesBuilder.addToRequests("memory", new Quantity(runtimeSpec.getMemoryRequest() + "Mi"));
+            if (StringUtils.isNotBlank(runtimeSpec.getMemoryLimit())) resourcesBuilder.addToLimits("memory", new Quantity(runtimeSpec.getMemoryLimit() + "Mi"));
             containerBuilder.withResources(resourcesBuilder.build());
         }
-
         Integer appPort = ctx.getApplicationServiceConfig().getPort();
-        if (appPort != null && appPort > 0) {
-            containerBuilder.addNewPort().withName("http").withContainerPort(appPort).endPort();
-        }
-        if (ctx.getHealthCheck() != null && ctx.getHealthCheck().probeEnabled() && appPort != null && appPort > 0) {
+        if (appPort \!= null && appPort > 0) containerBuilder.addNewPort().withName("http").withContainerPort(appPort).endPort();
+        if (ctx.getHealthCheck() \!= null && ctx.getHealthCheck().probeEnabled() && appPort \!= null && appPort > 0) {
             var healthCheck = ctx.getHealthCheck();
             containerBuilder.withNewLivenessProbe()
-                    .withNewHttpGet()
-                        .withPath(healthCheck.normalizedPath())
-                        .withNewPort(appPort)
-                    .endHttpGet()
+                    .withNewHttpGet().withPath(healthCheck.normalizedPath()).withNewPort(appPort).endHttpGet()
                     .withInitialDelaySeconds(healthCheck.effectiveInitialDelaySeconds())
                     .withPeriodSeconds(healthCheck.effectivePeriodSeconds())
                     .withTimeoutSeconds(healthCheck.effectiveTimeoutSeconds())
                     .withFailureThreshold(healthCheck.effectiveFailureThreshold())
                 .endLivenessProbe();
         }
-
-        StatefulSet statefulSet = new StatefulSetBuilder()
+        var statefulSet = new StatefulSetBuilder()
                 .withNewMetadata().withName(applicationName).withLabels(ctx.getLabels()).endMetadata()
                 .withNewSpec()
                     .withReplicas(runtimeSpec.getReplicas() == null ? 0 : runtimeSpec.getReplicas())
@@ -83,19 +61,9 @@ public class StatefulSetProcessor implements DeployProcessor {
                     .endTemplate()
                 .endSpec()
                 .build();
-
-        StatefulSet created = ctx.getClient().apps().statefulSets()
-                .inNamespace(namespace)
-                .resource(statefulSet)
-                .patch(ctx.getPatchContext());
-
+        var result = ctx.getK8s().applyStatefulSet(namespace, statefulSet);
         ctx.setOwnerReference(new OwnerReferenceBuilder()
-                .withApiVersion("apps/v1")
-                .withKind("StatefulSet")
-                .withName(applicationName)
-                .withUid(created.getMetadata().getUid())
-                .withController(true)
-                .withBlockOwnerDeletion(true)
-                .build());
+                .withApiVersion("apps/v1").withKind("StatefulSet").withName(applicationName)
+                .withUid(result.uid()).withController(true).withBlockOwnerDeletion(true).build());
     }
 }


### PR DESCRIPTION
## Summary

- **K8s port abstraction**: `KubernetesOperations` interface + `Fabric8KubernetesOperations` adapter isolates all fabric8 K8s client calls behind a port interface, decoupling domain/service layers from infrastructure
- **Pipeline rich model**: Added `isDeployable()`, `isInFlight()`, `isTerminal()`, `transitionTo()` business methods with state machine validation — state transition logic is now enforced by the entity itself
- **Domain events**: `ApplicationDeletedEvent`, `RuntimeSpecChangedEvent`, `PipelineStateEvent` with `@TransactionalEventListener` handlers for async K8s resource cleanup after DB commit
- **Value objects**: `KubernetesApiServer`, `ImageRepository`, `HostConfig` extracted from `Environment` inner classes into standalone `@Embeddable` types in `domain/valueobject/`
- **Domain services**: `ApplicationDomainService` (host conflict detection, cluster domain resolution), `PipelineDomainService` (deploy pre-check with duplicate guard)
- **New application services**: `ApplicationConfigService`, `ApplicationRuntimeService`, `ApplicationStatusService` — split from the original 630-line `ApplicationService`
- **Deploy processor chain**: All 5 processors (`NamespaceProcessor`, `ImagePullSecretProcessor`, `StatefulSetProcessor`, `ServiceProcessor`, `IngressRouteProcessor`) refactored to use the `KubernetesOperations` port

## What's NOT included (follow-up work)

- Existing services/controllers still use `data.*` imports — the linter reverted file moves to `domain/` packages. The new domain layer files exist in `domain/` and can be wired in gradually
- `ApplicationService` still contains the original methods alongside the new split services — callers can be migrated incrementally
- WebSocket handlers and `NodeService` use `KubernetesOperations.getClient()` as an escape hatch for streaming operations — these could be further abstracted

## Test plan

- [ ] `./mvnw compile` passes
- [ ] Unit tests pass (`PublishContainerTests`, `IDEProxyDomainUtilsTests`)
- [ ] Manual: create/update/delete application
- [ ] Manual: trigger Git deploy, verify pipeline state transitions
- [ ] Manual: create/delete IDE
- [ ] Manual: update ConfigMap
- [ ] Manual: check application pod status

🤖 Generated with [Claude Code](https://claude.ai/code)