### PR TITLE
fix(routing): reject uppercase hosts at save time

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/service/ApplicationService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/ApplicationService.java
@@ -14,6 +14,7 @@ import com.github.wellch4n.oops.domain.application.ApplicationBuildConfigPolicy;
 import com.github.wellch4n.oops.domain.application.HealthCheckPolicy;
 import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.domain.identity.User;
+import com.github.wellch4n.oops.domain.routing.DomainPolicy;
 import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
 import com.github.wellch4n.oops.domain.shared.UserRole;
 import com.github.wellch4n.oops.shared.exception.BizException;
@@ -57,6 +58,7 @@ public class ApplicationService {
     private final ApplicationExpertConfigGateway applicationExpertConfigGateway;
     private final ApplicationBuildConfigPolicy buildConfigPolicy;
     private final HealthCheckPolicy healthCheckPolicy;
+    private final DomainPolicy domainPolicy;
 
     public ApplicationService(ApplicationRepository applicationRepository,
                               EnvironmentRepository environmentRepository,
@@ -64,7 +66,8 @@ public class ApplicationService {
                               ApplicationRuntimeGateway applicationRuntimeGateway,
                               ApplicationExpertConfigGateway applicationExpertConfigGateway,
                               ApplicationBuildConfigPolicy buildConfigPolicy,
-                              HealthCheckPolicy healthCheckPolicy) {
+                              HealthCheckPolicy healthCheckPolicy,
+                              DomainPolicy domainPolicy) {
         this.applicationRepository = applicationRepository;
         this.environmentRepository = environmentRepository;
         this.userService = userService;
@@ -72,6 +75,7 @@ public class ApplicationService {
         this.applicationExpertConfigGateway = applicationExpertConfigGateway;
         this.buildConfigPolicy = buildConfigPolicy;
         this.healthCheckPolicy = healthCheckPolicy;
+        this.domainPolicy = domainPolicy;
     }
 
     public Application getApplication(String namespace, String name) {
@@ -492,6 +496,7 @@ public class ApplicationService {
                 if (host == null || host.isBlank()) {
                     continue;
                 }
+                domainPolicy.validateHost(host);
                 ServiceHostConflictView conflict = findHostConflictApplication(namespace, name, host);
                 if (conflict != null) {
                     throw new BizException("Host " + host + " is already used by environment "

--- a/src/main/java/com/github/wellch4n/oops/domain/routing/DomainPolicy.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/routing/DomainPolicy.java
@@ -10,13 +10,13 @@ import java.util.regex.Pattern;
 public class DomainPolicy {
 
     private static final Pattern HOST_PATTERN = Pattern.compile(
-            "^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)+$");
+            "^([a-z0-9]([a-z0-9\\-]{0,61}[a-z0-9])?)(\\.[a-z0-9]([a-z0-9\\-]{0,61}[a-z0-9])?)+$");
 
     public String normalizeHost(String host) {
         if (host == null) {
             return "";
         }
-        String trimmed = host.trim().toLowerCase();
+        String trimmed = host.trim();
         if (trimmed.startsWith("*.")) {
             trimmed = trimmed.substring(2);
         }
@@ -26,6 +26,9 @@ public class DomainPolicy {
     public void validateHost(String host) {
         if (host == null || host.isBlank()) {
             throw new BizException("Domain host is required");
+        }
+        if (!host.equals(host.toLowerCase())) {
+            throw new BizException("Domain must be lowercase: " + host);
         }
         if (!HOST_PATTERN.matcher(host).matches()) {
             throw new BizException("Invalid domain format: " + host);

--- a/web/app/apps/components/application-service-info.tsx
+++ b/web/app/apps/components/application-service-info.tsx
@@ -18,6 +18,7 @@ import { Check, ExternalLink, Pencil, Plug, Globe, Info, Plus, Trash2, X, Networ
 import { ApplicationEnvironment, ApplicationServiceConfig, ApplicationServiceEnvironmentConfig } from "@/lib/api/types"
 import { updateApplicationService, checkApplicationServiceHost } from "@/lib/api/applications"
 import { Domain, fetchDomains } from "@/lib/api/domains"
+import { isValidHost } from "@/lib/host-validation"
 import { ApplicationEnvironmentSelector } from "./application-environment-selector"
 import Link from "next/link"
 import { useLanguage } from "@/contexts/language-context"
@@ -216,6 +217,14 @@ export const ApplicationServiceInfo = forwardRef<ApplicationTabHandle, Props>(fu
     const key = hostErrorKey(environmentName, hostIndex)
     if (!trimmedHost) {
       clearHostError(environmentName, hostIndex)
+      return
+    }
+
+    if (!isValidHost(trimmedHost)) {
+      setHostErrors((current) => ({
+        ...current,
+        [key]: t("apps.service.hostInvalid"),
+      }))
       return
     }
 
@@ -445,6 +454,15 @@ export const ApplicationServiceInfo = forwardRef<ApplicationTabHandle, Props>(fu
 
     if (Object.keys(hostErrors).length > 0) {
       toast.error(Object.values(hostErrors)[0])
+      return false
+    }
+
+    const invalidHost = values.environmentConfigs
+      .flatMap((group) => group.hosts)
+      .map((host) => host.host.trim())
+      .find((host) => host && !isValidHost(host))
+    if (invalidHost) {
+      toast.error(t("apps.service.hostInvalid"))
       return false
     }
 

--- a/web/app/networks/domains/domain-form-dialog.tsx
+++ b/web/app/networks/domains/domain-form-dialog.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { toast } from "sonner"
 import { Domain, DomainCertMode, DomainRequest, createDomain, deleteDomain, updateDomain } from "@/lib/api/domains"
+import { isValidHost } from "@/lib/host-validation"
 import { useLanguage } from "@/contexts/language-context"
 
 interface Props {
@@ -79,10 +80,16 @@ export function DomainFormDialog({ open, onOpenChange, target, onSaved, onDelete
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    const trimmedHost = host.trim()
+    const bareHost = trimmedHost.startsWith("*.") ? trimmedHost.slice(2) : trimmedHost
+    if (!isValidHost(bareHost)) {
+      toast.error(t("domains.field.hostInvalid"))
+      return
+    }
     setSubmitting(true)
     try {
       const request: DomainRequest = {
-        host: host.trim(),
+        host: trimmedHost,
         description: description.trim() || undefined,
         https,
       }

--- a/web/lib/host-validation.ts
+++ b/web/lib/host-validation.ts
@@ -1,0 +1,7 @@
+// Mirrors backend DomainPolicy.HOST_PATTERN: lowercase RFC 1123 host names only,
+// since hosts are embedded into Kubernetes resource names.
+const HOST_PATTERN = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/
+
+export function isValidHost(host: string): boolean {
+  return HOST_PATTERN.test(host)
+}

--- a/web/locales/en-US/apps.ts
+++ b/web/locales/en-US/apps.ts
@@ -158,6 +158,7 @@ const apps = {
   "apps.service.accessEntryRepublishNotice": "Application access changes take effect after you republish the application.",
   "apps.service.addHost": "Add Host",
   "apps.service.hostDuplicated": "Host already used by environment {environment} / namespace {namespace} / application {name}",
+  "apps.service.hostInvalid": "Invalid host: only lowercase letters, digits, hyphens, and dots are allowed",
   "apps.service.prefixPlaceholder": "subdomain",
   "apps.service.apexConfirmTitle": "Use Apex Domain?",
   "apps.service.apexConfirmDesc": "No subdomain entered. Use the apex domain {host}?",

--- a/web/locales/en-US/domains.ts
+++ b/web/locales/en-US/domains.ts
@@ -12,6 +12,7 @@ const domains = {
   "domains.col.createdTime": "Created",
   "domains.field.host": "Host",
   "domains.field.hostPlaceholder": "example.com (covers all subdomains)",
+  "domains.field.hostInvalid": "Invalid domain: only lowercase letters, digits, hyphens, and dots are allowed",
   "domains.field.descriptionPlaceholder": "Purpose (optional)",
   "domains.field.https": "Enable HTTPS",
   "domains.field.certMode": "Certificate Mode",

--- a/web/locales/ja-JP/apps.ts
+++ b/web/locales/ja-JP/apps.ts
@@ -157,6 +157,7 @@ const apps = {
   "apps.service.accessEntryRepublishNotice": "アプリケーションアクセス設定は、アプリを再公開すると反映されます。",
   "apps.service.addHost": "ドメインを追加",
   "apps.service.hostDuplicated": "このドメインは環境 {environment} / ネームスペース {namespace} / アプリ {name} によって使用されています",
+  "apps.service.hostInvalid": "ドメイン形式が不正です：小文字、数字、ハイフン、ドットのみ使用できます",
   "apps.service.prefixPlaceholder": "サブドメイン",
   "apps.service.apexConfirmTitle": "ルートドメインを使用しますか？",
   "apps.service.apexConfirmDesc": "サブドメインが未入力です。ルートドメイン {host} を使用しますか？",

--- a/web/locales/ja-JP/domains.ts
+++ b/web/locales/ja-JP/domains.ts
@@ -12,6 +12,7 @@ const domains = {
   "domains.col.createdTime": "作成時刻",
   "domains.field.host": "ホスト",
   "domains.field.hostPlaceholder": "example.com（すべてのサブドメインを含む）",
+  "domains.field.hostInvalid": "ドメイン形式が不正です：小文字、数字、ハイフン、ドットのみ使用できます",
   "domains.field.descriptionPlaceholder": "用途の説明（任意）",
   "domains.field.https": "HTTPS を有効化",
   "domains.field.certMode": "証明書モード",

--- a/web/locales/zh-CN/apps.ts
+++ b/web/locales/zh-CN/apps.ts
@@ -158,6 +158,7 @@ const apps = {
   "apps.service.accessEntryRepublishNotice": "应用访问配置需要重新发布应用才会生效。",
   "apps.service.addHost": "添加域名",
   "apps.service.hostDuplicated": "域名已被环境 {environment} / 命名空间 {namespace} / 应用 {name} 占用",
+  "apps.service.hostInvalid": "域名格式不合法：只允许小写字母、数字、连字符和点",
   "apps.service.prefixPlaceholder": "子域名",
   "apps.service.apexConfirmTitle": "使用根域名？",
   "apps.service.apexConfirmDesc": "未填写子域名，确定要使用根域名 {host} 吗？",

--- a/web/locales/zh-CN/domains.ts
+++ b/web/locales/zh-CN/domains.ts
@@ -12,6 +12,7 @@ const domains = {
   "domains.col.createdTime": "创建时间",
   "domains.field.host": "域名",
   "domains.field.hostPlaceholder": "example.com（包含所有子域名）",
+  "domains.field.hostInvalid": "域名格式不合法：只允许小写字母、数字、连字符和点",
   "domains.field.descriptionPlaceholder": "用途说明（可选）",
   "domains.field.https": "启用 HTTPS",
   "domains.field.certMode": "证书模式",

--- a/web/locales/zh-TW/apps.ts
+++ b/web/locales/zh-TW/apps.ts
@@ -158,6 +158,7 @@ const apps = {
   "apps.service.accessEntryRepublishNotice": "應用訪問配置需要重新發布應用才會生效。",
   "apps.service.addHost": "新增域名",
   "apps.service.hostDuplicated": "網域已被環境 {environment} / 命名空間 {namespace} / 應用 {name} 佔用",
+  "apps.service.hostInvalid": "網域格式不合法：只允許小寫字母、數字、連字號和點",
   "apps.service.prefixPlaceholder": "子網域",
   "apps.service.apexConfirmTitle": "使用根網域？",
   "apps.service.apexConfirmDesc": "未填寫子網域，確定要使用根網域 {host} 嗎？",

--- a/web/locales/zh-TW/domains.ts
+++ b/web/locales/zh-TW/domains.ts
@@ -12,6 +12,7 @@ const domains = {
   "domains.col.createdTime": "建立時間",
   "domains.field.host": "網域",
   "domains.field.hostPlaceholder": "example.com（含所有子網域）",
+  "domains.field.hostInvalid": "網域格式不合法：只允許小寫字母、數字、連字號和點",
   "domains.field.descriptionPlaceholder": "用途說明（可選）",
   "domains.field.https": "啟用 HTTPS",
   "domains.field.certMode": "憑證模式",


### PR DESCRIPTION
Hosts are embedded into Kubernetes resource names (IngressRoute and TLS Secret names), which must be lowercase RFC 1123 subdomains. Entering an uppercase host previously passed validation and only failed later when the deploy task applied the Traefik IngressRoute.

Backend: tighten DomainPolicy.HOST_PATTERN to lowercase-only, report a dedicated "Domain must be lowercase" error, stop silently lowercasing in normalizeHost, and validate hosts in updateApplicationServiceConfig so application service configs fail fast on save.

Frontend: add a shared host-validation helper mirroring the backend pattern, validate in the domain form dialog before submitting, and in the application service config both on host confirmation (inline error) and on save as a safety net for pre-existing invalid hosts. New hostInvalid messages added to all four locales.