### PR TITLE
refactor(application): collapse build-config repository into source_config JSON

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/dto/ApplicationConfigDto.java
+++ b/src/main/java/com/github/wellch4n/oops/application/dto/ApplicationConfigDto.java
@@ -6,6 +6,8 @@ import com.github.wellch4n.oops.domain.application.ApplicationEnvironment;
 import com.github.wellch4n.oops.domain.application.ApplicationExpertConfig;
 import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
 import com.github.wellch4n.oops.domain.application.ApplicationServiceConfig;
+import com.github.wellch4n.oops.domain.application.GitSourceConfig;
+import com.github.wellch4n.oops.domain.application.ZipSourceConfig;
 import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
 import com.github.wellch4n.oops.domain.shared.DockerFileType;
 import java.time.LocalDateTime;
@@ -58,7 +60,7 @@ public final class ApplicationConfigDto {
                     config.getNamespace(),
                     config.getApplicationName(),
                     config.getSourceType(),
-                    config.getRepository(),
+                    config.repository(),
                     DockerFileConfig.from(config.getDockerFileConfig()),
                     config.getBuildImage(),
                     map(config.getEnvironmentConfigs(), BuildEnvironmentConfig::from)
@@ -72,7 +74,9 @@ public final class ApplicationConfigDto {
             config.setNamespace(namespace);
             config.setApplicationName(applicationName);
             config.setSourceType(sourceType);
-            config.setRepository(repository);
+            config.setSourceConfig(sourceType == ApplicationSourceType.ZIP
+                    ? new ZipSourceConfig()
+                    : new GitSourceConfig(repository));
             config.setDockerFileConfig(dockerFileConfig != null ? dockerFileConfig.toDomain() : null);
             config.setBuildImage(buildImage);
             config.setEnvironmentConfigs(map(environmentConfigs, BuildEnvironmentConfig::toDomain));

--- a/src/main/java/com/github/wellch4n/oops/application/service/DeploymentService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/DeploymentService.java
@@ -110,7 +110,7 @@ public class DeploymentService {
         switch (strategy) {
             case GitDeployStrategyParam gitStrategy -> {
                 String gitBranch = deployStrategyPolicy.normalizeGitBranch(gitStrategy.branch());
-                String gitRepository = buildConfig != null ? buildConfig.getRepository() : null;
+                String gitRepository = buildConfig != null ? buildConfig.repository() : null;
                 deployStrategyPolicy.ensureRepositoryPresent(gitRepository, "Repository is required for GIT publish");
                 pipeline.setPublishConfig(new GitPublishConfig(gitRepository, gitBranch));
             }

--- a/src/main/java/com/github/wellch4n/oops/domain/application/Application.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/Application.java
@@ -45,11 +45,11 @@ public class Application extends BaseAggregateRoot {
         ApplicationSourceType sourceType = buildConfigPolicy.normalizeSourceType(request.getSourceType());
         buildConfigPolicy.validate(
                 sourceType,
-                request.getRepository(),
+                request.repository(),
                 dockerFileConfig != null ? dockerFileConfig.getType() : null,
                 dockerFileConfig != null ? dockerFileConfig.getContent() : null);
         target.setSourceType(sourceType);
-        target.setRepository(buildConfigPolicy.normalizeRepository(sourceType, request.getRepository()));
+        target.setSourceConfig(buildConfigPolicy.buildSourceConfig(sourceType, request.repository()));
         target.setDockerFileConfig(dockerFileConfig);
         target.setBuildImage(request.getBuildImage());
         target.setEnvironmentConfigs(request.getEnvironmentConfigs());

--- a/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationBuildConfig.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationBuildConfig.java
@@ -13,10 +13,19 @@ public class ApplicationBuildConfig extends BaseDomainObject {
     private String namespace;
     private String applicationName;
     private ApplicationSourceType sourceType;
-    private String repository;
+    private SourceConfig sourceConfig;
     private DockerFileConfig dockerFileConfig;
     private String buildImage;
     private List<EnvironmentConfig> environmentConfigs;
+
+    /**
+     * Git repository URL when the source is GIT, otherwise {@code null}. Convenience accessor over
+     * {@link #sourceConfig}; named without a {@code get} prefix so Jackson does not treat it as a bean
+     * property during entity/domain mapping.
+     */
+    public String repository() {
+        return sourceConfig instanceof GitSourceConfig gitSourceConfig ? gitSourceConfig.repository() : null;
+    }
 
     @Data
     public static class DockerFileConfig {

--- a/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationBuildConfigPolicy.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationBuildConfigPolicy.java
@@ -23,8 +23,10 @@ public class ApplicationBuildConfigPolicy {
         }
     }
 
-    public String normalizeRepository(ApplicationSourceType sourceType, String repository) {
-        return normalizeSourceType(sourceType) == ApplicationSourceType.GIT ? repository : null;
+    public SourceConfig buildSourceConfig(ApplicationSourceType sourceType, String repository) {
+        return normalizeSourceType(sourceType) == ApplicationSourceType.GIT
+                ? new GitSourceConfig(repository)
+                : new ZipSourceConfig();
     }
 
     private boolean isBlank(String value) {

--- a/src/main/java/com/github/wellch4n/oops/domain/application/GitSourceConfig.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/GitSourceConfig.java
@@ -1,0 +1,4 @@
+package com.github.wellch4n.oops.domain.application;
+
+public record GitSourceConfig(String repository) implements SourceConfig {
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/application/SourceConfig.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/SourceConfig.java
@@ -1,0 +1,17 @@
+package com.github.wellch4n.oops.domain.application;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Source-type-specific build parameters captured on an application's build config. Serialized as a
+ * JSON blob (column {@code source_config}); the {@code type} discriminator matches
+ * {@code ApplicationSourceType} and the sibling {@code source_type} column.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = GitSourceConfig.class, name = "GIT"),
+        @JsonSubTypes.Type(value = ZipSourceConfig.class, name = "ZIP")
+})
+public sealed interface SourceConfig permits GitSourceConfig, ZipSourceConfig {
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/application/ZipSourceConfig.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/ZipSourceConfig.java
@@ -1,0 +1,9 @@
+package com.github.wellch4n.oops.domain.application;
+
+/**
+ * ZIP build source. Currently carries no persistent parameters — the archive object key is presigned
+ * per deploy and lives on the pipeline's publish config, not on the build config. Kept as a distinct
+ * {@link SourceConfig} variant so ZIP-specific build settings can be added here later.
+ */
+public record ZipSourceConfig() implements SourceConfig {
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/ide/KubernetesIdeGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/ide/KubernetesIdeGateway.java
@@ -262,7 +262,7 @@ public class KubernetesIdeGateway implements IdeGateway {
     private CloneStrategyParam buildCloneStrategyParam(ApplicationBuildConfig applicationBuildConfig, String branch) {
         return new GitCloneParam(
                 pipelineImageConfig.getClone(),
-                applicationBuildConfig != null ? applicationBuildConfig.getRepository() : null,
+                applicationBuildConfig != null ? applicationBuildConfig.repository() : null,
                 branch,
                 false
         );

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationBuildConfig.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationBuildConfig.java
@@ -2,8 +2,10 @@ package com.github.wellch4n.oops.infrastructure.persistence.jpa;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.wellch4n.oops.domain.application.SourceConfig;
 import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
 import com.github.wellch4n.oops.domain.shared.DockerFileType;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.converter.SourceConfigConverter;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -28,7 +30,9 @@ public class ApplicationBuildConfig extends BaseDataObject {
     @Enumerated(EnumType.STRING)
     private ApplicationSourceType sourceType;
 
-    private String repository;
+    @Column(name = "source_config", columnDefinition = "TEXT")
+    @Convert(converter = SourceConfigConverter.class)
+    private SourceConfig sourceConfig;
 
     @Lob
     @Column(name = "docker_file_config")

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PersistenceMapper.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PersistenceMapper.java
@@ -2,12 +2,16 @@ package com.github.wellch4n.oops.infrastructure.persistence.jpa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import java.util.List;
 
 final class PersistenceMapper {
+    // FAIL_ON_EMPTY_BEANS is disabled so a SourceConfig variant with no fields yet (e.g. ZipSourceConfig)
+    // round-trips through convertValue() during domain/entity mapping.
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .findAndRegisterModules()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
     private PersistenceMapper() {
     }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/converter/SourceConfigConverter.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/converter/SourceConfigConverter.java
@@ -1,0 +1,42 @@
+package com.github.wellch4n.oops.infrastructure.persistence.jpa.converter;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.github.wellch4n.oops.domain.application.SourceConfig;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class SourceConfigConverter implements AttributeConverter<SourceConfig, String> {
+
+    // Ignore unknown properties so JSON written by an older schema still deserializes after fields are added.
+    // Allow empty beans so a variant with no fields yet (e.g. ZipSourceConfig) still serializes.
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+    @Override
+    public String convertToDatabaseColumn(SourceConfig attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to serialize sourceConfig", e);
+        }
+    }
+
+    @Override
+    public SourceConfig convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(dbData, SourceConfig.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to deserialize sourceConfig", e);
+        }
+    }
+}

--- a/src/main/resources/db/migration/V17__add_application_build_config_source_config.sql
+++ b/src/main/resources/db/migration/V17__add_application_build_config_source_config.sql
@@ -1,0 +1,13 @@
+-- Collapse application_build_config.repository into a source-type-aware source_config JSON column.
+-- The repository field is GIT-only; ZIP never used it. The type discriminator mirrors source_type.
+-- GIT (or legacy NULL source_type) -> {"type":"GIT","repository":...}
+-- ZIP                              -> {"type":"ZIP"}
+ALTER TABLE `application_build_config` ADD COLUMN `source_config` text DEFAULT NULL;
+
+UPDATE `application_build_config`
+SET `source_config` = CASE
+    WHEN `source_type` = 'ZIP' THEN JSON_OBJECT('type', 'ZIP')
+    ELSE JSON_OBJECT('type', 'GIT', 'repository', `repository`)
+END;
+
+ALTER TABLE `application_build_config` DROP COLUMN `repository`;

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PersistenceMapperTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PersistenceMapperTests.java
@@ -1,12 +1,60 @@
 package com.github.wellch4n.oops.infrastructure.persistence.jpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.github.wellch4n.oops.domain.application.GitSourceConfig;
+import com.github.wellch4n.oops.domain.application.ZipSourceConfig;
+import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
 import com.github.wellch4n.oops.domain.shared.DomainCertMode;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.converter.SourceConfigConverter;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 class PersistenceMapperTests {
+
+    @Test
+    void mapsGitSourceConfigBetweenDomainAndEntity() {
+        com.github.wellch4n.oops.domain.application.ApplicationBuildConfig domain =
+                new com.github.wellch4n.oops.domain.application.ApplicationBuildConfig();
+        domain.setSourceType(ApplicationSourceType.GIT);
+        domain.setSourceConfig(new GitSourceConfig("https://example.com/repo.git"));
+
+        ApplicationBuildConfig entity = PersistenceMapper.toEntity(domain);
+        var roundTrip = PersistenceMapper.toDomain(entity);
+
+        assertInstanceOf(GitSourceConfig.class, entity.getSourceConfig());
+        assertEquals("https://example.com/repo.git", roundTrip.repository());
+    }
+
+    @Test
+    void mapsEmptyZipSourceConfigBetweenDomainAndEntity() {
+        com.github.wellch4n.oops.domain.application.ApplicationBuildConfig domain =
+                new com.github.wellch4n.oops.domain.application.ApplicationBuildConfig();
+        domain.setSourceType(ApplicationSourceType.ZIP);
+        domain.setSourceConfig(new ZipSourceConfig());
+
+        ApplicationBuildConfig entity = PersistenceMapper.toEntity(domain);
+        var roundTrip = PersistenceMapper.toDomain(entity);
+
+        assertInstanceOf(ZipSourceConfig.class, roundTrip.getSourceConfig());
+        assertNull(roundTrip.repository());
+    }
+
+    @Test
+    void sourceConfigConverterRoundTripsBothVariants() {
+        SourceConfigConverter converter = new SourceConfigConverter();
+
+        String gitJson = converter.convertToDatabaseColumn(new GitSourceConfig("git@example.com:repo.git"));
+        assertInstanceOf(GitSourceConfig.class, converter.convertToEntityAttribute(gitJson));
+        assertEquals("git@example.com:repo.git",
+                ((GitSourceConfig) converter.convertToEntityAttribute(gitJson)).repository());
+
+        String zipJson = converter.convertToDatabaseColumn(new ZipSourceConfig());
+        assertEquals("{\"type\":\"ZIP\"}", zipJson);
+        assertInstanceOf(ZipSourceConfig.class, converter.convertToEntityAttribute(zipJson));
+    }
 
     @Test
     void mapsDomainCertificateSecretsBetweenEntityAndDomain() {


### PR DESCRIPTION
The build config's `repository` field is GIT-only; ZIP source never used it and `ApplicationBuildConfigPolicy.normalizeRepository` already nulled it out for ZIP. Mirror the recent pipeline `publish_config` refactor by moving the source-type-specific payload into a polymorphic `source_config` JSON column, so ZIP no longer carries an unused column and future per-source fields have a typed home.

- Add a sealed `SourceConfig` (`@JsonTypeInfo` discriminator matching `ApplicationSourceType`) with `GitSourceConfig(repository)` and an empty-for-now `ZipSourceConfig`.
- Replace `ApplicationBuildConfig.repository` with `sourceConfig`, exposing a convenience `repository()` accessor; `buildSourceConfig()` replaces `normalizeRepository()` in the policy.
- Persist via `SourceConfigConverter`; keep the `source_type` column as the queryable discriminator (symmetric with pipeline keeping `publish_type` + `publish_config`) so list/badge hot paths need not deserialize the blob.
- V17 migration backfills `source_config` from `repository`/`source_type` and drops the `repository` column.
- Disable Jackson `FAIL_ON_EMPTY_BEANS` in the converter and `PersistenceMapper` so the empty `ZipSourceConfig` round-trips.

The REST/OpenAPI contract stays flat (`sourceType` + `repository`), so the frontend and the deploy CLI need no changes.