### PR TITLE
fix(websocket): use native ping frames for log stream heartbeat

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/interfaces/websocket/WebSocketSessionSupport.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/websocket/WebSocketSessionSupport.java
@@ -38,7 +38,7 @@ final class WebSocketSessionSupport {
             while (session.isOpen()) {
                 try {
                     Thread.sleep(HEARTBEAT_INTERVAL_MILLIS);
-                    sink.sendText("ping");
+                    sink.sendPing();
                 } catch (InterruptedException _) {
                     Thread.currentThread().interrupt();
                     break;

--- a/src/main/java/com/github/wellch4n/oops/interfaces/websocket/WebSocketStreamSink.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/websocket/WebSocketStreamSink.java
@@ -4,6 +4,7 @@ import com.github.wellch4n.oops.application.port.StreamSink;
 import java.io.IOException;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -23,6 +24,19 @@ final class WebSocketStreamSink implements StreamSink {
     public synchronized void sendText(String text) throws IOException {
         if (session.isOpen()) {
             session.sendMessage(new TextMessage(text));
+        }
+    }
+
+    /**
+     * Sends a native WebSocket ping control frame as a keepalive heartbeat. Browsers auto-respond
+     * with a pong frame at the protocol level, so it never surfaces in the client's {@code onmessage}
+     * (unlike a text "ping", which used to leak into the log view). Not part of the {@link StreamSink}
+     * port: ping/pong is a WebSocket transport concern, meaningless to other sink transports.
+     * Shares the same monitor as {@link #sendText} so the heartbeat thread never races a writer thread.
+     */
+    synchronized void sendPing() throws IOException {
+        if (session.isOpen()) {
+            session.sendMessage(new PingMessage());
         }
     }
 


### PR DESCRIPTION
The server-side heartbeat sent a text "ping" message every 10s. The pod log viewer's onmessage handler only filtered out "pong", so the "ping" text frame was treated as a log line and rendered in the runtime status log view.

Switch the heartbeat to a native WebSocket ping control frame. Browsers auto-respond with a pong at the protocol level and never surface control frames to onmessage, so the heartbeat is now invisible to the client and no longer pollutes the logs.

sendPing() lives on the concrete WebSocketStreamSink (not the StreamSink port) since ping/pong is a WebSocket transport concern, and shares the same monitor as sendText so the heartbeat thread never races a writer.