### PR TITLE
fix(persistence): ignore unknown props when deserializing publish_config

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/converter/PublishConfigConverter.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/converter/PublishConfigConverter.java
@@ -1,5 +1,6 @@
 package com.github.wellch4n.oops.infrastructure.persistence.jpa.converter;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.wellch4n.oops.domain.delivery.PublishConfig;
 import jakarta.persistence.AttributeConverter;
@@ -8,7 +9,9 @@ import jakarta.persistence.Converter;
 @Converter
 public class PublishConfigConverter implements AttributeConverter<PublishConfig, String> {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    // Ignore unknown properties so JSON written by an older schema still deserializes after fields are added.
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Override
     public String convertToDatabaseColumn(PublishConfig attribute) {


### PR DESCRIPTION
## What

`PublishConfigConverter` used a bare `new ObjectMapper()`. Any field added to a `PublishConfig` subtype in the future would make JSON written by an older schema fail to deserialize at read time.

This aligns the converter with `PersistenceMapper` by disabling `FAIL_ON_UNKNOWN_PROPERTIES`, so older `publish_config` JSON keeps deserializing after the model evolves.

## Why

Pure forward-compatibility hardening for the `publish_config` JSON column introduced in 2e68f0c. No change to current read/write behavior — existing rows only contain known fields.

## Test

Behavioral change is not unit-testable (it only matters once a new field is added later). Verified by inspection; the change mirrors the existing `PersistenceMapper` ObjectMapper configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)