### PR TITLE
fix(web): disable environment name editing

### DIFF
--- a/web/app/settings/environments/[id]/page.tsx
+++ b/web/app/settings/environments/[id]/page.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -283,8 +284,9 @@ export default function EnvironmentEditPage() {
                           <FormItem>
                             <FormLabel>{t("env.col.name")}</FormLabel>
                             <FormControl>
-                              <Input placeholder="Production" {...field} />
+                              <Input placeholder="Production" disabled {...field} />
                             </FormControl>
+                            <FormDescription>{t("env.nameImmutableDesc")}</FormDescription>
                             <FormMessage />
                           </FormItem>
                         )}

--- a/web/locales/en-US/env.ts
+++ b/web/locales/en-US/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "Failed to load environment",
   "env.nameRequired": "Name is required",
   "env.namePlaceholder": "Environment name",
+  "env.nameImmutableDesc": "Environment names cannot be changed after creation.",
   "env.col.name": "Name",
   "env.col.workNamespace": "Work Namespace",
   "env.col.imageRepo": "Image Repository",

--- a/web/locales/ja-JP/env.ts
+++ b/web/locales/ja-JP/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "環境の読み込みに失敗しました",
   "env.nameRequired": "名前は必須です",
   "env.namePlaceholder": "環境名",
+  "env.nameImmutableDesc": "環境名は作成後に変更できません。",
   "env.col.name": "名前",
   "env.col.workNamespace": "作業用名前空間",
   "env.col.imageRepo": "イメージリポジトリ",

--- a/web/locales/zh-CN/env.ts
+++ b/web/locales/zh-CN/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "加载环境失败",
   "env.nameRequired": "名称不能为空",
   "env.namePlaceholder": "环境名称",
+  "env.nameImmutableDesc": "环境名称创建后不可修改。",
   "env.col.name": "名称",
   "env.col.workNamespace": "工作命名空间",
   "env.col.imageRepo": "镜像仓库",

--- a/web/locales/zh-TW/env.ts
+++ b/web/locales/zh-TW/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "載入環境失敗",
   "env.nameRequired": "名稱不能為空",
   "env.namePlaceholder": "環境名稱",
+  "env.nameImmutableDesc": "環境名稱建立後不可修改。",
   "env.col.name": "名稱",
   "env.col.workNamespace": "工作命名空間",
   "env.col.imageRepo": "鏡像倉庫",


### PR DESCRIPTION
## Summary
- disable the environment name input on the edit page
- add localized helper text explaining that environment names cannot be changed after creation

## Tests
- git diff --check
- pnpm lint (fails: missing local package typescript-eslint)
- pnpm exec tsc --noEmit (fails: local dependency/type resolution issues for existing packages such as cmdk, radix-ui, and zustand)