### PR TITLE
feat(pipeline): add image-only deployment rollback

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/dto/PipelineDto.java
+++ b/src/main/java/com/github/wellch4n/oops/application/dto/PipelineDto.java
@@ -3,6 +3,7 @@ package com.github.wellch4n.oops.application.dto;
 import com.github.wellch4n.oops.domain.delivery.Pipeline;
 import com.github.wellch4n.oops.domain.shared.DeployMode;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.domain.shared.PipelineTriggerType;
 import java.time.LocalDateTime;
 
 public record PipelineDto(
@@ -18,7 +19,9 @@ public record PipelineDto(
         DeployMode deployMode,
         String operatorId,
         String operatorName,
-        String message
+        String message,
+        PipelineTriggerType triggerType,
+        String rollbackFromPipelineId
 ) {
     public static PipelineDto from(Pipeline pipeline, String operatorName) {
         return new PipelineDto(
@@ -34,7 +37,9 @@ public record PipelineDto(
                 pipeline.getDeployMode(),
                 pipeline.getOperatorId(),
                 operatorName,
-                pipeline.getMessage()
+                pipeline.getMessage(),
+                pipeline.getTriggerType(),
+                pipeline.getRollbackFromPipelineId()
         );
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/application/port/ApplicationRuntimeGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/application/port/ApplicationRuntimeGateway.java
@@ -21,4 +21,10 @@ public interface ApplicationRuntimeGateway {
     void restartPod(Environment environment, String namespace, String podName);
 
     String findInternalServiceDomain(Environment environment, String namespace, String applicationName);
+
+    /**
+     * Returns the container image currently set on the application's StatefulSet, or {@code null}
+     * if the workload does not exist. Used to highlight which pipeline's artifact is currently live.
+     */
+    String findCurrentImage(Environment environment, String namespace, String applicationName);
 }

--- a/src/main/java/com/github/wellch4n/oops/application/service/ApplicationService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/ApplicationService.java
@@ -449,6 +449,14 @@ public class ApplicationService {
         return applicationRuntimeGateway.getPodStatuses(environment, namespace, name);
     }
 
+    public String getCurrentImage(String namespace, String name, String environmentName) {
+        Environment environment = environmentRepository.findFirstByName(environmentName);
+        if (environment == null) {
+            throw new IllegalArgumentException("Environment not found: " + environmentName);
+        }
+        return applicationRuntimeGateway.findCurrentImage(environment, namespace, name);
+    }
+
     public SseEmitter watchApplicationStatus(String namespace, String name, String environmentName) {
         Environment environment = environmentRepository.findFirstByName(environmentName);
         if (environment == null) {

--- a/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
@@ -192,6 +192,71 @@ public class PipelineService {
     }
 
     @Transactional(noRollbackFor = RuntimeException.class)
+    public String rollback(String namespace, String applicationName, String targetPipelineId, String operatorUserId) {
+        Pipeline source = pipelineRepository.findByNamespaceAndApplicationNameAndId(namespace, applicationName, targetPipelineId);
+        if (source == null) {
+            throw new BizException("Target pipeline not found");
+        }
+        if (source.getStatus() != PipelineStatus.SUCCEEDED) {
+            throw new BizException("Only succeeded pipelines can be rolled back to");
+        }
+        if (StringUtils.isBlank(source.getArtifact())) {
+            throw new BizException("Target pipeline has no artifact to deploy");
+        }
+
+        deploymentConcurrencyPolicy.ensureNoActivePipeline(pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(
+                namespace, applicationName, List.of(PipelineStatus.RUNNING, PipelineStatus.DEPLOYING)
+        ));
+
+        Pipeline rollbackPipeline = pipelineRepository.save(Pipeline.rollback(source, operatorUserId));
+        eventPublisher.publishEvent(PipelineNotificationEvent.of(
+                rollbackPipeline, PipelineNotificationType.CREATED, "回滚任务已创建。"
+        ));
+
+        pipelineStateMachine.ensureCanTransition(PipelineStatus.INITIALIZED, PipelineStatus.DEPLOYING);
+        int claimed = pipelineRepository.updateStatusIfMatch(rollbackPipeline.getId(), PipelineStatus.INITIALIZED, PipelineStatus.DEPLOYING);
+        if (claimed == 0) {
+            throw new BizException("Pipeline state changed concurrently, please retry");
+        }
+        rollbackPipeline.markDeploying();
+        eventPublisher.publishEvent(PipelineNotificationEvent.of(
+                rollbackPipeline, PipelineNotificationType.DEPLOYING, "回滚任务已进入部署阶段。"
+        ));
+
+        try {
+            Environment environment = requireEnvironment(rollbackPipeline.getEnvironment());
+            Application application = applicationRepository.findAggregate(namespace, applicationName);
+            if (application == null) {
+                throw new BizException("Application not found");
+            }
+            ApplicationRuntimeSpec.EnvironmentConfig runtimeSpec =
+                    application.runtimeEnvironmentConfigOrDefault(rollbackPipeline.getEnvironment());
+            ApplicationRuntimeSpec.HealthCheck healthCheck = application.healthCheckOrDefault();
+            ApplicationServiceConfig serviceConfig = application.serviceConfigOrDefault();
+
+            artifactDeploymentExecutor.deploy(rollbackPipeline, application, environment, runtimeSpec, healthCheck, serviceConfig);
+
+            pipelineStateMachine.ensureCanTransition(PipelineStatus.DEPLOYING, PipelineStatus.SUCCEEDED);
+            pipelineRepository.updateStatusIfMatch(rollbackPipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.SUCCEEDED);
+            rollbackPipeline.markSucceeded();
+            eventPublisher.publishEvent(PipelineNotificationEvent.of(
+                    rollbackPipeline, PipelineNotificationType.SUCCEEDED, "回滚已成功。"
+            ));
+        } catch (Exception e) {
+            pipelineStateMachine.ensureCanTransition(PipelineStatus.DEPLOYING, PipelineStatus.ERROR);
+            String message = StringUtils.defaultIfBlank(e.getMessage(), "回滚任务执行失败，请查看日志。");
+            pipelineRepository.updateStatusAndMessageIfMatch(
+                    rollbackPipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.ERROR, message);
+            rollbackPipeline.markFailed(message);
+            eventPublisher.publishEvent(PipelineNotificationEvent.of(
+                    rollbackPipeline, PipelineNotificationType.FAILED, message
+            ));
+            throw new RuntimeException("Rollback failed: " + e.getMessage(), e);
+        }
+        return rollbackPipeline.getId();
+    }
+
+    @Transactional(noRollbackFor = RuntimeException.class)
     public Boolean stopPipeline(String namespace, String applicationName, String id) {
         Pipeline pipeline = pipelineRepository.findByNamespaceAndApplicationNameAndId(namespace, applicationName, id);
         if (pipeline == null) {

--- a/src/main/java/com/github/wellch4n/oops/domain/delivery/Pipeline.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/delivery/Pipeline.java
@@ -4,6 +4,7 @@ import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
 import com.github.wellch4n.oops.domain.shared.BaseAggregateRoot;
 import com.github.wellch4n.oops.domain.shared.DeployMode;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.domain.shared.PipelineTriggerType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -23,6 +24,8 @@ public class Pipeline extends BaseAggregateRoot {
     private DeployMode deployMode;
     private String operatorId;
     private String message;
+    private PipelineTriggerType triggerType;
+    private String rollbackFromPipelineId;
 
     public static Pipeline initialize(
             String namespace,
@@ -40,6 +43,29 @@ public class Pipeline extends BaseAggregateRoot {
         pipeline.setDeployMode(deployMode != null ? deployMode : DeployMode.IMMEDIATE);
         pipeline.setOperatorId(operatorId);
         pipeline.setStatus(PipelineStatus.INITIALIZED);
+        pipeline.setTriggerType(PipelineTriggerType.BUILD);
+        return pipeline;
+    }
+
+    /**
+     * Builds a rollback pipeline that reuses a historic pipeline's artifact (image) and skips the build phase.
+     * The source must be a successfully deployed pipeline; the new pipeline starts at {@link PipelineStatus#INITIALIZED}
+     * and is expected to transition directly to {@link PipelineStatus#DEPLOYING}.
+     */
+    public static Pipeline rollback(Pipeline source, String operatorId) {
+        Pipeline pipeline = new Pipeline();
+        pipeline.setNamespace(source.getNamespace());
+        pipeline.setApplicationName(source.getApplicationName());
+        pipeline.setEnvironment(source.getEnvironment());
+        pipeline.setArtifact(source.getArtifact());
+        pipeline.setPublishType(source.getPublishType());
+        pipeline.setBranch(source.getBranch());
+        pipeline.setPublishRepository(source.getPublishRepository());
+        pipeline.setDeployMode(DeployMode.IMMEDIATE);
+        pipeline.setOperatorId(operatorId);
+        pipeline.setStatus(PipelineStatus.INITIALIZED);
+        pipeline.setTriggerType(PipelineTriggerType.ROLLBACK);
+        pipeline.setRollbackFromPipelineId(source.getId());
         return pipeline;
     }
 

--- a/src/main/java/com/github/wellch4n/oops/domain/delivery/PipelineStateMachine.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/delivery/PipelineStateMachine.java
@@ -17,6 +17,7 @@ public class PipelineStateMachine {
     static {
         ALLOWED_TRANSITIONS.put(PipelineStatus.INITIALIZED, EnumSet.of(
                 PipelineStatus.RUNNING,
+                PipelineStatus.DEPLOYING,
                 PipelineStatus.ERROR,
                 PipelineStatus.STOPPED
         ));

--- a/src/main/java/com/github/wellch4n/oops/domain/shared/PipelineTriggerType.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/shared/PipelineTriggerType.java
@@ -1,0 +1,14 @@
+package com.github.wellch4n.oops.domain.shared;
+
+/**
+ * Distinguishes how a pipeline was triggered.
+ *
+ * <ul>
+ *   <li>{@link #BUILD} — a normal build-and-deploy pipeline.</li>
+ *   <li>{@link #ROLLBACK} — a rollback that reuses a historic artifact and skips the build phase.</li>
+ * </ul>
+ */
+public enum PipelineTriggerType {
+    BUILD,
+    ROLLBACK
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesApplicationRuntimeGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesApplicationRuntimeGateway.java
@@ -258,6 +258,27 @@ public class KubernetesApplicationRuntimeGateway implements ApplicationRuntimeGa
                 CLUSTER_SUFFIX);
     }
 
+    @Override
+    public String findCurrentImage(Environment environment, String namespace, String applicationName) {
+        var client = clientPool.get(environment.getKubernetesApiServer());
+        var statefulSet = client.apps().statefulSets()
+                .inNamespace(namespace)
+                .withName(applicationName)
+                .get();
+        if (statefulSet == null
+                || statefulSet.getSpec() == null
+                || statefulSet.getSpec().getTemplate() == null
+                || statefulSet.getSpec().getTemplate().getSpec() == null) {
+            return null;
+        }
+        var containers = statefulSet.getSpec().getTemplate().getSpec().getContainers();
+        return containers.stream()
+                .filter(container -> applicationName.equals(container.getName()))
+                .map(io.fabric8.kubernetes.api.model.Container::getImage)
+                .findFirst()
+                .orElseGet(() -> containers.isEmpty() ? null : containers.getFirst().getImage());
+    }
+
     private boolean hasResource(ApplicationRuntimeSpec.EnvironmentConfig runtimeSpec) {
         return StringUtils.isNotBlank(runtimeSpec.getCpuRequest())
                 || StringUtils.isNotBlank(runtimeSpec.getCpuLimit())

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/Pipeline.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/Pipeline.java
@@ -3,6 +3,7 @@ package com.github.wellch4n.oops.infrastructure.persistence.jpa;
 import com.github.wellch4n.oops.domain.shared.DeployMode;
 import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.domain.shared.PipelineTriggerType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -41,6 +42,11 @@ public class Pipeline extends BaseDataObject {
     private String operatorId;
 
     private String message;
+
+    @Enumerated(EnumType.STRING)
+    private PipelineTriggerType triggerType;
+
+    private String rollbackFromPipelineId;
 
     public String getName() {
         return String.format("%s-pipeline-%s", applicationName, getId());

--- a/src/main/java/com/github/wellch4n/oops/interfaces/rest/ApplicationController.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/rest/ApplicationController.java
@@ -200,6 +200,13 @@ public class ApplicationController {
         return Result.success(applicationService.getApplicationStatus(namespace, name, env));
     }
 
+    @GetMapping("/{name}/current-image")
+    public Result<String> getCurrentImage(@PathVariable String namespace,
+                                          @PathVariable String name,
+                                          @RequestParam String env) {
+        return Result.success(applicationService.getCurrentImage(namespace, name, env));
+    }
+
     @GetMapping("/{name}/status/watch")
     public SseEmitter watchApplicationStatus(@PathVariable String namespace,
                                               @PathVariable String name,

--- a/src/main/java/com/github/wellch4n/oops/interfaces/rest/PipelineController.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/rest/PipelineController.java
@@ -2,9 +2,11 @@ package com.github.wellch4n.oops.interfaces.rest;
 
 import com.github.wellch4n.oops.application.dto.Page;
 import com.github.wellch4n.oops.application.dto.PipelineDto;
+import com.github.wellch4n.oops.interfaces.dto.AuthUserPrincipal;
 import com.github.wellch4n.oops.interfaces.dto.Result;
 import com.github.wellch4n.oops.application.service.PipelineService;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -55,5 +57,15 @@ public class PipelineController {
                                           @PathVariable String name,
                                           @PathVariable String id) {
         return Result.success(pipelineService.deployPipeline(namespace, name, id));
+    }
+
+    @PostMapping("/{id}/rollback")
+    @PreAuthorize("isAuthenticated()")
+    public Result<String> rollbackPipeline(@PathVariable String namespace,
+                                           @PathVariable String name,
+                                           @PathVariable String id,
+                                           Authentication authentication) {
+        AuthUserPrincipal principal = (AuthUserPrincipal) authentication.getPrincipal();
+        return Result.success(pipelineService.rollback(namespace, name, id, principal.userId()));
     }
 }

--- a/src/main/resources/db/migration/V10__add_pipeline_trigger_type.sql
+++ b/src/main/resources/db/migration/V10__add_pipeline_trigger_type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `pipeline`
+    ADD COLUMN `trigger_type` varchar(32) DEFAULT 'BUILD',
+    ADD COLUMN `rollback_from_pipeline_id` varchar(255) DEFAULT NULL;

--- a/src/test/java/com/github/wellch4n/oops/application/service/PipelineRollbackTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/service/PipelineRollbackTests.java
@@ -1,0 +1,190 @@
+package com.github.wellch4n.oops.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.wellch4n.oops.application.event.PipelineNotificationEvent;
+import com.github.wellch4n.oops.application.port.ArtifactDeploymentExecutor;
+import com.github.wellch4n.oops.application.port.PipelineJobGateway;
+import com.github.wellch4n.oops.application.port.PipelineLogGateway;
+import com.github.wellch4n.oops.application.port.repository.ApplicationRepository;
+import com.github.wellch4n.oops.application.port.repository.PipelineRepository;
+import com.github.wellch4n.oops.domain.application.Application;
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
+import com.github.wellch4n.oops.domain.application.ApplicationServiceConfig;
+import com.github.wellch4n.oops.domain.delivery.DeploymentConcurrencyPolicy;
+import com.github.wellch4n.oops.domain.delivery.Pipeline;
+import com.github.wellch4n.oops.domain.delivery.PipelineStateMachine;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.domain.shared.PipelineTriggerType;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+
+class PipelineRollbackTests {
+
+    private static final String NAMESPACE = "default";
+    private static final String APP_NAME = "demo";
+    private static final String ENV = "prod";
+    private static final String SOURCE_ID = "source-pipeline-id";
+    private static final String NEW_ID = "new-rollback-id";
+
+    private PipelineRepository pipelineRepository;
+    private EnvironmentService environmentService;
+    private ApplicationRepository applicationRepository;
+    private UserService userService;
+    private ApplicationEventPublisher eventPublisher;
+    private ArtifactDeploymentExecutor artifactDeploymentExecutor;
+    private PipelineService pipelineService;
+
+    @BeforeEach
+    void setUp() {
+        pipelineRepository = org.mockito.Mockito.mock(PipelineRepository.class);
+        environmentService = org.mockito.Mockito.mock(EnvironmentService.class);
+        applicationRepository = org.mockito.Mockito.mock(ApplicationRepository.class);
+        userService = org.mockito.Mockito.mock(UserService.class);
+        eventPublisher = org.mockito.Mockito.mock(ApplicationEventPublisher.class);
+        artifactDeploymentExecutor = org.mockito.Mockito.mock(ArtifactDeploymentExecutor.class);
+        PipelineJobGateway pipelineJobGateway = org.mockito.Mockito.mock(PipelineJobGateway.class);
+        PipelineLogGateway pipelineLogGateway = org.mockito.Mockito.mock(PipelineLogGateway.class);
+
+        pipelineService = new PipelineService(
+                pipelineRepository,
+                environmentService,
+                applicationRepository,
+                userService,
+                eventPublisher,
+                artifactDeploymentExecutor,
+                pipelineJobGateway,
+                pipelineLogGateway,
+                PipelineStateMachine.getInstance(),
+                new DeploymentConcurrencyPolicy()
+        );
+    }
+
+    private Pipeline succeededSource() {
+        Pipeline source = new Pipeline();
+        source.setId(SOURCE_ID);
+        source.setNamespace(NAMESPACE);
+        source.setApplicationName(APP_NAME);
+        source.setEnvironment(ENV);
+        source.setArtifact("registry.example.com/demo:v1");
+        source.setStatus(PipelineStatus.SUCCEEDED);
+        return source;
+    }
+
+    private void stubHappyDependencies() {
+        when(pipelineRepository.save(any(Pipeline.class))).thenAnswer(invocation -> {
+            Pipeline saved = invocation.getArgument(0);
+            saved.setId(NEW_ID);
+            return saved;
+        });
+        when(pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(eq(NAMESPACE), eq(APP_NAME), anyList()))
+                .thenReturn(false);
+        when(pipelineRepository.updateStatusIfMatch(eq(NEW_ID), eq(PipelineStatus.INITIALIZED), eq(PipelineStatus.DEPLOYING)))
+                .thenReturn(1);
+
+        Environment environment = new Environment();
+        environment.setName(ENV);
+        when(environmentService.getEnvironment(ENV)).thenReturn(environment);
+
+        Application application = new Application();
+        application.setName(APP_NAME);
+        application.setNamespace(NAMESPACE);
+        when(applicationRepository.findAggregate(NAMESPACE, APP_NAME)).thenReturn(application);
+    }
+
+    @Test
+    void rollbackCreatesNewRollbackPipelineAndDeploys() {
+        when(pipelineRepository.findByNamespaceAndApplicationNameAndId(NAMESPACE, APP_NAME, SOURCE_ID))
+                .thenReturn(succeededSource());
+        stubHappyDependencies();
+
+        String resultId = pipelineService.rollback(NAMESPACE, APP_NAME, SOURCE_ID, "operator-1");
+
+        assertEquals(NEW_ID, resultId);
+
+        ArgumentCaptor<Pipeline> savedCaptor = ArgumentCaptor.forClass(Pipeline.class);
+        verify(pipelineRepository).save(savedCaptor.capture());
+        Pipeline saved = savedCaptor.getValue();
+        assertEquals(PipelineTriggerType.ROLLBACK, saved.getTriggerType());
+        assertEquals(SOURCE_ID, saved.getRollbackFromPipelineId());
+        assertEquals("registry.example.com/demo:v1", saved.getArtifact());
+        assertEquals("operator-1", saved.getOperatorId());
+
+        verify(artifactDeploymentExecutor).deploy(any(Pipeline.class), any(Application.class), any(Environment.class),
+                any(ApplicationRuntimeSpec.EnvironmentConfig.class), any(ApplicationRuntimeSpec.HealthCheck.class),
+                any(ApplicationServiceConfig.class));
+        verify(pipelineRepository).updateStatusIfMatch(NEW_ID, PipelineStatus.DEPLOYING, PipelineStatus.SUCCEEDED);
+    }
+
+    @Test
+    void rollbackRejectsNonSucceededTarget() {
+        Pipeline running = succeededSource();
+        running.setStatus(PipelineStatus.RUNNING);
+        when(pipelineRepository.findByNamespaceAndApplicationNameAndId(NAMESPACE, APP_NAME, SOURCE_ID))
+                .thenReturn(running);
+
+        assertThrows(BizException.class,
+                () -> pipelineService.rollback(NAMESPACE, APP_NAME, SOURCE_ID, "operator-1"));
+        verify(pipelineRepository, never()).save(any());
+    }
+
+    @Test
+    void rollbackRejectsMissingArtifact() {
+        Pipeline noArtifact = succeededSource();
+        noArtifact.setArtifact("  ");
+        when(pipelineRepository.findByNamespaceAndApplicationNameAndId(NAMESPACE, APP_NAME, SOURCE_ID))
+                .thenReturn(noArtifact);
+
+        assertThrows(BizException.class,
+                () -> pipelineService.rollback(NAMESPACE, APP_NAME, SOURCE_ID, "operator-1"));
+        verify(pipelineRepository, never()).save(any());
+    }
+
+    @Test
+    void rollbackRejectsMissingTarget() {
+        when(pipelineRepository.findByNamespaceAndApplicationNameAndId(NAMESPACE, APP_NAME, SOURCE_ID))
+                .thenReturn(null);
+
+        assertThrows(BizException.class,
+                () -> pipelineService.rollback(NAMESPACE, APP_NAME, SOURCE_ID, "operator-1"));
+        verify(pipelineRepository, never()).save(any());
+    }
+
+    @Test
+    void rollbackBlockedByActivePipeline() {
+        when(pipelineRepository.findByNamespaceAndApplicationNameAndId(NAMESPACE, APP_NAME, SOURCE_ID))
+                .thenReturn(succeededSource());
+        when(pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(eq(NAMESPACE), eq(APP_NAME), anyList()))
+                .thenReturn(true);
+
+        assertThrows(BizException.class,
+                () -> pipelineService.rollback(NAMESPACE, APP_NAME, SOURCE_ID, "operator-1"));
+        verify(pipelineRepository, never()).save(any());
+    }
+
+    @Test
+    void rollbackMarksErrorWhenDeployFails() {
+        when(pipelineRepository.findByNamespaceAndApplicationNameAndId(NAMESPACE, APP_NAME, SOURCE_ID))
+                .thenReturn(succeededSource());
+        stubHappyDependencies();
+        org.mockito.Mockito.doThrow(new RuntimeException("boom"))
+                .when(artifactDeploymentExecutor).deploy(any(), any(), any(), any(), any(), any());
+
+        assertThrows(RuntimeException.class,
+                () -> pipelineService.rollback(NAMESPACE, APP_NAME, SOURCE_ID, "operator-1"));
+
+        verify(pipelineRepository).updateStatusAndMessageIfMatch(
+                eq(NEW_ID), eq(PipelineStatus.DEPLOYING), eq(PipelineStatus.ERROR), any());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/delivery/PipelineStateMachineTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/delivery/PipelineStateMachineTests.java
@@ -1,0 +1,49 @@
+package com.github.wellch4n.oops.domain.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import org.junit.jupiter.api.Test;
+
+class PipelineStateMachineTests {
+
+    private final PipelineStateMachine stateMachine = PipelineStateMachine.getInstance();
+
+    @Test
+    void allowsInitializedToDeployingForRollback() {
+        assertDoesNotThrow(() -> stateMachine.ensureCanTransition(
+                PipelineStatus.INITIALIZED, PipelineStatus.DEPLOYING));
+    }
+
+    @Test
+    void stillAllowsNormalBuildPath() {
+        assertDoesNotThrow(() -> stateMachine.ensureCanTransition(
+                PipelineStatus.INITIALIZED, PipelineStatus.RUNNING));
+        assertDoesNotThrow(() -> stateMachine.ensureCanTransition(
+                PipelineStatus.RUNNING, PipelineStatus.BUILD_SUCCEEDED));
+        assertDoesNotThrow(() -> stateMachine.ensureCanTransition(
+                PipelineStatus.BUILD_SUCCEEDED, PipelineStatus.DEPLOYING));
+        assertDoesNotThrow(() -> stateMachine.ensureCanTransition(
+                PipelineStatus.DEPLOYING, PipelineStatus.SUCCEEDED));
+    }
+
+    @Test
+    void rejectsIllegalTransitionFromInitialized() {
+        assertThrows(BizException.class, () -> stateMachine.ensureCanTransition(
+                PipelineStatus.INITIALIZED, PipelineStatus.SUCCEEDED));
+        assertThrows(BizException.class, () -> stateMachine.ensureCanTransition(
+                PipelineStatus.INITIALIZED, PipelineStatus.BUILD_SUCCEEDED));
+    }
+
+    @Test
+    void terminalStatesCannotTransition() {
+        assertThrows(BizException.class, () -> stateMachine.ensureCanTransition(
+                PipelineStatus.SUCCEEDED, PipelineStatus.DEPLOYING));
+        assertThrows(BizException.class, () -> stateMachine.ensureCanTransition(
+                PipelineStatus.ERROR, PipelineStatus.DEPLOYING));
+        assertThrows(BizException.class, () -> stateMachine.ensureCanTransition(
+                PipelineStatus.STOPPED, PipelineStatus.DEPLOYING));
+    }
+}

--- a/web/app/pipelines/columns.tsx
+++ b/web/app/pipelines/columns.tsx
@@ -30,12 +30,6 @@ export const getPipelineColumns = (
               {t("pipelines.col.currentVersion")}
             </Badge>
           )}
-          {row.original.triggerType === "ROLLBACK" && (
-            <Badge variant="outline" className="gap-1">
-              <Undo2 className="size-3" />
-              {t("pipelines.col.rollbackTag")}
-            </Badge>
-          )}
         </div>
       )
     },
@@ -53,6 +47,20 @@ export const getPipelineColumns = (
       const deployMode = row.original.deployMode
       if (!deployMode) return <span className="text-muted-foreground">-</span>
       return deployMode === "IMMEDIATE" ? t("apps.pipeline.modeImmediate") : t("apps.pipeline.modeManual")
+    }
+  },
+  {
+    accessorKey: "triggerType",
+    header: t("pipelines.col.triggerType"),
+    size: 90,
+    cell: ({ row }) => {
+      const isRollback = row.original.triggerType === "ROLLBACK"
+      return (
+        <Badge variant={isRollback ? "outline" : "secondary"} className="gap-1">
+          {isRollback ? <Undo2 className="size-3" /> : <Rocket className="size-3" />}
+          {isRollback ? t("pipelines.col.rollbackTag") : t("pipelines.col.buildTag")}
+        </Badge>
+      )
     }
   },
   {

--- a/web/app/pipelines/columns.tsx
+++ b/web/app/pipelines/columns.tsx
@@ -6,22 +6,39 @@ import { Pipeline } from "@/lib/api/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Copyable } from "@/components/ui/copyable"
-import { Eye, Ban, Rocket } from "lucide-react"
+import { Eye, Ban, Rocket, Undo2, CircleDot } from "lucide-react"
 
 export const getPipelineColumns = (
   t: (key: string) => string,
   onStop: (pipeline: Pipeline) => void,
-  onDeploy: (pipeline: Pipeline) => void
+  onDeploy: (pipeline: Pipeline) => void,
+  onRollback: (pipeline: Pipeline) => void,
+  currentPipelineId?: string | null
 ): ColumnDef<Pipeline>[] => [
   {
     accessorKey: "id",
     header: "ID",
-    size: 260,
-    cell: ({ row }) => (
-      <div className="whitespace-nowrap">
-        <Copyable value={row.original.id} maxLength={Infinity} />
-      </div>
-    ),
+    size: 300,
+    cell: ({ row }) => {
+      const isCurrent = !!currentPipelineId && row.original.id === currentPipelineId
+      return (
+        <div className="flex items-center gap-1.5 whitespace-nowrap">
+          <Copyable value={row.original.id} maxLength={Infinity} />
+          {isCurrent && (
+            <Badge variant="default" className="gap-1">
+              <CircleDot className="size-3" />
+              {t("pipelines.col.currentVersion")}
+            </Badge>
+          )}
+          {row.original.triggerType === "ROLLBACK" && (
+            <Badge variant="outline" className="gap-1">
+              <Undo2 className="size-3" />
+              {t("pipelines.col.rollbackTag")}
+            </Badge>
+          )}
+        </div>
+      )
+    },
   },
   {
     accessorKey: "environment",
@@ -102,6 +119,14 @@ export const getPipelineColumns = (
             <Button variant="destructive" size="sm" className="h-8 px-2 gap-1" onClick={() => onStop(row.original)}>
               <Ban className="size-4" />
               {t("pipelines.col.stop")}
+            </Button>
+          )}
+          {row.original.status === "SUCCEEDED"
+            && !!row.original.artifact
+            && !(currentPipelineId && row.original.id === currentPipelineId) && (
+            <Button variant="outline" size="sm" className="h-8 px-2 gap-1" onClick={() => onRollback(row.original)}>
+              <Undo2 className="size-4" />
+              {t("pipelines.col.rollbackBtn")}
             </Button>
           )}
         </div>

--- a/web/app/pipelines/columns.tsx
+++ b/web/app/pipelines/columns.tsx
@@ -6,6 +6,7 @@ import { Pipeline } from "@/lib/api/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Copyable } from "@/components/ui/copyable"
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { Eye, Ban, Rocket, Undo2, CircleDot } from "lucide-react"
 
 export const getPipelineColumns = (
@@ -55,11 +56,31 @@ export const getPipelineColumns = (
     size: 90,
     cell: ({ row }) => {
       const isRollback = row.original.triggerType === "ROLLBACK"
+      if (!isRollback) {
+        return (
+          <span className="inline-flex items-center gap-1 text-muted-foreground whitespace-nowrap">
+            <Rocket className="size-3.5" />
+            {t("pipelines.col.buildTag")}
+          </span>
+        )
+      }
+      const fromId = row.original.rollbackFromPipelineId
+      const label = (
+        <span className="inline-flex items-center gap-1 text-foreground whitespace-nowrap">
+          <Undo2 className="size-3.5" />
+          {t("pipelines.col.rollbackTag")}
+        </span>
+      )
+      if (!fromId) return label
       return (
-        <Badge variant={isRollback ? "outline" : "secondary"} className="gap-1">
-          {isRollback ? <Undo2 className="size-3" /> : <Rocket className="size-3" />}
-          {isRollback ? t("pipelines.col.rollbackTag") : t("pipelines.col.buildTag")}
-        </Badge>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-help underline decoration-dotted underline-offset-4">{label}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t("pipelines.col.rollbackFrom")}{fromId}
+          </TooltipContent>
+        </Tooltip>
       )
     }
   },

--- a/web/app/pipelines/columns.tsx
+++ b/web/app/pipelines/columns.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Copyable } from "@/components/ui/copyable"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
-import { Eye, Ban, Rocket, Undo2, CircleDot } from "lucide-react"
+import { Eye, Ban, Rocket, Undo2, CircleDot, Info } from "lucide-react"
 
 export const getPipelineColumns = (
   t: (key: string) => string,
@@ -58,29 +58,28 @@ export const getPipelineColumns = (
       const isRollback = row.original.triggerType === "ROLLBACK"
       if (!isRollback) {
         return (
-          <span className="inline-flex items-center gap-1 text-muted-foreground whitespace-nowrap">
+          <span className="inline-flex items-center gap-1 whitespace-nowrap">
             <Rocket className="size-3.5" />
             {t("pipelines.col.buildTag")}
           </span>
         )
       }
       const fromId = row.original.rollbackFromPipelineId
-      const label = (
-        <span className="inline-flex items-center gap-1 text-foreground whitespace-nowrap">
+      return (
+        <span className="inline-flex items-center gap-1 whitespace-nowrap">
           <Undo2 className="size-3.5" />
           {t("pipelines.col.rollbackTag")}
+          {fromId && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="size-3.5 text-muted-foreground cursor-help" />
+              </TooltipTrigger>
+              <TooltipContent>
+                {t("pipelines.col.rollbackFrom")}{fromId}
+              </TooltipContent>
+            </Tooltip>
+          )}
         </span>
-      )
-      if (!fromId) return label
-      return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="cursor-help underline decoration-dotted underline-offset-4">{label}</span>
-          </TooltipTrigger>
-          <TooltipContent>
-            {t("pipelines.col.rollbackFrom")}{fromId}
-          </TooltipContent>
-        </Tooltip>
       )
     }
   },

--- a/web/app/pipelines/page.tsx
+++ b/web/app/pipelines/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { DataTable } from "@/components/ui/data-table"
-import { getPipelines, stopPipeline, deployPipeline } from "@/lib/api/pipelines"
+import { getPipelines, stopPipeline, deployPipeline, rollbackPipeline, getCurrentImage } from "@/lib/api/pipelines"
 import { getApplications, getApplicationBuildEnvConfigs } from "@/lib/api/applications"
 import { Pipeline, Application } from "@/lib/api/types"
 import { getPipelineColumns } from "./columns"
@@ -58,6 +58,9 @@ function PipelinesContent() {
   const [deployTarget, setDeployTarget] = useState<Pipeline | null>(null)
   const [stopTarget, setStopTarget] = useState<Pipeline | null>(null)
   const [stopping, setStopping] = useState(false)
+  const [rollbackTarget, setRollbackTarget] = useState<Pipeline | null>(null)
+  const [rolling, setRolling] = useState(false)
+  const [currentPipelineId, setCurrentPipelineId] = useState<string | null>(null)
 
   const [applications, setApplications] = useState<Application[]>([])
   const [environments, setEnvironments] = useState<string[]>([])
@@ -183,6 +186,25 @@ function PipelinesContent() {
     if (initialized) fetchPipelines()
   }, [initialized, fetchPipelines])
 
+  // Load the current live image to highlight which pipeline is deployed.
+  // Only meaningful when a concrete environment is selected.
+  useEffect(() => {
+    if (!activeNamespace || !selectedApp || selectedEnv === "all") {
+      setCurrentPipelineId(null)
+      return
+    }
+    const load = async () => {
+      try {
+        const res = await getCurrentImage(activeNamespace, selectedApp, selectedEnv)
+        const image = res.data
+        setCurrentPipelineId(image ? image.split(":").pop() ?? null : null)
+      } catch {
+        setCurrentPipelineId(null)
+      }
+    }
+    load()
+  }, [activeNamespace, selectedApp, selectedEnv])
+
   const handleStop = (pipeline: Pipeline) => {
     setStopTarget(pipeline)
   }
@@ -204,6 +226,25 @@ function PipelinesContent() {
 
   const handleDeploy = (pipeline: Pipeline) => {
     setDeployTarget(pipeline)
+  }
+
+  const handleRollback = (pipeline: Pipeline) => {
+    setRollbackTarget(pipeline)
+  }
+
+  const confirmRollback = async () => {
+    if (!rollbackTarget) return
+    setRolling(true)
+    try {
+      await rollbackPipeline(rollbackTarget.namespace, rollbackTarget.applicationName, rollbackTarget.id)
+      toast.success(t("pipelines.rollbackSuccess"))
+      fetchPipelines()
+    } catch {
+      toast.error(t("pipelines.rollbackError"))
+    } finally {
+      setRolling(false)
+      setRollbackTarget(null)
+    }
   }
 
   const confirmDeploy = async () => {
@@ -311,7 +352,7 @@ function PipelinesContent() {
         table={
           <>
             <div className="overflow-x-auto">
-              <DataTable columns={getPipelineColumns(t, handleStop, handleDeploy)} data={pipelines} loading={initialLoad} />
+              <DataTable columns={getPipelineColumns(t, handleStop, handleDeploy, handleRollback, currentPipelineId)} data={pipelines} loading={initialLoad} />
             </div>
             {selectedApp && (
               <div className="flex items-center justify-end gap-4 mt-2">
@@ -387,6 +428,22 @@ function PipelinesContent() {
             <AlertDialogCancel disabled={stopping}>{t("common.cancel")}</AlertDialogCancel>
             <Button onClick={confirmStop} disabled={stopping}>
               {stopping ? t("pipelines.stopping") : t("pipelines.stopConfirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <AlertDialog open={!!rollbackTarget} onOpenChange={(open) => { if (!open && !rolling) setRollbackTarget(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("pipelines.rollbackConfirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("pipelines.rollbackConfirmDescPrefix")}<strong>{rollbackTarget?.artifact}</strong>{t("pipelines.rollbackConfirmDescSuffix")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={rolling}>{t("common.cancel")}</AlertDialogCancel>
+            <Button onClick={confirmRollback} disabled={rolling}>
+              {rolling ? t("pipelines.rolling") : t("pipelines.rollbackConfirm")}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/web/app/settings/environments/[id]/page.tsx
+++ b/web/app/settings/environments/[id]/page.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -283,8 +284,9 @@ export default function EnvironmentEditPage() {
                           <FormItem>
                             <FormLabel>{t("env.col.name")}</FormLabel>
                             <FormControl>
-                              <Input placeholder="Production" {...field} />
+                              <Input placeholder="Production" disabled {...field} />
                             </FormControl>
+                            <FormDescription>{t("env.nameImmutableDesc")}</FormDescription>
                             <FormMessage />
                           </FormItem>
                         )}

--- a/web/lib/api/pipelines.ts
+++ b/web/lib/api/pipelines.ts
@@ -49,3 +49,24 @@ export const deployPipeline = async (namespace: string, name: string, id: string
   }
   return response.json() as Promise<ApiResponse<boolean>>
 }
+
+// Rolls back to a historic successful pipeline by deploying its image again.
+// Returns the id of the newly created rollback pipeline.
+export const rollbackPipeline = async (namespace: string, name: string, id: string): Promise<ApiResponse<string>> => {
+  const response = await apiFetch(`/api/namespaces/${namespace}/applications/${name}/pipelines/${id}/rollback`, {
+    method: "POST",
+  })
+  if (!response.ok) {
+    throw new Error("Failed to rollback pipeline")
+  }
+  return response.json() as Promise<ApiResponse<string>>
+}
+
+// Returns the container image currently running on the application's StatefulSet for the given environment.
+export const getCurrentImage = async (namespace: string, name: string, environment: string): Promise<ApiResponse<string>> => {
+  const response = await apiFetch(`/api/namespaces/${namespace}/applications/${name}/current-image?env=${encodeURIComponent(environment)}`)
+  if (!response.ok) {
+    throw new Error("Failed to fetch current image")
+  }
+  return response.json() as Promise<ApiResponse<string>>
+}

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -182,6 +182,8 @@ export interface LastSuccessfulPipelineInfo {
   publishRepository?: string | null
 }
 
+export type PipelineTriggerType = 'BUILD' | 'ROLLBACK'
+
 export interface Pipeline {
   id: string
   namespace: string
@@ -194,6 +196,8 @@ export interface Pipeline {
   operatorId?: string
   operatorName?: string
   message?: string | null
+  triggerType?: PipelineTriggerType
+  rollbackFromPipelineId?: string | null
 }
 
 export interface ConfigMap {

--- a/web/locales/en-US/env.ts
+++ b/web/locales/en-US/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "Failed to load environment",
   "env.nameRequired": "Name is required",
   "env.namePlaceholder": "Environment name",
+  "env.nameImmutableDesc": "Environment names cannot be changed after creation.",
   "env.col.name": "Name",
   "env.col.workNamespace": "Work Namespace",
   "env.col.imageRepo": "Image Repository",

--- a/web/locales/en-US/pipelines.ts
+++ b/web/locales/en-US/pipelines.ts
@@ -39,6 +39,7 @@ const pipelines = {
   "pipelines.col.triggerType": "Type",
   "pipelines.col.buildTag": "Build",
   "pipelines.col.rollbackTag": "Rollback",
+  "pipelines.col.rollbackFrom": "Rolled back from: ",
   "pipelines.col.rollbackBtn": "Rollback",
   "pipelines.rollbackSuccess": "Rollback triggered",
   "pipelines.rollbackError": "Rollback failed",

--- a/web/locales/en-US/pipelines.ts
+++ b/web/locales/en-US/pipelines.ts
@@ -35,6 +35,16 @@ const pipelines = {
   "pipelines.confirmDescPrefix": "This will deploy to environment ",
   "pipelines.confirmDescSuffix": ". This cannot be undone.",
   "pipelines.confirm": "Deploy",
+  "pipelines.col.currentVersion": "Live",
+  "pipelines.col.rollbackTag": "Rollback",
+  "pipelines.col.rollbackBtn": "Rollback",
+  "pipelines.rollbackSuccess": "Rollback triggered",
+  "pipelines.rollbackError": "Rollback failed",
+  "pipelines.rollbackConfirmTitle": "Confirm Rollback?",
+  "pipelines.rollbackConfirmDescPrefix": "This will roll back the deployment to image ",
+  "pipelines.rollbackConfirmDescSuffix": ". Runtime and config stay at current values. This cannot be undone.",
+  "pipelines.rollbackConfirm": "Rollback",
+  "pipelines.rolling": "Rolling back...",
 }
 
 export default pipelines

--- a/web/locales/en-US/pipelines.ts
+++ b/web/locales/en-US/pipelines.ts
@@ -36,6 +36,8 @@ const pipelines = {
   "pipelines.confirmDescSuffix": ". This cannot be undone.",
   "pipelines.confirm": "Deploy",
   "pipelines.col.currentVersion": "Live",
+  "pipelines.col.triggerType": "Type",
+  "pipelines.col.buildTag": "Build",
   "pipelines.col.rollbackTag": "Rollback",
   "pipelines.col.rollbackBtn": "Rollback",
   "pipelines.rollbackSuccess": "Rollback triggered",

--- a/web/locales/ja-JP/env.ts
+++ b/web/locales/ja-JP/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "環境の読み込みに失敗しました",
   "env.nameRequired": "名前は必須です",
   "env.namePlaceholder": "環境名",
+  "env.nameImmutableDesc": "環境名は作成後に変更できません。",
   "env.col.name": "名前",
   "env.col.workNamespace": "作業用名前空間",
   "env.col.imageRepo": "イメージリポジトリ",

--- a/web/locales/ja-JP/pipelines.ts
+++ b/web/locales/ja-JP/pipelines.ts
@@ -36,6 +36,8 @@ const pipelines = {
   "pipelines.confirmDescSuffix": " にデプロイします。この操作は元に戻せません。",
   "pipelines.confirm": "公開を確認",
   "pipelines.col.currentVersion": "稼働中",
+  "pipelines.col.triggerType": "種別",
+  "pipelines.col.buildTag": "ビルド",
   "pipelines.col.rollbackTag": "ロールバック",
   "pipelines.col.rollbackBtn": "ロールバック",
   "pipelines.rollbackSuccess": "ロールバックを開始しました",

--- a/web/locales/ja-JP/pipelines.ts
+++ b/web/locales/ja-JP/pipelines.ts
@@ -39,6 +39,7 @@ const pipelines = {
   "pipelines.col.triggerType": "種別",
   "pipelines.col.buildTag": "ビルド",
   "pipelines.col.rollbackTag": "ロールバック",
+  "pipelines.col.rollbackFrom": "ロールバック元: ",
   "pipelines.col.rollbackBtn": "ロールバック",
   "pipelines.rollbackSuccess": "ロールバックを開始しました",
   "pipelines.rollbackError": "ロールバックに失敗しました",

--- a/web/locales/ja-JP/pipelines.ts
+++ b/web/locales/ja-JP/pipelines.ts
@@ -35,6 +35,16 @@ const pipelines = {
   "pipelines.confirmDescPrefix": "現在のビルド成果物を環境 ",
   "pipelines.confirmDescSuffix": " にデプロイします。この操作は元に戻せません。",
   "pipelines.confirm": "公開を確認",
+  "pipelines.col.currentVersion": "稼働中",
+  "pipelines.col.rollbackTag": "ロールバック",
+  "pipelines.col.rollbackBtn": "ロールバック",
+  "pipelines.rollbackSuccess": "ロールバックを開始しました",
+  "pipelines.rollbackError": "ロールバックに失敗しました",
+  "pipelines.rollbackConfirmTitle": "ロールバックしますか？",
+  "pipelines.rollbackConfirmDescPrefix": "デプロイをイメージ ",
+  "pipelines.rollbackConfirmDescSuffix": " にロールバックします。ランタイムと設定は現在の値のままです。この操作は元に戻せません。",
+  "pipelines.rollbackConfirm": "ロールバック",
+  "pipelines.rolling": "ロールバック中...",
 }
 
 export default pipelines

--- a/web/locales/zh-CN/env.ts
+++ b/web/locales/zh-CN/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "加载环境失败",
   "env.nameRequired": "名称不能为空",
   "env.namePlaceholder": "环境名称",
+  "env.nameImmutableDesc": "环境名称创建后不可修改。",
   "env.col.name": "名称",
   "env.col.workNamespace": "工作命名空间",
   "env.col.imageRepo": "镜像仓库",

--- a/web/locales/zh-CN/pipelines.ts
+++ b/web/locales/zh-CN/pipelines.ts
@@ -36,6 +36,8 @@ const pipelines = {
   "pipelines.confirmDescSuffix": "，该操作无法撤销。",
   "pipelines.confirm": "确认发布",
   "pipelines.col.currentVersion": "当前版本",
+  "pipelines.col.triggerType": "类型",
+  "pipelines.col.buildTag": "发布",
   "pipelines.col.rollbackTag": "回滚",
   "pipelines.col.rollbackBtn": "回滚",
   "pipelines.rollbackSuccess": "已触发回滚",

--- a/web/locales/zh-CN/pipelines.ts
+++ b/web/locales/zh-CN/pipelines.ts
@@ -35,6 +35,16 @@ const pipelines = {
   "pipelines.confirmDescPrefix": "将把当前编译产物部署到环境 ",
   "pipelines.confirmDescSuffix": "，该操作无法撤销。",
   "pipelines.confirm": "确认发布",
+  "pipelines.col.currentVersion": "当前版本",
+  "pipelines.col.rollbackTag": "回滚",
+  "pipelines.col.rollbackBtn": "回滚",
+  "pipelines.rollbackSuccess": "已触发回滚",
+  "pipelines.rollbackError": "回滚失败",
+  "pipelines.rollbackConfirmTitle": "确认回滚？",
+  "pipelines.rollbackConfirmDescPrefix": "将把部署回滚到镜像 ",
+  "pipelines.rollbackConfirmDescSuffix": "，运行参数与配置保持当前值，该操作无法撤销。",
+  "pipelines.rollbackConfirm": "确认回滚",
+  "pipelines.rolling": "回滚中...",
 }
 
 export default pipelines

--- a/web/locales/zh-CN/pipelines.ts
+++ b/web/locales/zh-CN/pipelines.ts
@@ -39,6 +39,7 @@ const pipelines = {
   "pipelines.col.triggerType": "类型",
   "pipelines.col.buildTag": "发布",
   "pipelines.col.rollbackTag": "回滚",
+  "pipelines.col.rollbackFrom": "回滚自: ",
   "pipelines.col.rollbackBtn": "回滚",
   "pipelines.rollbackSuccess": "已触发回滚",
   "pipelines.rollbackError": "回滚失败",

--- a/web/locales/zh-TW/env.ts
+++ b/web/locales/zh-TW/env.ts
@@ -12,6 +12,7 @@ const env = {
   "env.loadError": "載入環境失敗",
   "env.nameRequired": "名稱不能為空",
   "env.namePlaceholder": "環境名稱",
+  "env.nameImmutableDesc": "環境名稱建立後不可修改。",
   "env.col.name": "名稱",
   "env.col.workNamespace": "工作命名空間",
   "env.col.imageRepo": "鏡像倉庫",

--- a/web/locales/zh-TW/pipelines.ts
+++ b/web/locales/zh-TW/pipelines.ts
@@ -36,6 +36,8 @@ const pipelines = {
   "pipelines.confirmDescSuffix": "，該操作無法撤銷。",
   "pipelines.confirm": "確認發布",
   "pipelines.col.currentVersion": "目前版本",
+  "pipelines.col.triggerType": "類型",
+  "pipelines.col.buildTag": "發布",
   "pipelines.col.rollbackTag": "回滾",
   "pipelines.col.rollbackBtn": "回滾",
   "pipelines.rollbackSuccess": "已觸發回滾",

--- a/web/locales/zh-TW/pipelines.ts
+++ b/web/locales/zh-TW/pipelines.ts
@@ -39,6 +39,7 @@ const pipelines = {
   "pipelines.col.triggerType": "類型",
   "pipelines.col.buildTag": "發布",
   "pipelines.col.rollbackTag": "回滾",
+  "pipelines.col.rollbackFrom": "回滾自: ",
   "pipelines.col.rollbackBtn": "回滾",
   "pipelines.rollbackSuccess": "已觸發回滾",
   "pipelines.rollbackError": "回滾失敗",

--- a/web/locales/zh-TW/pipelines.ts
+++ b/web/locales/zh-TW/pipelines.ts
@@ -35,6 +35,16 @@ const pipelines = {
   "pipelines.confirmDescPrefix": "將把目前編譯產物部署到環境",
   "pipelines.confirmDescSuffix": "，該操作無法撤銷。",
   "pipelines.confirm": "確認發布",
+  "pipelines.col.currentVersion": "目前版本",
+  "pipelines.col.rollbackTag": "回滾",
+  "pipelines.col.rollbackBtn": "回滾",
+  "pipelines.rollbackSuccess": "已觸發回滾",
+  "pipelines.rollbackError": "回滾失敗",
+  "pipelines.rollbackConfirmTitle": "確認回滾？",
+  "pipelines.rollbackConfirmDescPrefix": "將把部署回滾到映像 ",
+  "pipelines.rollbackConfirmDescSuffix": "，執行參數與設定保持目前值，該操作無法撤銷。",
+  "pipelines.rollbackConfirm": "確認回滾",
+  "pipelines.rolling": "回滾中...",
 }
 
 export default pipelines


### PR DESCRIPTION
## What

Roll back a deployment to a previous pipeline's image without rebuilding.

A rollback creates a **new** `Pipeline` record (preserving history) marked with `triggerType=ROLLBACK` and `rollbackFromPipelineId`, copies the historic artifact, **skips the build step**, and deploys straight through the existing artifact deploy chain.

Runtime spec, service config, and the env-var ConfigMap stay at the application's **current** values (12-factor: config decoupled from release). Full config rollback is deliberately out of scope for this first version.

## Backend

- New `PipelineTriggerType {BUILD, ROLLBACK}` enum + `triggerType` / `rollbackFromPipelineId` fields on `Pipeline` (domain + JPA), Flyway `V10` migration defaulting existing rows to `BUILD`.
- `Pipeline.rollback()` factory; opened state-machine edge `INITIALIZED → DEPLOYING` (rollback skips RUNNING/BUILD_SUCCEEDED).
- `PipelineService.rollback()` and `POST .../pipelines/{id}/rollback` endpoint.
- `ApplicationRuntimeGateway.findCurrentImage()` + K8s impl, exposed via `GET .../applications/{name}/current-image?env=` to highlight the live version.
- `PipelineDto` exposes `triggerType` + `rollbackFromPipelineId`.

## Frontend

- Rollback button (SUCCEEDED pipelines with an artifact that aren't currently live), confirm dialog, "live version" highlight, and rollback badge on the pipelines page.
- `rollbackPipeline()` / `getCurrentImage()` API clients; i18n across all 4 locales.

## Tests

`PipelineStateMachineTests` + `PipelineRollbackTests` — 10 tests, all green. Frontend `pnpm build` passes.

## Notes

- Permission reuses `isAuthenticated()` — collaborators can roll back, consistent with deploy.
- No image-existence pre-check; rollback behaves identically to a normal deploy (server-side apply reports SUCCEEDED immediately).
- Post-deploy health verification (detecting ImagePullBackOff / not-ready after apply) is a platform-wide concern and is intentionally deferred to a separate PR.