### PR TITLE
fix(docker): remove hardcoded Aliyun Maven mirror

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -4,19 +4,6 @@
 FROM maven:3.9-eclipse-temurin-25 AS builder
 WORKDIR /build
 
-RUN echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" \
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" \
-  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd"> \
-  <mirrors> \
-    <mirror> \
-      <id>aliyunmaven</id> \
-      <mirrorOf>central</mirrorOf> \
-      <name>Aliyun Maven</name> \
-      <url>https://maven.aliyun.com/repository/public</url> \
-    </mirror> \
-  </mirrors> \
-</settings>' > /usr/share/maven/conf/settings.xml
-
 COPY pom.xml ./
 RUN --mount=type=cache,target=/root/.m2 \
     mvn dependency:go-offline -B


### PR DESCRIPTION
The backend build image hardcoded an Aliyun Maven mirror in settings.xml, forcing all dependency resolution through that registry regardless of where the image is built. Drop it so the build uses Maven Central by default.