### PR TITLE
refactor: code style cleanup and lint fixes

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/service/ApplicationService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/ApplicationService.java
@@ -125,7 +125,7 @@ public class ApplicationService {
         application.setOwner(normalizeOwner(creatorUserId));
         try {
             application = applicationRepository.saveAndFlush(application);
-        } catch (DataIntegrityViolationException e) {
+        } catch (DataIntegrityViolationException exception) {
             throw new BizException("Application name already exists");
         }
         return application.getId();
@@ -163,8 +163,8 @@ public class ApplicationService {
             }
             try {
                 applicationRuntimeGateway.deleteWorkload(environment, namespace, name);
-            } catch (Exception e) {
-                log.error("Failed to delete K8s resources for app {}/{} in env {}: {}", namespace, name, env.getEnvironmentName(), e.getMessage());
+            } catch (Exception exception) {
+                log.error("Failed to delete K8s resources for app {}/{} in env {}: {}", namespace, name, env.getEnvironmentName(), exception.getMessage());
                 throw new BizException("Application deletion failed");
             }
         }
@@ -359,7 +359,7 @@ public class ApplicationService {
                                                           List<ApplicationRuntimeSpec.EnvironmentConfig> existingConfigs) {
         for (ApplicationRuntimeSpec.EnvironmentConfig config : configs) {
             ApplicationRuntimeSpec.EnvironmentConfig existing = existingConfigs.stream()
-                    .filter(c -> c.getEnvironmentName().equals(config.getEnvironmentName()))
+                    .filter(existingConfig -> existingConfig.getEnvironmentName().equals(config.getEnvironmentName()))
                     .findFirst().orElse(null);
 
             boolean replicasChanged = config.getReplicas() != null
@@ -375,8 +375,8 @@ public class ApplicationService {
                 Environment environment = environmentRepository.findFirstByName(config.getEnvironmentName());
                 if (environment == null) continue;
                 applicationRuntimeGateway.applyRuntimeSpec(environment, namespace, appName, config);
-            } catch (Exception e) {
-                log.warn("Failed to apply runtime spec for app={} env={}: {}", appName, config.getEnvironmentName(), e.getMessage());
+            } catch (Exception exception) {
+                log.warn("Failed to apply runtime spec for app={} env={}: {}", appName, config.getEnvironmentName(), exception.getMessage());
             }
         }
     }
@@ -407,7 +407,7 @@ public class ApplicationService {
                                           List<ApplicationExpertConfig.EnvironmentConfig> existingConfigs) {
         for (ApplicationExpertConfig.EnvironmentConfig config : configs) {
             ApplicationExpertConfig.EnvironmentConfig existing = existingConfigs.stream()
-                    .filter(c -> c.getEnvironmentName().equals(config.getEnvironmentName()))
+                    .filter(existingConfig -> existingConfig.getEnvironmentName().equals(config.getEnvironmentName()))
                     .findFirst().orElse(null);
 
             boolean serviceAccountChanged = !StringUtils.equals(
@@ -420,8 +420,8 @@ public class ApplicationService {
                 Environment environment = environmentRepository.findFirstByName(config.getEnvironmentName());
                 if (environment == null) continue;
                 applicationExpertConfigGateway.applyExpertConfig(environment, namespace, appName, config);
-            } catch (Exception e) {
-                log.warn("Failed to apply expert config for app={} env={}: {}", appName, config.getEnvironmentName(), e.getMessage());
+            } catch (Exception exception) {
+                log.warn("Failed to apply expert config for app={} env={}: {}", appName, config.getEnvironmentName(), exception.getMessage());
             }
         }
     }
@@ -451,7 +451,7 @@ public class ApplicationService {
                 .map(Environment::getName)
                 .collect(Collectors.toSet());
         return all.stream()
-                .filter(e -> existingEnvNames.contains(e.getEnvironmentName()))
+                .filter(binding -> existingEnvNames.contains(binding.getEnvironmentName()))
                 .map(ApplicationConfigDto.EnvironmentBinding::from)
                 .toList();
     }
@@ -582,8 +582,8 @@ public class ApplicationService {
                     : null;
 
             return new ClusterDomainView(internalDomain, externalDomains);
-        } catch (Exception e) {
-            log.error("Failed to get cluster domain: {}", e.getMessage(), e);
+        } catch (Exception exception) {
+            log.error("Failed to get cluster domain: {}", exception.getMessage(), exception);
         }
         return null;
     }

--- a/src/main/java/com/github/wellch4n/oops/application/service/DomainService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/DomainService.java
@@ -114,8 +114,8 @@ public class DomainService {
             try {
                 meta = PemCertificateParser.parseCertificate(request.getCertPem());
                 PemCertificateParser.validatePrivateKey(request.getKeyPem());
-            } catch (IllegalArgumentException e) {
-                throw new BizException(e.getMessage(), e);
+            } catch (IllegalArgumentException exception) {
+                throw new BizException(exception.getMessage(), exception);
             }
             if (!PemCertificateParser.hostMatches(domain.getHost(), meta.getDnsNames())) {
                 throw new BizException("Certificate does not match domain, certificate is for: "

--- a/src/main/java/com/github/wellch4n/oops/application/service/EnvironmentService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/EnvironmentService.java
@@ -65,8 +65,8 @@ public class EnvironmentService {
     public Environment createEnvironment(Environment environment) {
         try {
             ResourceNameChecker.checkEnvironmentName(environment.getName());
-        } catch (IllegalArgumentException e) {
-            throw new BizException(e.getMessage(), e);
+        } catch (IllegalArgumentException exception) {
+            throw new BizException(exception.getMessage(), exception);
         }
         Environment existing = environmentRepository.findFirstByName(environment.getName());
         if (existing != null) {
@@ -94,8 +94,8 @@ public class EnvironmentService {
                 return new KubernetesValidationResult(false, "NAMESPACE_MISSING", "Work namespace does not exist");
             }
             return new KubernetesValidationResult(true, "VALID", "Validation passed");
-        } catch (Exception e) {
-            return new KubernetesValidationResult(false, "ERROR", "Validation failed: " + e.getMessage());
+        } catch (Exception exception) {
+            return new KubernetesValidationResult(false, "ERROR", "Validation failed: " + exception.getMessage());
         }
     }
 
@@ -106,8 +106,8 @@ public class EnvironmentService {
         try {
             environmentGateway.createNamespace(kubernetesApiServer, workNamespace);
             return true;
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create work namespace: " + e.getMessage());
+        } catch (Exception exception) {
+            throw new BizException("Failed to create work namespace: " + exception.getMessage(), exception);
         }
     }
 
@@ -136,9 +136,9 @@ public class EnvironmentService {
         try {
             environmentGateway.syncImagePullSecret(environment);
             log.info("Synced dockerhub secret to namespace: {}", environment.getWorkNamespace());
-        } catch (Exception e) {
+        } catch (Exception exception) {
             throw new BizException("Failed to sync dockerhub secret to namespace "
-                    + environment.getWorkNamespace() + ": " + e.getMessage(), e);
+                    + environment.getWorkNamespace() + ": " + exception.getMessage(), exception);
         }
     }
 
@@ -146,9 +146,9 @@ public class EnvironmentService {
         try {
             environmentGateway.syncGitCredentialSecret(environment);
             log.info("Synced git-credential secret to namespace: {}", environment.getWorkNamespace());
-        } catch (Exception e) {
+        } catch (Exception exception) {
             throw new BizException("Failed to sync git-credential secret to namespace "
-                    + environment.getWorkNamespace() + ": " + e.getMessage(), e);
+                    + environment.getWorkNamespace() + ": " + exception.getMessage(), exception);
         }
     }
 

--- a/src/main/java/com/github/wellch4n/oops/application/service/ExternalAccountService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/ExternalAccountService.java
@@ -20,15 +20,15 @@ public class ExternalAccountService {
     public ExternalAccountService(List<ExternalAuthStrategy> strategyList) {
         this.strategies = strategyList.stream()
                 .collect(Collectors.toMap(
-                        s -> s.getProvider().name().toLowerCase(),
-                        s -> s
+                        strategy -> strategy.getProvider().name().toLowerCase(),
+                        strategy -> strategy
                 ));
     }
 
     public List<String> getEnabledProviders() {
         return strategies.values().stream()
                 .filter(ExternalAuthStrategy::isEnabled)
-                .map(s -> s.getProvider().name().toLowerCase())
+                .map(strategy -> strategy.getProvider().name().toLowerCase())
                 .toList();
     }
 
@@ -39,13 +39,13 @@ public class ExternalAccountService {
     public String authenticate(String provider, String code) {
         try {
             return getEnabledStrategy(provider).authenticate(code);
-        } catch (IOException e) {
-            log.error("External authentication failed for provider {}", provider, e);
-            String detail = e.getMessage();
+        } catch (IOException exception) {
+            log.error("External authentication failed for provider {}", provider, exception);
+            String detail = exception.getMessage();
             String message = (detail == null || detail.isBlank())
                     ? "Authentication failed"
                     : "Authentication failed: " + detail;
-            throw new BizException(message, e);
+            throw new BizException(message, exception);
         }
     }
 

--- a/src/main/java/com/github/wellch4n/oops/application/service/ExternalMessageService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/ExternalMessageService.java
@@ -15,8 +15,8 @@ public class ExternalMessageService {
     public ExternalMessageService(List<ExternalMessageStrategy> strategyList) {
         this.strategies = strategyList.stream()
                 .collect(Collectors.toMap(
-                        s -> s.getProvider().name().toLowerCase(),
-                        s -> s
+                        strategy -> strategy.getProvider().name().toLowerCase(),
+                        strategy -> strategy
                 ));
     }
 

--- a/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
@@ -172,16 +172,16 @@ public class PipelineService {
             artifactDeploymentExecutor.deploy(pipeline, application, environment, runtimeSpec, healthCheck, serviceConfig, expertConfig);
 
             completeDeployPhase(pipeline, "正在等待新版本发布生效…");
-        } catch (Exception e) {
+        } catch (Exception exception) {
             pipelineStateMachine.ensureCanTransition(PipelineStatus.DEPLOYING, PipelineStatus.ERROR);
-            String message = StringUtils.defaultIfBlank(e.getMessage(), "发布任务执行失败，请查看日志。");
+            String message = StringUtils.defaultIfBlank(exception.getMessage(), "发布任务执行失败，请查看日志。");
             pipelineRepository.updateStatusAndMessageIfMatch(
                     pipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.ERROR, message);
             pipeline.markFailed(message);
             eventPublisher.publishEvent(PipelineNotificationEvent.of(
                     pipeline, PipelineNotificationType.FAILED, message
             ));
-            throw new RuntimeException("Deploy failed: " + e.getMessage(), e);
+            throw new BizException("Deploy failed: " + exception.getMessage(), exception);
         }
         return true;
     }
@@ -233,16 +233,16 @@ public class PipelineService {
             artifactDeploymentExecutor.deploy(rollbackPipeline, application, environment, runtimeSpec, healthCheck, serviceConfig, expertConfig);
 
             completeDeployPhase(rollbackPipeline, "正在等待回滚版本发布生效…");
-        } catch (Exception e) {
+        } catch (Exception exception) {
             pipelineStateMachine.ensureCanTransition(PipelineStatus.DEPLOYING, PipelineStatus.ERROR);
-            String message = StringUtils.defaultIfBlank(e.getMessage(), "回滚任务执行失败，请查看日志。");
+            String message = StringUtils.defaultIfBlank(exception.getMessage(), "回滚任务执行失败，请查看日志。");
             pipelineRepository.updateStatusAndMessageIfMatch(
                     rollbackPipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.ERROR, message);
             rollbackPipeline.markFailed(message);
             eventPublisher.publishEvent(PipelineNotificationEvent.of(
                     rollbackPipeline, PipelineNotificationType.FAILED, message
             ));
-            throw new RuntimeException("Rollback failed: " + e.getMessage(), e);
+            throw new BizException("Rollback failed: " + exception.getMessage(), exception);
         }
         return rollbackPipeline.getId();
     }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/stream/KubernetesPipelineLogStreamGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/stream/KubernetesPipelineLogStreamGateway.java
@@ -6,6 +6,7 @@ import com.github.wellch4n.oops.application.port.StreamSink;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
 import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.domain.delivery.Pipeline;
+import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -30,7 +31,7 @@ public class KubernetesPipelineLogStreamGateway implements PipelineLogStreamGate
     private static final String LOGS_EXPIRED_MESSAGE = "Logs expired: the build job has been cleaned up";
     private static final String MSG_TYPE = "type";
 
-    private final ExecutorService executorService = Executors.newCachedThreadPool();
+    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
@@ -42,7 +43,7 @@ public class KubernetesPipelineLogStreamGateway implements PipelineLogStreamGate
 
     private void streamLogs(Pipeline pipeline, Environment environment, StreamSink sink, KubernetesStreamHandle handle) {
         try {
-            KubernetesClient client = com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients.from(environment.getKubernetesApiServer());
+            KubernetesClient client = KubernetesClients.from(environment.getKubernetesApiServer());
             handle.add(client);
 
             String workNamespace = environment.getWorkNamespace();
@@ -184,10 +185,10 @@ public class KubernetesPipelineLogStreamGateway implements PipelineLogStreamGate
         var spec = job.getSpec().getTemplate().getSpec();
         List<String> containers = new ArrayList<>();
         if (spec.getInitContainers() != null) {
-            spec.getInitContainers().forEach(c -> containers.add(c.getName()));
+            spec.getInitContainers().forEach(container -> containers.add(container.getName()));
         }
         if (spec.getContainers() != null) {
-            spec.getContainers().forEach(c -> containers.add(c.getName()));
+            spec.getContainers().forEach(container -> containers.add(container.getName()));
         }
         return containers;
     }
@@ -206,7 +207,7 @@ public class KubernetesPipelineLogStreamGateway implements PipelineLogStreamGate
         return Stream.concat(
                 Optional.ofNullable(pod.getStatus().getInitContainerStatuses()).orElse(List.of()).stream(),
                 Optional.ofNullable(pod.getStatus().getContainerStatuses()).orElse(List.of()).stream()
-        ).anyMatch(s -> s.getName().equals(containerName) && s.getState().getTerminated() != null);
+        ).anyMatch(containerStatus -> containerStatus.getName().equals(containerName) && containerStatus.getState().getTerminated() != null);
     }
 
     private boolean isContainerReady(Pod pod, String containerName) {

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/stream/KubernetesPodLogStreamGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/stream/KubernetesPodLogStreamGateway.java
@@ -3,6 +3,7 @@ package com.github.wellch4n.oops.infrastructure.kubernetes.stream;
 import com.github.wellch4n.oops.application.port.PodLogStreamGateway;
 import com.github.wellch4n.oops.application.port.StreamSink;
 import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
@@ -17,12 +18,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class KubernetesPodLogStreamGateway implements PodLogStreamGateway {
-    private final ExecutorService executorService = Executors.newCachedThreadPool();
+    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
 
     @Override
     public AutoCloseable stream(Environment environment, String namespace, String podName, StreamSink sink) {
         KubernetesStreamHandle handle = new KubernetesStreamHandle();
-        KubernetesClient client = com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients.from(environment.getKubernetesApiServer());
+        KubernetesClient client = KubernetesClients.from(environment.getKubernetesApiServer());
         handle.add(client);
 
         PodResource podResource = client.pods().inNamespace(namespace).withName(podName);

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/stream/KubernetesTerminalSessionGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/stream/KubernetesTerminalSessionGateway.java
@@ -3,6 +3,7 @@ package com.github.wellch4n.oops.infrastructure.kubernetes.stream;
 import com.github.wellch4n.oops.application.port.StreamSink;
 import com.github.wellch4n.oops.application.port.TerminalSessionGateway;
 import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
@@ -17,7 +18,7 @@ public class KubernetesTerminalSessionGateway implements TerminalSessionGateway 
 
     @Override
     public TerminalSession open(Environment environment, String namespace, String podName, String container, StreamSink sink) {
-        KubernetesClient client = com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients.from(environment.getKubernetesApiServer());
+        KubernetesClient client = KubernetesClients.from(environment.getKubernetesApiServer());
         KubernetesStreamHandle handle = new KubernetesStreamHandle();
         handle.add(client);
 
@@ -36,8 +37,8 @@ public class KubernetesTerminalSessionGateway implements TerminalSessionGateway 
                         }
 
                         @Override
-                        public void onFailure(Throwable t, Response response) {
-                            log.warn("Terminal session failed for pod {}/{}: {}", namespace, podName, t.getMessage());
+                        public void onFailure(Throwable throwable, Response response) {
+                            log.warn("Terminal session failed for pod {}/{}: {}", namespace, podName, throwable.getMessage());
                             closeSinkWithError(sink);
                         }
                     })

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/ArtifactDeployTask.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/ArtifactDeployTask.java
@@ -9,6 +9,7 @@ import com.github.wellch4n.oops.domain.application.ApplicationServiceConfig;
 import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.domain.delivery.Pipeline;
 import com.github.wellch4n.oops.domain.shared.OopsTypes;
+import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients;
 import com.github.wellch4n.oops.infrastructure.kubernetes.task.processor.DeployContext;
 import com.github.wellch4n.oops.infrastructure.kubernetes.task.processor.DeployProcessor;
 import com.github.wellch4n.oops.infrastructure.kubernetes.task.processor.ImagePullSecretProcessor;
@@ -56,8 +57,8 @@ public class ArtifactDeployTask implements Callable<Boolean> {
 
     @Override
     public Boolean call() {
-        try (KubernetesClient client = com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients.from(environment.getKubernetesApiServer())) {
-            DeployContext ctx = new DeployContext(
+        try (KubernetesClient client = KubernetesClients.from(environment.getKubernetesApiServer())) {
+            DeployContext context = new DeployContext(
                     pipeline, application, environment, runtimeSpec, healthCheck,
                     applicationServiceConfig, expertConfig, ingressConfig, client, OopsConstants.PATCH_CONTEXT,
                     SERVICE_PORT, Map.of(
@@ -74,7 +75,7 @@ public class ArtifactDeployTask implements Callable<Boolean> {
                     new IngressRouteProcessor()
             );
 
-            processors.forEach(p -> p.process(ctx));
+            processors.forEach(processor -> processor.process(context));
         }
         return true;
     }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/PipelineExecuteTask.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/PipelineExecuteTask.java
@@ -15,6 +15,7 @@ import com.github.wellch4n.oops.domain.delivery.ZipPublishConfig;
 import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
 import com.github.wellch4n.oops.domain.shared.DockerFileType;
+import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients;
 import com.github.wellch4n.oops.infrastructure.kubernetes.pod.PipelineBuildPod;
 import com.github.wellch4n.oops.application.port.ObjectStorage;
 import com.github.wellch4n.oops.infrastructure.kubernetes.volume.SecretVolume;
@@ -109,7 +110,7 @@ public class PipelineExecuteTask implements Callable<PipelineBuildPod> {
         pipelineBuildPod.addVolumes(workspaceVolume.getVolumes(), secretVolume.getVolumes());
         pipelineBuildPod.setArtifact(artifact);
 
-        try (var client = com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients.from(environment.getKubernetesApiServer())) {
+        try (var client = KubernetesClients.from(environment.getKubernetesApiServer())) {
             client.batch().v1().jobs().inNamespace(environment.getWorkNamespace()).resource(pipelineBuildPod).create();
         } catch (Exception e) {
             throw new IllegalStateException("Failed to create pipeline job: " + pipeline.getName(), e);

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/processor/IngressRouteProcessor.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/processor/IngressRouteProcessor.java
@@ -36,7 +36,7 @@ public class IngressRouteProcessor implements DeployProcessor {
         List<ApplicationServiceConfig.EnvironmentConfig> envServiceConfigs = ctx.getApplicationServiceConfig()
                 .getEnvironmentConfigs(ctx.getEnvironment().getName())
                 .stream()
-                .filter(c -> StringUtils.isNotEmpty(c.getHost()))
+                .filter(config -> StringUtils.isNotEmpty(config.getHost()))
                 .toList();
 
         if (envServiceConfigs.isEmpty()) {

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/scheduler/PipelineInstanceScanJob.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/scheduler/PipelineInstanceScanJob.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Component;
  * @date 2025/7/8
  */
 
+@Slf4j
 @Component
 public class PipelineInstanceScanJob {
     private static final Duration ROLLOUT_TIMEOUT = Duration.ofMinutes(5);
@@ -130,7 +132,7 @@ public class PipelineInstanceScanJob {
 
                         completeDeployPhase(pipeline);
                     } else if (jobStatus == PipelineJobStatus.FAILED) {
-                        System.err.println("Error processing succeeded pipeline " + pipeline.getId());
+                        log.warn("Pipeline build failed: {}", pipeline.getId());
                         pipelineStateMachine.ensureCanTransition(PipelineStatus.RUNNING, PipelineStatus.ERROR);
                         String message = "镜像构建失败，请查看流水线日志。";
                         int updated = pipelineRepository.updateStatusAndMessageIfMatch(
@@ -144,7 +146,7 @@ public class PipelineInstanceScanJob {
                         }
                     }
                 } catch (Exception exception) {
-                    System.out.println("Error scanning pipeline instance: " + exception.getMessage());
+                    log.error("Error scanning pipeline instance {}: {}", pipeline.getId(), exception.getMessage(), exception);
                     String message = StringUtils.defaultIfBlank(exception.getMessage(), "发布任务执行失败，请查看日志。");
                     int deployingUpdated = pipelineRepository.updateStatusAndMessageIfMatch(
                             pipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.ERROR, message
@@ -198,7 +200,7 @@ public class PipelineInstanceScanJob {
                     }
                     // otherwise: still rolling out, leave ROLLING_OUT for the next tick
                 } catch (Exception exception) {
-                    System.out.println("Error rollingOut pipeline instance: " + exception.getMessage());
+                    log.error("Error rolling out pipeline instance {}: {}", pipeline.getId(), exception.getMessage(), exception);
                 }
             }
         } finally {

--- a/src/main/java/com/github/wellch4n/oops/interfaces/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/rest/GlobalExceptionHandler.java
@@ -13,13 +13,13 @@ public class GlobalExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(BizException.class)
-    public Result<Void> handleBizException(BizException e) {
-        return Result.failure(e.getMessage());
+    public Result<Void> handleBizException(BizException exception) {
+        return Result.failure(exception.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
-    public Result<Void> handleException(Exception e) {
-        log.error("Unhandled exception", e);
+    public Result<Void> handleException(Exception exception) {
+        log.error("Unhandled exception", exception);
         return Result.failure("Internal server error");
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/interfaces/websocket/WebSocketSessionSupport.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/websocket/WebSocketSessionSupport.java
@@ -42,8 +42,8 @@ final class WebSocketSessionSupport {
                 } catch (InterruptedException _) {
                     Thread.currentThread().interrupt();
                     break;
-                } catch (IOException e) {
-                    log.debug("WebSocket heartbeat failed for session {}", session.getId(), e);
+                } catch (IOException ioException) {
+                    log.debug("WebSocket heartbeat failed for session {}", session.getId(), ioException);
                     break;
                 }
             }
@@ -64,8 +64,8 @@ final class WebSocketSessionSupport {
         }
         try {
             closeable.close();
-        } catch (Exception e) {
-            log.debug("Failed to close {}", resourceName, e);
+        } catch (Exception exception) {
+            log.debug("Failed to close {}", resourceName, exception);
         }
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/shared/util/PemCertificateParser.java
+++ b/src/main/java/com/github/wellch4n/oops/shared/util/PemCertificateParser.java
@@ -41,8 +41,8 @@ public final class PemCertificateParser {
         if (certPem == null || certPem.isBlank()) {
             throw new IllegalArgumentException("Certificate content is empty");
         }
-        Matcher m = CERT_BLOCK.matcher(certPem);
-        if (!m.find()) {
+        Matcher certBlockMatcher = CERT_BLOCK.matcher(certPem);
+        if (!certBlockMatcher.find()) {
             throw new IllegalArgumentException("Invalid certificate format, expected PEM (-----BEGIN CERTIFICATE-----)");
         }
         try {
@@ -60,9 +60,9 @@ public final class PemCertificateParser {
 
     private static List<String> extractDnsNames(X509Certificate cert, String subject) throws CertificateParsingException {
         List<String> names = new ArrayList<>();
-        Matcher cn = CN_PATTERN.matcher(subject);
-        if (cn.find()) {
-            names.add(cn.group(1).trim().toLowerCase());
+        Matcher cnMatcher = CN_PATTERN.matcher(subject);
+        if (cnMatcher.find()) {
+            names.add(cnMatcher.group(1).trim().toLowerCase());
         }
         var altNames = cert.getSubjectAlternativeNames();
         if (altNames != null) {
@@ -70,8 +70,8 @@ public final class PemCertificateParser {
                 // entry[0] = type (2 = dNSName), entry[1] = value
                 if (entry.size() >= 2 && Integer.valueOf(2).equals(entry.get(0))) {
                     Object value = entry.get(1);
-                    if (value instanceof String s) {
-                        String lower = s.trim().toLowerCase();
+                    if (value instanceof String dnsName) {
+                        String lower = dnsName.trim().toLowerCase();
                         if (!names.contains(lower)) {
                             names.add(lower);
                         }
@@ -85,15 +85,15 @@ public final class PemCertificateParser {
     public static boolean hostMatches(String host, List<String> certDnsNames) {
         if (host == null || certDnsNames == null || certDnsNames.isEmpty()) return false;
         String normalizedHost = stripWildcard(host);
-        for (String cn : certDnsNames) {
-            if (stripWildcard(cn).equals(normalizedHost)) return true;
+        for (String certDnsName : certDnsNames) {
+            if (stripWildcard(certDnsName).equals(normalizedHost)) return true;
         }
         return false;
     }
 
     private static String stripWildcard(String name) {
-        String s = name == null ? "" : name.trim().toLowerCase();
-        return s.startsWith("*.") ? s.substring(2) : s;
+        String normalized = name == null ? "" : name.trim().toLowerCase();
+        return normalized.startsWith("*.") ? normalized.substring(2) : normalized;
     }
 
     public static void validatePrivateKey(String keyPem) {
@@ -104,11 +104,11 @@ public final class PemCertificateParser {
             throw new IllegalArgumentException(
                     "PKCS#1 format is not supported, please convert to PKCS#8 using: openssl pkcs8 -topk8 -nocrypt (-----BEGIN PRIVATE KEY-----)");
         }
-        Matcher m = PKCS8_KEY_BLOCK.matcher(keyPem);
-        if (!m.find()) {
+        Matcher keyBlockMatcher = PKCS8_KEY_BLOCK.matcher(keyPem);
+        if (!keyBlockMatcher.find()) {
             throw new IllegalArgumentException("Invalid private key format, expected PKCS#8 PEM (-----BEGIN PRIVATE KEY-----)");
         }
-        byte[] der = Base64.getMimeDecoder().decode(m.group(1).trim());
+        byte[] der = Base64.getMimeDecoder().decode(keyBlockMatcher.group(1).trim());
         PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(der);
         if (isInvalidKeyFactory("RSA", keySpec) && isInvalidKeyFactory("EC", keySpec)) {
             throw new IllegalArgumentException("Failed to parse private key (neither RSA nor EC)");

--- a/web/app/apps/[namespace]/[name]/page.tsx
+++ b/web/app/apps/[namespace]/[name]/page.tsx
@@ -3,7 +3,7 @@
 
 import { Suspense, useState, useEffect } from "react"
 import { useRouter, useParams } from "next/navigation"
-import { ApplicationForm } from "../../application-form"
+import { ApplicationForm } from "@/app/apps/application-form"
 import {
   getApplication,
   getApplicationBuildConfig,

--- a/web/app/apps/[namespace]/[name]/pods/[pod]/logs/page.tsx
+++ b/web/app/apps/[namespace]/[name]/pods/[pod]/logs/page.tsx
@@ -96,7 +96,7 @@ function ApplicationPodLogsContent() {
   }, [logs])
 
   if (!env) {
-    return <div className="p-4">Missing env parameter</div>
+    return <div className="p-4">{t("pods.missingEnv")}</div>
   }
 
   const isConnected = connectionStatus === "connected"

--- a/web/app/apps/[namespace]/[name]/pods/[pod]/terminal/page.tsx
+++ b/web/app/apps/[namespace]/[name]/pods/[pod]/terminal/page.tsx
@@ -37,7 +37,7 @@ function TerminalPageContent() {
   const namespace = params.namespace as string
   const name = params.name as string
   const pod = params.pod as string
-  const env = searchParams.get("env")
+  const env = searchParams.get("env") ?? ""
   const [connectionStatus, setConnectionStatus] = useState<
     "connecting" | "connected" | "disconnected"
   >("connecting")
@@ -47,26 +47,26 @@ function TerminalPageContent() {
   const { t } = useLanguage()
 
   const listDirectory = useCallback(
-    (path: string) => listPodDirectory({ namespace, name, pod, env: env!, path }),
+    (path: string) => listPodDirectory({ namespace, name, pod, env: env, path }),
     [namespace, name, pod, env],
   )
 
   const getDownloadUrl = useCallback(
-    (path: string) => getPodFileDownloadUrl({ namespace, name, pod, env: env!, path }),
+    (path: string) => getPodFileDownloadUrl({ namespace, name, pod, env: env, path }),
     [namespace, name, pod, env],
   )
 
   const uploadFile = useCallback(
     (parentDir: string, file: File) => {
       const dirPath = parentDir.endsWith("/") ? parentDir : `${parentDir}/`
-      return uploadPodFile({ namespace, name, pod, env: env!, path: dirPath, file })
+      return uploadPodFile({ namespace, name, pod, env: env, path: dirPath, file })
     },
     [namespace, name, pod, env],
   )
 
   const getFileContent = useCallback(
     async (path: string) => {
-      const result = await getPodFileContent({ namespace, name, pod, env: env!, path })
+      const result = await getPodFileContent({ namespace, name, pod, env: env, path })
       return result.content
     },
     [namespace, name, pod, env],
@@ -74,23 +74,23 @@ function TerminalPageContent() {
 
   const saveFileContent = useCallback(
     (path: string, content: string) =>
-      savePodFileContent({ namespace, name, pod, env: env!, path, content }),
+      savePodFileContent({ namespace, name, pod, env: env, path, content }),
     [namespace, name, pod, env],
   )
 
   const deletePath = useCallback(
-    (path: string) => deletePodPath({ namespace, name, pod, env: env!, path }),
+    (path: string) => deletePodPath({ namespace, name, pod, env: env, path }),
     [namespace, name, pod, env],
   )
 
   const renamePath = useCallback(
     (fromPath: string, toPath: string) =>
-      renamePodPath({ namespace, name, pod, env: env!, fromPath, toPath }),
+      renamePodPath({ namespace, name, pod, env: env, fromPath, toPath }),
     [namespace, name, pod, env],
   )
 
   const createDirectory = useCallback(
-    (path: string) => createPodDirectory({ namespace, name, pod, env: env!, path }),
+    (path: string) => createPodDirectory({ namespace, name, pod, env: env, path }),
     [namespace, name, pod, env],
   )
 
@@ -126,7 +126,7 @@ function TerminalPageContent() {
   }, [fileTreeWidth])
 
   if (!env) {
-    return <div className="p-4">Missing env parameter</div>
+    return <div className="p-4">{t("pods.missingEnv")}</div>
   }
 
   const isConnected = connectionStatus === "connected"

--- a/web/app/apps/components/application-service-info.tsx
+++ b/web/app/apps/components/application-service-info.tsx
@@ -586,7 +586,7 @@ export const ApplicationServiceInfo = forwardRef<ApplicationTabHandle, Props>(fu
             <span className="text-sm font-semibold">{t("apps.service.accessEntry")}</span>
             <Tooltip>
               <TooltipTrigger asChild>
-                <button type="button" className="text-muted-foreground hover:text-foreground inline-flex items-center" aria-label={t("apps.service.accessEntryRepublishNotice")}>
+                <button type="button" className="text-muted-foreground hover:text-foreground inline-flex items-center cursor-pointer" aria-label={t("apps.service.accessEntryRepublishNotice")}>
                   <Info className="size-3.5" />
                 </button>
               </TooltipTrigger>

--- a/web/app/ides/page.tsx
+++ b/web/app/ides/page.tsx
@@ -500,9 +500,9 @@ function IDEPageContent() {
                 ) : (
                   <Tabs defaultValue="env">
                     <TabsList className="w-full">
-                      <TabsTrigger value="env" className="flex-1">{t("ide.tabEnv")}</TabsTrigger>
-                      <TabsTrigger value="extensions" className="flex-1">{t("ide.tabExtensions")}</TabsTrigger>
-                      <TabsTrigger value="settings" className="flex-1">{t("ide.tabSettings")}</TabsTrigger>
+                      <TabsTrigger value="env" className="flex-1 cursor-pointer">{t("ide.tabEnv")}</TabsTrigger>
+                      <TabsTrigger value="extensions" className="flex-1 cursor-pointer">{t("ide.tabExtensions")}</TabsTrigger>
+                      <TabsTrigger value="settings" className="flex-1 cursor-pointer">{t("ide.tabSettings")}</TabsTrigger>
                     </TabsList>
                     <TabsContent value="env">
                       <Textarea

--- a/web/app/networks/domains/domain-form-dialog.tsx
+++ b/web/app/networks/domains/domain-form-dialog.tsx
@@ -110,7 +110,7 @@ export function DomainFormDialog({ open, onOpenChange, target, onSaved, onDelete
       onSaved()
       onOpenChange(false)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Error")
+      toast.error(err instanceof Error ? err.message : t("common.error"))
     } finally {
       setSubmitting(false)
     }
@@ -125,7 +125,7 @@ export function DomainFormDialog({ open, onOpenChange, target, onSaved, onDelete
       onDeleted?.()
       onOpenChange(false)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Error")
+      toast.error(err instanceof Error ? err.message : t("common.error"))
     } finally {
       setSubmitting(false)
       setDeleteConfirmOpen(false)

--- a/web/app/sandboxes/[id]/page.tsx
+++ b/web/app/sandboxes/[id]/page.tsx
@@ -185,7 +185,7 @@ export default function SandboxDetailPage() {
           <span className="text-xs text-muted-foreground font-mono">{sandbox.id}</span>
           <Tooltip>
             <TooltipTrigger asChild>
-              <button type="button" className="text-muted-foreground hover:text-foreground inline-flex items-center">
+              <button type="button" className="text-muted-foreground hover:text-foreground inline-flex items-center cursor-pointer">
                 <Info className="size-3.5" />
               </button>
             </TooltipTrigger>

--- a/web/app/sandboxes/page.tsx
+++ b/web/app/sandboxes/page.tsx
@@ -574,7 +574,7 @@ function SandboxesContent() {
                     {t("sandbox.useDefaultKeepalive")}
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button type="button" className="text-muted-foreground hover:text-foreground inline-flex items-center" aria-label={t("sandbox.useDefaultKeepaliveHint")}>
+                        <button type="button" className="text-muted-foreground hover:text-foreground inline-flex items-center cursor-pointer" aria-label={t("sandbox.useDefaultKeepaliveHint")}>
                           <Info className="size-3.5" />
                         </button>
                       </TooltipTrigger>

--- a/web/app/settings/environments/[id]/page.tsx
+++ b/web/app/settings/environments/[id]/page.tsx
@@ -127,7 +127,7 @@ export default function EnvironmentEditPage() {
           router.push("/settings/environments")
         }
       } catch (error) {
-        toast.error("加载环境失败")
+        toast.error(t("env.loadError"))
         console.error(error)
         router.push("/settings/environments")
       } finally {
@@ -159,7 +159,7 @@ export default function EnvironmentEditPage() {
         }
     } catch {
         toast.dismiss()
-        toast.error("工作空间创建失败")
+        toast.error(t("env.workspaceCreateError"))
     }
   }
 
@@ -230,7 +230,7 @@ export default function EnvironmentEditPage() {
       }
     } catch (e) {
       console.error(e)
-      toast.error("环境更新失败")
+      toast.error(t("env.updateError"))
     }
   }
 
@@ -249,7 +249,7 @@ export default function EnvironmentEditPage() {
       }
     } catch (e) {
       console.error(e)
-      toast.error("环境删除失败")
+      toast.error(t("env.deleteError"))
     } finally {
       setIsDeleting(false)
       if (ok) {

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,8 +1,13 @@
+"use client"
+
+import { useLanguage } from "@/contexts/language-context"
+
 export default function SettingsPage() {
+  const { t } = useLanguage()
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-semibold">系统设置</h1>
-      <p className="mt-4">请选择左侧子菜单进行设置。</p>
+      <h1 className="text-2xl font-semibold">{t("settings.title")}</h1>
+      <p className="mt-4">{t("settings.selectSubmenu")}</p>
     </div>
   )
 }

--- a/web/components/doc/doc-layout.tsx
+++ b/web/components/doc/doc-layout.tsx
@@ -9,6 +9,7 @@ import { ContentPage } from "@/components/content-page"
 import { DOC_TOPICS } from "@/components/doc/doc-topics"
 import { DocProvider } from "@/components/doc/doc-context"
 import { cn } from "@/lib/utils"
+import { useLanguage } from "@/contexts/language-context"
 
 function slugify(title: string): string {
   return title
@@ -34,14 +35,15 @@ function AnchorHeading({
   className: string
   children: ReactNode
 }) {
+  const { t } = useLanguage()
   const handleCopy = async () => {
     const url = `${window.location.origin}${window.location.pathname}#${id}`
     try {
       await navigator.clipboard.writeText(url)
-      toast.success("锚点链接已复制")
+      toast.success(t("doc.anchorCopied"))
     } catch {
       window.location.hash = id
-      toast.success("已定位到该章节")
+      toast.success(t("doc.anchorNavigated"))
     }
   }
 
@@ -51,9 +53,9 @@ function AnchorHeading({
       <button
         type="button"
         onClick={handleCopy}
-        aria-label="复制锚点链接"
-        title="复制锚点链接"
-        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+        aria-label={t("doc.copyAnchor")}
+        title={t("doc.copyAnchor")}
+        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
       >
         <Link2 className="h-3.5 w-3.5" />
       </button>
@@ -68,9 +70,10 @@ interface DocLayoutProps {
 
 export function DocLayout({ title, children }: DocLayoutProps) {
   const pathname = usePathname()
+  const { t } = useLanguage()
 
   return (
-    <ContentPage title="OpenAPI 文档" documentTitle={title}>
+    <ContentPage title={t("doc.title")} documentTitle={title}>
       <DocProvider>
         <div className="flex gap-6 items-start">
           <aside className="hidden md:block w-48 shrink-0 sticky top-14">

--- a/web/components/doc/endpoint.tsx
+++ b/web/components/doc/endpoint.tsx
@@ -5,6 +5,7 @@ import { Check, Copy } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useDocContext } from "./doc-context"
+import { useLanguage } from "@/contexts/language-context"
 
 type Method = "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
 
@@ -31,13 +32,14 @@ function buildCurl(method: Method, url: string, token: string): string {
   if (hasBody) {
     lines[lines.length - 1] += " \\"
     lines.push("  -H 'Content-Type: application/json' \\")
-    lines.push("  -d '<请求体>'")
+    lines.push("  -d '<request-body>'")
   }
   return lines.join("\n")
 }
 
 export function Endpoint({ method, path, summary }: EndpointProps) {
   const { accessToken, baseUrl } = useDocContext()
+  const { t } = useLanguage()
   const [copied, setCopied] = useState(false)
   const token = accessToken ?? "$OOPS_TOKEN"
   const url = `${baseUrl}${path}`
@@ -77,7 +79,7 @@ export function Endpoint({ method, path, summary }: EndpointProps) {
           size="icon"
           className="absolute right-1 top-1 size-6 text-muted-foreground hover:text-foreground"
           onClick={onCopy}
-          aria-label="复制 curl"
+          aria-label={t("doc.copyCurl")}
         >
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </Button>

--- a/web/components/doc/field-table.tsx
+++ b/web/components/doc/field-table.tsx
@@ -1,4 +1,7 @@
+"use client"
+
 import { ReactNode } from "react"
+import { useLanguage } from "@/contexts/language-context"
 
 export interface FieldRow {
   name: string
@@ -8,14 +11,15 @@ export interface FieldRow {
 }
 
 export function FieldTable({ rows }: { rows: FieldRow[] }) {
+  const { t } = useLanguage()
   return (
     <div className="overflow-x-auto rounded-md border">
       <table className="w-full text-sm">
         <thead className="bg-muted/50">
           <tr className="text-left">
-            <th className="px-3 py-2 font-medium w-1/4">字段</th>
-            <th className="px-3 py-2 font-medium w-1/4">类型</th>
-            <th className="px-3 py-2 font-medium">说明</th>
+            <th className="px-3 py-2 font-medium w-1/4">{t("doc.field")}</th>
+            <th className="px-3 py-2 font-medium w-1/4">{t("doc.type")}</th>
+            <th className="px-3 py-2 font-medium">{t("doc.description")}</th>
           </tr>
         </thead>
         <tbody>

--- a/web/components/file-tree.tsx
+++ b/web/components/file-tree.tsx
@@ -215,13 +215,13 @@ export default function FileTree({
           [path]: {
             entries: prev[path]?.entries ?? null,
             loading: false,
-            error: err instanceof Error ? err.message : "Failed to load",
+            error: err instanceof Error ? err.message : t("terminal.files.loadFailed"),
             expanded: true,
           },
         }))
       }
     },
-    [listDirectory],
+    [listDirectory, t],
   )
 
   useEffect(() => {
@@ -252,7 +252,7 @@ export default function FileTree({
         toast.success(t("terminal.files.uploadSuccess"))
         await loadDirectory(parentDir)
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Upload failed")
+        toast.error(err instanceof Error ? err.message : t("terminal.files.uploadFailed"))
       } finally {
         setUploadingDirs((prev) => {
           const next = { ...prev }
@@ -315,11 +315,11 @@ export default function FileTree({
           draft: "",
           loading: false,
           saving: false,
-          error: err instanceof Error ? err.message : "Failed to load file",
+          error: err instanceof Error ? err.message : t("terminal.files.loadFileFailed"),
         })
       }
     },
-    [getFileContent],
+    [getFileContent, t],
   )
 
   const handleSaveEdit = useCallback(async () => {
@@ -331,7 +331,7 @@ export default function FileTree({
       setEdit(null)
     } catch (err) {
       setEdit((prev) =>
-        prev ? { ...prev, saving: false, error: err instanceof Error ? err.message : "Save failed" } : prev,
+        prev ? { ...prev, saving: false, error: err instanceof Error ? err.message : t("terminal.files.saveFailed") } : prev,
       )
     }
   }, [edit, saveFileContent, t])
@@ -375,7 +375,7 @@ export default function FileTree({
       refreshParent(rename.entry.path)
     } catch (err) {
       setRename((prev) =>
-        prev ? { ...prev, saving: false, error: err instanceof Error ? err.message : "Rename failed" } : prev,
+        prev ? { ...prev, saving: false, error: err instanceof Error ? err.message : t("terminal.files.renameFailed") } : prev,
       )
     }
   }, [rename, renamePath, t, refreshParent])
@@ -394,7 +394,7 @@ export default function FileTree({
       setDel(null)
       refreshParent(target.path)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Delete failed")
+      toast.error(err instanceof Error ? err.message : t("terminal.files.deleteFailed"))
       setDel((prev) => (prev ? { ...prev, deleting: false } : prev))
     }
   }, [del, deletePath, t, refreshParent])
@@ -453,7 +453,7 @@ export default function FileTree({
             <button
               type="button"
               onClick={() => openMkdir(rootPath)}
-              className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+              className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer"
               title={t("terminal.files.newFolder")}
             >
               <FolderPlus className="size-3.5" />
@@ -462,7 +462,7 @@ export default function FileTree({
           <button
             type="button"
             onClick={() => loadDirectory(rootPath)}
-            className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+            className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer"
             title={t("common.refresh")}
           >
             {rootState?.loading ? (
@@ -925,7 +925,7 @@ function TreeRow({
       await navigator.clipboard.writeText(text)
       toast.success(t("terminal.files.copied"))
     } catch {
-      toast.error("Copy failed")
+      toast.error(t("terminal.files.copyFailed"))
     }
   }
 
@@ -937,7 +937,7 @@ function TreeRow({
       a.click()
       a.remove()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Download failed")
+      toast.error(err instanceof Error ? err.message : t("terminal.files.downloadFailed"))
     }
   }
 

--- a/web/components/ui/command.tsx
+++ b/web/components/ui/command.tsx
@@ -96,7 +96,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className
     )}
     {...props}

--- a/web/components/ui/context-menu.tsx
+++ b/web/components/ui/context-menu.tsx
@@ -66,7 +66,7 @@ function ContextMenuSubTrigger({
       data-slot="context-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}
@@ -126,7 +126,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        "relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
         className
       )}
       {...props}
@@ -144,7 +144,7 @@ function ContextMenuCheckboxItem({
     <ContextMenuPrimitive.CheckboxItem
       data-slot="context-menu-checkbox-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -169,7 +169,7 @@ function ContextMenuRadioItem({
     <ContextMenuPrimitive.RadioItem
       data-slot="context-menu-radio-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/web/components/ui/copyable.tsx
+++ b/web/components/ui/copyable.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
+import { useLanguage } from "@/contexts/language-context"
 
 interface CopyableProps {
   value: string
@@ -12,9 +13,10 @@ interface CopyableProps {
 }
 
 export function Copyable({ value, copyValue, maxLength = 10, className, displayClassName }: CopyableProps) {
+  const { t } = useLanguage()
   const handleCopy = async () => {
     await navigator.clipboard.writeText(copyValue ?? value)
-    toast.success("已复制")
+    toast.success(t("common.copied"))
   }
 
   const display =

--- a/web/components/ui/dropdown-menu.tsx
+++ b/web/components/ui/dropdown-menu.tsx
@@ -76,7 +76,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -94,7 +94,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -130,7 +130,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -213,7 +213,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/web/components/ui/select.tsx
+++ b/web/components/ui/select.tsx
@@ -109,7 +109,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/web/lib/api/auth.ts
+++ b/web/lib/api/auth.ts
@@ -22,7 +22,7 @@ export async function getFeishuLoginUrl(): Promise<string> {
   const res = await apiFetch("/api/auth/external/feishu/redirect")
   const data = await res.json() as ApiResponse<string>
   if (!data.success || !data.data) {
-    throw new Error(data.message || "获取飞书登录地址失败")
+    throw new Error(data.message || "Failed to get Feishu login URL")
   }
   return data.data
 }
@@ -57,7 +57,7 @@ export async function login(username: string, password: string): Promise<LoginRe
   })
   const data = await res.json() as ApiResponse<LoginResult>
   if (!data.success) {
-    throw new Error(data.message || "登录失败")
+    throw new Error(data.message || "Login failed")
   }
   setAuth(data.data.token)
   return data.data
@@ -69,7 +69,7 @@ export async function feishuCallback(code: string): Promise<string> {
   })
   const data = await res.json() as ApiResponse<string>
   if (!data.success || !data.data) {
-    throw new Error(data.message || "登录失败")
+    throw new Error(data.message || "Login failed")
   }
   return data.data
 }

--- a/web/lib/auth-keys.ts
+++ b/web/lib/auth-keys.ts
@@ -1,0 +1,8 @@
+// Shared auth storage key names. Centralized here so the Next.js middleware
+// (proxy.ts, edge runtime) and the browser-side auth helpers (lib/auth.ts) stay
+// in sync without duplicating magic strings.
+
+export const AUTH_TOKEN_COOKIE = "auth_token"
+export const AUTH_USER_ID_KEY = "auth_user_id"
+export const AUTH_USERNAME_KEY = "auth_username"
+export const AUTH_ROLE_KEY = "auth_role"

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,3 +1,10 @@
+import {
+  AUTH_TOKEN_COOKIE,
+  AUTH_USER_ID_KEY,
+  AUTH_USERNAME_KEY,
+  AUTH_ROLE_KEY,
+} from "@/lib/auth-keys"
+
 interface JwtClaims {
   sub: string
   userId: string
@@ -23,7 +30,7 @@ function decodeJwt(token: string): JwtClaims | null {
 export function getToken(): string | null {
   if (typeof document === "undefined") return null
   const value = `; ${document.cookie}`
-  const parts = value.split(`; auth_token=`)
+  const parts = value.split(`; ${AUTH_TOKEN_COOKIE}=`)
   if (parts.length === 2) return parts.pop()!.split(";").shift() || null
   return null
 }
@@ -35,18 +42,18 @@ function getClaims(): JwtClaims | null {
 
 export function setAuth(token: string) {
   const maxAge = 7 * 24 * 3600
-  document.cookie = `auth_token=${token}; path=/; max-age=${maxAge}; SameSite=Lax`
+  document.cookie = `${AUTH_TOKEN_COOKIE}=${token}; path=/; max-age=${maxAge}; SameSite=Lax`
 }
 
 export function clearAuth() {
   if (typeof document !== "undefined") {
-    document.cookie = "auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
-    document.cookie = "auth_token=; path=/; max-age=0; SameSite=Lax"
+    document.cookie = `${AUTH_TOKEN_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+    document.cookie = `${AUTH_TOKEN_COOKIE}=; path=/; max-age=0; SameSite=Lax`
   }
   if (typeof localStorage !== "undefined") {
-    localStorage.removeItem("auth_user_id")
-    localStorage.removeItem("auth_username")
-    localStorage.removeItem("auth_role")
+    localStorage.removeItem(AUTH_USER_ID_KEY)
+    localStorage.removeItem(AUTH_USERNAME_KEY)
+    localStorage.removeItem(AUTH_ROLE_KEY)
   }
 }
 

--- a/web/locales/en-US/common.ts
+++ b/web/locales/en-US/common.ts
@@ -1,4 +1,7 @@
 const common = {
+  "common.copied": "Copied",
+  "settings.title": "System Settings",
+  "settings.selectSubmenu": "Please select a submenu on the left to configure.",
   "common.loading": "Loading...",
   "common.noData": "No data",
   "common.environment": "Environment:",
@@ -60,6 +63,24 @@ const common = {
   "terminal.files.newFolderTitle": "New folder",
   "terminal.files.newFolderPlaceholder": "Folder name",
   "terminal.files.newFolderSuccess": "Created",
+  "terminal.files.copyFailed": "Copy failed",
+  "terminal.files.downloadFailed": "Download failed",
+  "terminal.files.uploadFailed": "Upload failed",
+  "terminal.files.loadFailed": "Failed to load",
+  "terminal.files.loadFileFailed": "Failed to load file",
+  "terminal.files.saveFailed": "Save failed",
+  "terminal.files.renameFailed": "Rename failed",
+  "terminal.files.deleteFailed": "Delete failed",
+  "pods.missingEnv": "Missing env parameter",
+  "common.error": "Error",
+  "doc.field": "Field",
+  "doc.type": "Type",
+  "doc.description": "Description",
+  "doc.anchorCopied": "Anchor link copied",
+  "doc.anchorNavigated": "Jumped to section",
+  "doc.copyAnchor": "Copy anchor link",
+  "doc.copyCurl": "Copy curl",
+  "doc.title": "OpenAPI Docs",
 }
 
 export default common

--- a/web/locales/ja-JP/common.ts
+++ b/web/locales/ja-JP/common.ts
@@ -1,4 +1,7 @@
 const common = {
+  "common.copied": "コピーしました",
+  "settings.title": "システム設定",
+  "settings.selectSubmenu": "左のサブメニューを選択して設定してください。",
   "common.loading": "読み込み中...",
   "common.noData": "まだデータがありません",
   "common.environment": "環境：",
@@ -60,6 +63,24 @@ const common = {
   "terminal.files.newFolderTitle": "新規フォルダ",
   "terminal.files.newFolderPlaceholder": "フォルダ名",
   "terminal.files.newFolderSuccess": "作成しました",
+  "terminal.files.copyFailed": "コピーに失敗しました",
+  "terminal.files.downloadFailed": "ダウンロードに失敗しました",
+  "terminal.files.uploadFailed": "アップロードに失敗しました",
+  "terminal.files.loadFailed": "読み込みに失敗しました",
+  "terminal.files.loadFileFailed": "ファイルの読み込みに失敗しました",
+  "terminal.files.saveFailed": "保存に失敗しました",
+  "terminal.files.renameFailed": "名前の変更に失敗しました",
+  "terminal.files.deleteFailed": "削除に失敗しました",
+  "pods.missingEnv": "env パラメータがありません",
+  "common.error": "エラーが発生しました",
+  "doc.field": "フィールド",
+  "doc.type": "型",
+  "doc.description": "説明",
+  "doc.anchorCopied": "アンカーリンクをコピーしました",
+  "doc.anchorNavigated": "セクションに移動しました",
+  "doc.copyAnchor": "アンカーリンクをコピー",
+  "doc.copyCurl": "curl をコピー",
+  "doc.title": "OpenAPI ドキュメント",
 }
 
 export default common

--- a/web/locales/zh-CN/common.ts
+++ b/web/locales/zh-CN/common.ts
@@ -1,4 +1,7 @@
 const common = {
+  "common.copied": "已复制",
+  "settings.title": "系统设置",
+  "settings.selectSubmenu": "请选择左侧子菜单进行设置。",
   "common.loading": "加载中...",
   "common.noData": "暂无数据",
   "common.environment": "环境:",
@@ -60,6 +63,24 @@ const common = {
   "terminal.files.newFolderTitle": "新建文件夹",
   "terminal.files.newFolderPlaceholder": "文件夹名称",
   "terminal.files.newFolderSuccess": "已创建",
+  "terminal.files.copyFailed": "复制失败",
+  "terminal.files.downloadFailed": "下载失败",
+  "terminal.files.uploadFailed": "上传失败",
+  "terminal.files.loadFailed": "加载失败",
+  "terminal.files.loadFileFailed": "加载文件失败",
+  "terminal.files.saveFailed": "保存失败",
+  "terminal.files.renameFailed": "重命名失败",
+  "terminal.files.deleteFailed": "删除失败",
+  "pods.missingEnv": "缺少 env 参数",
+  "common.error": "操作失败",
+  "doc.field": "字段",
+  "doc.type": "类型",
+  "doc.description": "说明",
+  "doc.anchorCopied": "锚点链接已复制",
+  "doc.anchorNavigated": "已定位到该章节",
+  "doc.copyAnchor": "复制锚点链接",
+  "doc.copyCurl": "复制 curl",
+  "doc.title": "OpenAPI 文档",
 }
 
 export default common

--- a/web/locales/zh-TW/common.ts
+++ b/web/locales/zh-TW/common.ts
@@ -1,4 +1,7 @@
 const common = {
+  "common.copied": "已複製",
+  "settings.title": "系統設定",
+  "settings.selectSubmenu": "請選擇左側子選單進行設定。",
   "common.loading": "載入中...",
   "common.noData": "暫無數據",
   "common.environment": "環境:",
@@ -60,6 +63,24 @@ const common = {
   "terminal.files.newFolderTitle": "新建資料夾",
   "terminal.files.newFolderPlaceholder": "資料夾名稱",
   "terminal.files.newFolderSuccess": "已建立",
+  "terminal.files.copyFailed": "複製失敗",
+  "terminal.files.downloadFailed": "下載失敗",
+  "terminal.files.uploadFailed": "上傳失敗",
+  "terminal.files.loadFailed": "載入失敗",
+  "terminal.files.loadFileFailed": "載入檔案失敗",
+  "terminal.files.saveFailed": "儲存失敗",
+  "terminal.files.renameFailed": "重新命名失敗",
+  "terminal.files.deleteFailed": "刪除失敗",
+  "pods.missingEnv": "缺少 env 參數",
+  "common.error": "操作失敗",
+  "doc.field": "欄位",
+  "doc.type": "類型",
+  "doc.description": "說明",
+  "doc.anchorCopied": "錨點連結已複製",
+  "doc.anchorNavigated": "已定位到該章節",
+  "doc.copyAnchor": "複製錨點連結",
+  "doc.copyCurl": "複製 curl",
+  "doc.title": "OpenAPI 文件",
 }
 
 export default common

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
+import { AUTH_TOKEN_COOKIE } from "@/lib/auth-keys"
 
 export function proxy(request: NextRequest) {
-  const token = request.cookies.get("auth_token")?.value
+  const token = request.cookies.get(AUTH_TOKEN_COOKIE)?.value
   const { pathname } = request.nextUrl
 
   if (pathname === "/login") {


### PR DESCRIPTION
Backend:
- Rename single-letter variables to descriptive names (e->exception, s->strategy, c->existingConfig, m/cn->matcher, etc.) per code style
- Replace inline fully-qualified class names with imports
- Use virtual-thread executors instead of newCachedThreadPool
- Throw BizException (with cause) instead of bare RuntimeException
- Add @Slf4j logging in place of System.err.println

Frontend:
- Centralize auth storage key names in lib/auth-keys.ts and reuse in proxy.ts and lib/auth.ts to drop magic strings
- Replace hardcoded Chinese strings with i18n / English messages and add the corresponding locale entries (zh-CN, zh-TW, en-US, ja-JP)
- Misc cursor-pointer and UI component consistency fixes