### PR TITLE
test: add unit tests for pure server-side logic

### DIFF
--- a/src/test/java/com/github/wellch4n/oops/application/dto/DeploymentHealthTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/dto/DeploymentHealthTests.java
@@ -1,0 +1,49 @@
+package com.github.wellch4n.oops.application.dto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class DeploymentHealthTests {
+
+    private DeploymentHealth health(String failureReason, Instant notReadySince) {
+        return new DeploymentHealth(false, false, 3, 1, failureReason, notReadySince);
+    }
+
+    @Test
+    void hasFailureTrueOnlyForNonBlankReason() {
+        assertTrue(health("ImagePullBackOff", null).hasFailure());
+        assertFalse(health(null, null).hasFailure());
+        assertFalse(health("   ", null).hasFailure());
+    }
+
+    @Test
+    void notReadyLongerThanFalseWhenNotReadySinceNull() {
+        assertFalse(health(null, null).notReadyLongerThan(Instant.now(), Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void notReadyLongerThanTrueWhenTimeoutElapsed() {
+        Instant notReadySince = Instant.parse("2026-01-01T00:00:00Z");
+        Instant now = notReadySince.plus(Duration.ofMinutes(6));
+        assertTrue(health(null, notReadySince).notReadyLongerThan(now, Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void notReadyLongerThanTrueExactlyAtBoundary() {
+        Instant notReadySince = Instant.parse("2026-01-01T00:00:00Z");
+        Instant now = notReadySince.plus(Duration.ofMinutes(5));
+        // boundary: elapsed == timeout counts as "longer than" (deadline reached)
+        assertTrue(health(null, notReadySince).notReadyLongerThan(now, Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void notReadyLongerThanFalseWhenWithinTimeout() {
+        Instant notReadySince = Instant.parse("2026-01-01T00:00:00Z");
+        Instant now = notReadySince.plus(Duration.ofMinutes(4));
+        assertFalse(health(null, notReadySince).notReadyLongerThan(now, Duration.ofMinutes(5)));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/application/dto/EnvironmentDtoTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/dto/EnvironmentDtoTests.java
@@ -1,0 +1,69 @@
+package com.github.wellch4n.oops.application.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.environment.Environment.GitCredential;
+import com.github.wellch4n.oops.domain.environment.Environment.ImageRepository;
+import com.github.wellch4n.oops.domain.environment.Environment.KubernetesApiServer;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentDtoTests {
+
+    private Environment fullEnvironment() {
+        Environment environment = new Environment();
+        environment.setId("env-1");
+        environment.setName("prod");
+        environment.setWorkNamespace("work");
+        environment.setBuildStorageClass("ssd");
+        environment.setKubernetesApiServer(KubernetesApiServer.of("https://api", "secret-token"));
+        environment.setImageRepository(ImageRepository.of("registry", "user", "registry-pass"));
+        environment.setGitCredential(GitCredential.of("git-user", "git-pass", "private-key"));
+        return environment;
+    }
+
+    @Test
+    void fromExposesAllFields() {
+        EnvironmentDto dto = EnvironmentDto.from(fullEnvironment());
+        assertEquals("secret-token", dto.kubernetesApiServer().token());
+        assertEquals("registry-pass", dto.imageRepository().password());
+        assertEquals("git-pass", dto.gitCredential().password());
+        assertEquals("private-key", dto.gitCredential().privateKey());
+    }
+
+    @Test
+    void fromRedactedHidesSecretsButKeepsNonSensitiveFields() {
+        EnvironmentDto dto = EnvironmentDto.fromRedacted(fullEnvironment());
+        // non-sensitive fields preserved
+        assertEquals("prod", dto.name());
+        assertEquals("https://api", dto.kubernetesApiServer().url());
+        assertEquals("registry", dto.imageRepository().url());
+        assertEquals("user", dto.imageRepository().username());
+        // secrets redacted
+        assertNull(dto.kubernetesApiServer().token());
+        assertNull(dto.imageRepository().password());
+        assertNull(dto.gitCredential());
+    }
+
+    @Test
+    void fromHandlesNullNestedObjects() {
+        Environment environment = new Environment();
+        environment.setId("env-2");
+        environment.setName("dev");
+        EnvironmentDto dto = EnvironmentDto.from(environment);
+        assertNull(dto.kubernetesApiServer());
+        assertNull(dto.imageRepository());
+        assertNull(dto.gitCredential());
+    }
+
+    @Test
+    void fromRedactedHandlesNullNestedObjects() {
+        Environment environment = new Environment();
+        environment.setName("dev");
+        EnvironmentDto dto = EnvironmentDto.fromRedacted(environment);
+        assertNull(dto.kubernetesApiServer());
+        assertNull(dto.imageRepository());
+        assertNull(dto.gitCredential());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/application/dto/PageTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/dto/PageTests.java
@@ -1,0 +1,32 @@
+package com.github.wellch4n.oops.application.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PageTests {
+
+    @Test
+    void computesTotalPagesByCeiling() {
+        Page<String> page = Page.of(21, List.of("a"), 10);
+        assertEquals(3, page.totalPages());
+        assertEquals(21, page.total());
+        assertEquals(10, page.size());
+    }
+
+    @Test
+    void exactMultipleHasNoExtraPage() {
+        assertEquals(2, Page.of(20, List.of(), 10).totalPages());
+    }
+
+    @Test
+    void emptyResultHasZeroPages() {
+        assertEquals(0, Page.of(0, List.of(), 10).totalPages());
+    }
+
+    @Test
+    void zeroSizeYieldsZeroPagesWithoutDivideByZero() {
+        assertEquals(0, Page.of(5, List.of(), 0).totalPages());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/application/service/SandboxDefaultsTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/service/SandboxDefaultsTests.java
@@ -1,0 +1,75 @@
+package com.github.wellch4n.oops.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.shared.exception.BizException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SandboxDefaultsTests {
+
+    @Test
+    void trimToNullCollapsesBlankToNull() {
+        assertNull(SandboxDefaults.trimToNull(null));
+        assertNull(SandboxDefaults.trimToNull("   "));
+        assertEquals("x", SandboxDefaults.trimToNull("  x  "));
+    }
+
+    @Test
+    void firstNonBlankPrefersTrimmedRequested() {
+        assertEquals("req", SandboxDefaults.firstNonBlank("  req ", "fallback"));
+        assertEquals("fallback", SandboxDefaults.firstNonBlank(null, "fallback"));
+        assertEquals("fallback", SandboxDefaults.firstNonBlank("   ", "fallback"));
+    }
+
+    @Test
+    void positiveOrDefaultReturnsFallbackForNullAndRejectsNonPositive() {
+        assertEquals(300, SandboxDefaults.positiveOrDefault(null, 300, "timeout"));
+        assertEquals(5, SandboxDefaults.positiveOrDefault(5, 300, "timeout"));
+        assertThrows(BizException.class, () -> SandboxDefaults.positiveOrDefault(0, 300, "timeout"));
+        assertThrows(BizException.class, () -> SandboxDefaults.positiveOrDefault(-1, 300, "timeout"));
+    }
+
+    @Test
+    void nonNegativeOrDefaultAllowsZeroButRejectsNegative() {
+        assertEquals(60, SandboxDefaults.nonNegativeOrDefault(null, 60, "ttl"));
+        assertEquals(0, SandboxDefaults.nonNegativeOrDefault(0, 60, "ttl"));
+        assertThrows(BizException.class, () -> SandboxDefaults.nonNegativeOrDefault(-1, 60, "ttl"));
+    }
+
+    @Test
+    void sanitizeEnvReturnsEmptyForNullOrEmpty() {
+        assertTrue(SandboxDefaults.sanitizeEnv(null).isEmpty());
+        assertTrue(SandboxDefaults.sanitizeEnv(Map.of()).isEmpty());
+    }
+
+    @Test
+    void sanitizeEnvTrimsNamesSkipsBlankAndNullsValueToEmpty() {
+        Map<String, String> input = new LinkedHashMap<>();
+        input.put("  FOO  ", "bar");
+        input.put("   ", "ignored");
+        input.put("BAZ", null);
+        Map<String, String> result = SandboxDefaults.sanitizeEnv(input);
+        assertEquals(2, result.size());
+        assertEquals("bar", result.get("FOO"));
+        assertEquals("", result.get("BAZ"));
+    }
+
+    @Test
+    void sanitizeEnvRejectsInvalidVariableName() {
+        assertThrows(BizException.class,
+                () -> SandboxDefaults.sanitizeEnv(Map.of("1BAD", "x")));
+        assertThrows(BizException.class,
+                () -> SandboxDefaults.sanitizeEnv(Map.of("has-dash", "x")));
+    }
+
+    @Test
+    void sanitizeEnvResultIsImmutable() {
+        Map<String, String> result = SandboxDefaults.sanitizeEnv(Map.of("FOO", "bar"));
+        assertThrows(UnsupportedOperationException.class, () -> result.put("X", "y"));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationBuildConfigPolicyTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationBuildConfigPolicyTests.java
@@ -1,0 +1,67 @@
+package com.github.wellch4n.oops.domain.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
+import com.github.wellch4n.oops.domain.shared.DockerFileType;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import org.junit.jupiter.api.Test;
+
+class ApplicationBuildConfigPolicyTests {
+
+    private final ApplicationBuildConfigPolicy policy = new ApplicationBuildConfigPolicy();
+
+    @Test
+    void normalizeSourceTypeDefaultsToGit() {
+        assertEquals(ApplicationSourceType.GIT, policy.normalizeSourceType(null));
+        assertEquals(ApplicationSourceType.ZIP, policy.normalizeSourceType(ApplicationSourceType.ZIP));
+    }
+
+    @Test
+    void validateRequiresRepositoryForGit() {
+        assertThrows(BizException.class,
+                () -> policy.validate(ApplicationSourceType.GIT, "  ", null, null));
+        assertThrows(BizException.class,
+                () -> policy.validate(null, null, null, null));
+        // valid git
+        policy.validate(ApplicationSourceType.GIT, "git@host:repo.git", null, null);
+    }
+
+    @Test
+    void validateDoesNotRequireRepositoryForZip() {
+        policy.validate(ApplicationSourceType.ZIP, null, null, null);
+    }
+
+    @Test
+    void validateRequiresContentForUserDockerfile() {
+        assertThrows(BizException.class,
+                () -> policy.validate(ApplicationSourceType.ZIP, null, DockerFileType.USER, "  "));
+        // with content it is fine
+        policy.validate(ApplicationSourceType.ZIP, null, DockerFileType.USER, "FROM scratch");
+    }
+
+    @Test
+    void validateAllowsBuiltinDockerfileWithoutContent() {
+        policy.validate(ApplicationSourceType.GIT, "repo", DockerFileType.BUILTIN, null);
+    }
+
+    @Test
+    void buildSourceConfigReturnsGitConfigWithRepository() {
+        SourceConfig config = policy.buildSourceConfig(ApplicationSourceType.GIT, "repo-url");
+        GitSourceConfig gitConfig = assertInstanceOf(GitSourceConfig.class, config);
+        assertEquals("repo-url", gitConfig.repository());
+    }
+
+    @Test
+    void buildSourceConfigReturnsZipConfig() {
+        assertInstanceOf(ZipSourceConfig.class,
+                policy.buildSourceConfig(ApplicationSourceType.ZIP, null));
+    }
+
+    @Test
+    void buildSourceConfigDefaultsNullToGit() {
+        assertInstanceOf(GitSourceConfig.class, policy.buildSourceConfig(null, "repo"));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationPriorityTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationPriorityTests.java
@@ -1,0 +1,45 @@
+package com.github.wellch4n.oops.domain.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class ApplicationPriorityTests {
+
+    @Test
+    void fromValueDefaultsBlankToNormal() {
+        assertEquals(ApplicationPriority.NORMAL, ApplicationPriority.fromValue(null));
+        assertEquals(ApplicationPriority.NORMAL, ApplicationPriority.fromValue("  "));
+    }
+
+    @Test
+    void fromValueDefaultsUnknownToNormal() {
+        assertEquals(ApplicationPriority.NORMAL, ApplicationPriority.fromValue("URGENT"));
+    }
+
+    @Test
+    void fromValueIsCaseInsensitiveAndTrims() {
+        assertEquals(ApplicationPriority.HIGH, ApplicationPriority.fromValue("  high "));
+        assertEquals(ApplicationPriority.LOW, ApplicationPriority.fromValue("Low"));
+    }
+
+    @Test
+    void priorityClassNameOfResolvesNamedTiers() {
+        assertEquals("oops-high-priority", ApplicationPriority.priorityClassNameOf("HIGH"));
+        assertEquals("oops-low-priority", ApplicationPriority.priorityClassNameOf("LOW"));
+    }
+
+    @Test
+    void priorityClassNameOfNormalIsNull() {
+        assertNull(ApplicationPriority.priorityClassNameOf("NORMAL"));
+        assertNull(ApplicationPriority.priorityClassNameOf("anything-unknown"));
+    }
+
+    @Test
+    void defaultValuesMatchTier() {
+        assertEquals(1_000_000, ApplicationPriority.HIGH.defaultValue());
+        assertEquals(0, ApplicationPriority.NORMAL.defaultValue());
+        assertEquals(-1_000_000, ApplicationPriority.LOW.defaultValue());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationServiceConfigTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationServiceConfigTests.java
@@ -1,0 +1,52 @@
+package com.github.wellch4n.oops.domain.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.domain.application.ApplicationServiceConfig.EnvironmentConfig;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ApplicationServiceConfigTests {
+
+    private EnvironmentConfig environmentConfig(String name) {
+        EnvironmentConfig config = new EnvironmentConfig();
+        config.setEnvironmentName(name);
+        return config;
+    }
+
+    @Test
+    void getEnvironmentConfigsFiltersByName() {
+        ApplicationServiceConfig config = new ApplicationServiceConfig();
+        config.setEnvironmentConfigs(List.of(
+                environmentConfig("prod"), environmentConfig("dev"), environmentConfig("prod")));
+        assertEquals(2, config.getEnvironmentConfigs("prod").size());
+        assertEquals(1, config.getEnvironmentConfigs("dev").size());
+        assertTrue(config.getEnvironmentConfigs("staging").isEmpty());
+    }
+
+    @Test
+    void getEnvironmentConfigsEmptyWhenUnset() {
+        assertTrue(new ApplicationServiceConfig().getEnvironmentConfigs("prod").isEmpty());
+    }
+
+    @Test
+    void distinctInternalPortsRemovesDuplicatesPreservingOrder() {
+        ApplicationServiceConfig config = new ApplicationServiceConfig();
+        config.setInternalPorts(List.of(8080, 9090, 8080));
+        assertEquals(List.of(8080, 9090), config.distinctInternalPorts());
+    }
+
+    @Test
+    void distinctInternalPortsDropsNullAndNonPositive() {
+        ApplicationServiceConfig config = new ApplicationServiceConfig();
+        config.setInternalPorts(Arrays.asList(8080, null, 0, -1, 9090));
+        assertEquals(List.of(8080, 9090), config.distinctInternalPorts());
+    }
+
+    @Test
+    void distinctInternalPortsEmptyWhenUnset() {
+        assertTrue(new ApplicationServiceConfig().distinctInternalPorts().isEmpty());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationTests.java
@@ -1,0 +1,86 @@
+package com.github.wellch4n.oops.domain.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ApplicationTests {
+
+    private Application application(String owner) {
+        Application application = new Application();
+        application.setName("demo");
+        application.placeInNamespace("default");
+        application.changeProfile("desc", owner);
+        return application;
+    }
+
+    @Test
+    void changeCollaboratorsExcludesOwner() {
+        Application application = application("owner-1");
+        application.changeCollaborators(List.of("owner-1", "user-2"));
+        assertEquals(List.of("user-2"), application.collaboratorUserIds());
+    }
+
+    @Test
+    void changeCollaboratorsDeduplicates() {
+        Application application = application("owner-1");
+        application.changeCollaborators(List.of("user-2", "user-2", "user-3"));
+        assertEquals(List.of("user-2", "user-3"), application.collaboratorUserIds());
+    }
+
+    @Test
+    void changeCollaboratorsFiltersBlankAndNull() {
+        Application application = application("owner-1");
+        application.changeCollaborators(Arrays.asList("user-2", null, "", "   "));
+        assertEquals(List.of("user-2"), application.collaboratorUserIds());
+    }
+
+    @Test
+    void changeCollaboratorsHandlesNull() {
+        Application application = application("owner-1");
+        application.changeCollaborators(null);
+        assertTrue(application.collaboratorUserIds().isEmpty());
+    }
+
+    @Test
+    void changeCollaboratorsStampsNamespaceAndApplicationName() {
+        Application application = application("owner-1");
+        application.changeCollaborators(List.of("user-2"));
+        ApplicationCollaborator collaborator = application.getCollaborators().getFirst();
+        assertEquals("default", collaborator.getNamespace());
+        assertEquals("demo", collaborator.getApplicationName());
+        assertEquals("user-2", collaborator.getUserId());
+    }
+
+    @Test
+    void collaboratorUserIdsEmptyWhenUnset() {
+        Application application = application("owner-1");
+        assertTrue(application.collaboratorUserIds().isEmpty());
+    }
+
+    @Test
+    void sourceTypeDefaultsToGitWhenUnset() {
+        Application application = application("owner-1");
+        assertEquals(ApplicationSourceType.GIT, application.sourceType());
+    }
+
+    @Test
+    void sourceTypeDefaultsToGitWhenBuildConfigSourceTypeNull() {
+        Application application = application("owner-1");
+        application.setBuildConfig(new ApplicationBuildConfig());
+        assertEquals(ApplicationSourceType.GIT, application.sourceType());
+    }
+
+    @Test
+    void sourceTypeReflectsConfiguredValue() {
+        Application application = application("owner-1");
+        ApplicationBuildConfig buildConfig = new ApplicationBuildConfig();
+        buildConfig.setSourceType(ApplicationSourceType.ZIP);
+        application.setBuildConfig(buildConfig);
+        assertEquals(ApplicationSourceType.ZIP, application.sourceType());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/application/HealthCheckPolicyTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/application/HealthCheckPolicyTests.java
@@ -1,0 +1,115 @@
+package com.github.wellch4n.oops.domain.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec.HealthCheck;
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec.HealthCheck.Probe;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import org.junit.jupiter.api.Test;
+
+class HealthCheckPolicyTests {
+
+    private final HealthCheckPolicy policy = new HealthCheckPolicy();
+
+    @Test
+    void normalizeNullHealthCheckProducesDisabledProbesWithDefaults() {
+        HealthCheck normalized = policy.normalize(null);
+        Probe liveness = normalized.getLiveness();
+        assertFalse(liveness.getEnabled());
+        assertEquals("/", liveness.getPath());
+        assertEquals(30, liveness.getInitialDelaySeconds());
+        assertEquals(10, liveness.getPeriodSeconds());
+        assertEquals(3, liveness.getTimeoutSeconds());
+        assertEquals(3, liveness.getFailureThreshold());
+    }
+
+    @Test
+    void normalizeCoercesNullEnabledToFalse() {
+        HealthCheck healthCheck = new HealthCheck();
+        Probe probe = new Probe();
+        probe.setEnabled(null);
+        healthCheck.setLiveness(probe);
+        assertFalse(policy.normalize(healthCheck).getLiveness().getEnabled());
+    }
+
+    @Test
+    void normalizeThrowsWhenEnabledWithBlankPath() {
+        HealthCheck healthCheck = new HealthCheck();
+        Probe probe = new Probe();
+        probe.setEnabled(true);
+        probe.setPath("  ");
+        healthCheck.setReadiness(probe);
+        assertThrows(BizException.class, () -> policy.normalize(healthCheck));
+    }
+
+    @Test
+    void normalizePrependsSlashToPath() {
+        HealthCheck healthCheck = new HealthCheck();
+        Probe probe = new Probe();
+        probe.setEnabled(true);
+        probe.setPath("healthz");
+        healthCheck.setLiveness(probe);
+        assertEquals("/healthz", policy.normalize(healthCheck).getLiveness().getPath());
+    }
+
+    @Test
+    void normalizeKeepsPathWithLeadingSlash() {
+        HealthCheck healthCheck = new HealthCheck();
+        Probe probe = new Probe();
+        probe.setEnabled(true);
+        probe.setPath("/ready");
+        healthCheck.setReadiness(probe);
+        assertEquals("/ready", policy.normalize(healthCheck).getReadiness().getPath());
+    }
+
+    @Test
+    void normalizeReplacesInvalidNumericFieldsWithDefaults() {
+        HealthCheck healthCheck = new HealthCheck();
+        Probe probe = new Probe();
+        probe.setEnabled(true);
+        probe.setPath("/");
+        probe.setInitialDelaySeconds(-1);
+        probe.setPeriodSeconds(0);
+        probe.setTimeoutSeconds(0);
+        probe.setFailureThreshold(0);
+        healthCheck.setLiveness(probe);
+        Probe normalized = policy.normalize(healthCheck).getLiveness();
+        assertEquals(30, normalized.getInitialDelaySeconds());
+        assertEquals(10, normalized.getPeriodSeconds());
+        assertEquals(3, normalized.getTimeoutSeconds());
+        assertEquals(3, normalized.getFailureThreshold());
+    }
+
+    @Test
+    void normalizeAllowsZeroInitialDelay() {
+        HealthCheck healthCheck = new HealthCheck();
+        Probe probe = new Probe();
+        probe.setEnabled(true);
+        probe.setPath("/");
+        probe.setInitialDelaySeconds(0);
+        healthCheck.setLiveness(probe);
+        assertEquals(0, policy.normalize(healthCheck).getLiveness().getInitialDelaySeconds());
+    }
+
+    @Test
+    void normalizePreservesValidCustomValues() {
+        HealthCheck healthCheck = new HealthCheck();
+        Probe probe = new Probe();
+        probe.setEnabled(true);
+        probe.setPath("/live");
+        probe.setInitialDelaySeconds(5);
+        probe.setPeriodSeconds(15);
+        probe.setTimeoutSeconds(2);
+        probe.setFailureThreshold(6);
+        healthCheck.setLiveness(probe);
+        Probe normalized = policy.normalize(healthCheck).getLiveness();
+        assertTrue(normalized.getEnabled());
+        assertEquals(5, normalized.getInitialDelaySeconds());
+        assertEquals(15, normalized.getPeriodSeconds());
+        assertEquals(2, normalized.getTimeoutSeconds());
+        assertEquals(6, normalized.getFailureThreshold());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/application/ProbeTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/application/ProbeTests.java
@@ -1,0 +1,70 @@
+package com.github.wellch4n.oops.domain.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec.HealthCheck.Probe;
+import org.junit.jupiter.api.Test;
+
+class ProbeTests {
+
+    @Test
+    void probeEnabledRequiresEnabledFlagAndNonBlankPath() {
+        Probe probe = new Probe();
+        probe.setEnabled(true);
+        probe.setPath("/healthz");
+        assertTrue(probe.probeEnabled());
+
+        probe.setEnabled(false);
+        assertFalse(probe.probeEnabled());
+
+        probe.setEnabled(true);
+        probe.setPath("  ");
+        assertFalse(probe.probeEnabled());
+    }
+
+    @Test
+    void normalizedPathPrependsSlashAndDefaultsBlank() {
+        Probe probe = new Probe();
+        probe.setPath("ready");
+        assertEquals("/ready", probe.normalizedPath());
+
+        probe.setPath("/live");
+        assertEquals("/live", probe.normalizedPath());
+
+        probe.setPath("  ");
+        assertEquals("/", probe.normalizedPath());
+    }
+
+    @Test
+    void effectiveInitialDelayAllowsZeroButFallsBackOnNegativeOrNull() {
+        Probe probe = new Probe();
+        probe.setInitialDelaySeconds(0);
+        assertEquals(0, probe.effectiveInitialDelaySeconds());
+        probe.setInitialDelaySeconds(-1);
+        assertEquals(30, probe.effectiveInitialDelaySeconds());
+        probe.setInitialDelaySeconds(null);
+        assertEquals(30, probe.effectiveInitialDelaySeconds());
+        probe.setInitialDelaySeconds(7);
+        assertEquals(7, probe.effectiveInitialDelaySeconds());
+    }
+
+    @Test
+    void effectivePeriodTimeoutThresholdRequirePositiveElseDefault() {
+        Probe probe = new Probe();
+        probe.setPeriodSeconds(0);
+        probe.setTimeoutSeconds(0);
+        probe.setFailureThreshold(0);
+        assertEquals(10, probe.effectivePeriodSeconds());
+        assertEquals(3, probe.effectiveTimeoutSeconds());
+        assertEquals(3, probe.effectiveFailureThreshold());
+
+        probe.setPeriodSeconds(20);
+        probe.setTimeoutSeconds(5);
+        probe.setFailureThreshold(6);
+        assertEquals(20, probe.effectivePeriodSeconds());
+        assertEquals(5, probe.effectiveTimeoutSeconds());
+        assertEquals(6, probe.effectiveFailureThreshold());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/delivery/DeployStrategyPolicyTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/delivery/DeployStrategyPolicyTests.java
@@ -1,0 +1,92 @@
+package com.github.wellch4n.oops.domain.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import org.junit.jupiter.api.Test;
+
+class DeployStrategyPolicyTests {
+
+    private final DeployStrategyPolicy policy = new DeployStrategyPolicy();
+
+    @Test
+    void strategyMatchesWhenTypesEqual() {
+        policy.ensureStrategyMatches(ApplicationSourceType.ZIP, ApplicationSourceType.ZIP);
+    }
+
+    @Test
+    void strategyDefaultsNullConfiguredToGit() {
+        policy.ensureStrategyMatches(null, ApplicationSourceType.GIT);
+        assertThrows(BizException.class,
+                () -> policy.ensureStrategyMatches(null, ApplicationSourceType.ZIP));
+    }
+
+    @Test
+    void strategyMismatchThrows() {
+        assertThrows(BizException.class,
+                () -> policy.ensureStrategyMatches(ApplicationSourceType.GIT, ApplicationSourceType.ZIP));
+    }
+
+    @Test
+    void normalizeGitBranchDefaultsToMain() {
+        assertEquals("main", policy.normalizeGitBranch(null));
+        assertEquals("main", policy.normalizeGitBranch("  "));
+        assertEquals("develop", policy.normalizeGitBranch("develop"));
+    }
+
+    @Test
+    void ensureRepositoryPresentThrowsForBlank() {
+        assertThrows(BizException.class, () -> policy.ensureRepositoryPresent(null, "msg"));
+        assertThrows(BizException.class, () -> policy.ensureRepositoryPresent("  ", "msg"));
+        policy.ensureRepositoryPresent("repo", "msg");
+    }
+
+    @Test
+    void resolveZipUsesExplicitObjectKey() {
+        ZipPublishConfig config = policy.resolveZipPublishConfig("key123", null, null);
+        assertEquals("key123", config.objectKey());
+        assertNull(config.url());
+    }
+
+    @Test
+    void resolveZipUsesExplicitUrl() {
+        ZipPublishConfig config = policy.resolveZipPublishConfig(null, "https://x/a.zip", null);
+        assertNull(config.objectKey());
+        assertEquals("https://x/a.zip", config.url());
+    }
+
+    @Test
+    void resolveZipRejectsBothObjectKeyAndUrl() {
+        assertThrows(BizException.class,
+                () -> policy.resolveZipPublishConfig("key", "https://x/a.zip", null));
+    }
+
+    @Test
+    void resolveZipRejectsWhenNothingProvided() {
+        assertThrows(BizException.class,
+                () -> policy.resolveZipPublishConfig(null, null, null));
+        assertThrows(BizException.class,
+                () -> policy.resolveZipPublishConfig("  ", "  ", "  "));
+    }
+
+    @Test
+    void resolveZipLegacyHttpTreatedAsUrl() {
+        ZipPublishConfig http = policy.resolveZipPublishConfig(null, null, "http://x/a.zip");
+        assertEquals("http://x/a.zip", http.url());
+        assertNull(http.objectKey());
+
+        ZipPublishConfig https = policy.resolveZipPublishConfig(null, null, "https://x/a.zip");
+        assertEquals("https://x/a.zip", https.url());
+        assertNull(https.objectKey());
+    }
+
+    @Test
+    void resolveZipLegacyNonUrlTreatedAsObjectKey() {
+        ZipPublishConfig config = policy.resolveZipPublishConfig(null, null, "uploads/a.zip");
+        assertEquals("uploads/a.zip", config.objectKey());
+        assertNull(config.url());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/delivery/PipelineTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/delivery/PipelineTests.java
@@ -1,0 +1,110 @@
+package com.github.wellch4n.oops.domain.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.domain.shared.ApplicationSourceType;
+import com.github.wellch4n.oops.domain.shared.DeployMode;
+import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.domain.shared.PipelineTriggerType;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import org.junit.jupiter.api.Test;
+
+class PipelineTests {
+
+    @Test
+    void initializeSetsReleaseDefaults() {
+        Pipeline pipeline = Pipeline.initialize(
+                "default", "demo", "prod", ApplicationSourceType.GIT, DeployMode.MANUAL, "user-1");
+        assertEquals(PipelineStatus.INITIALIZED, pipeline.getStatus());
+        assertEquals(PipelineTriggerType.RELEASE, pipeline.getTriggerType());
+        assertEquals(DeployMode.MANUAL, pipeline.getDeployMode());
+        assertEquals("user-1", pipeline.getOperatorId());
+    }
+
+    @Test
+    void initializeDefaultsNullDeployModeToImmediate() {
+        Pipeline pipeline = Pipeline.initialize(
+                "default", "demo", "prod", ApplicationSourceType.GIT, null, "user-1");
+        assertEquals(DeployMode.IMMEDIATE, pipeline.getDeployMode());
+    }
+
+    @Test
+    void rollbackReusesSourceArtifactAndMarksTrigger() {
+        Pipeline source = Pipeline.initialize(
+                "default", "demo", "prod", ApplicationSourceType.GIT, DeployMode.MANUAL, "user-1");
+        source.setId("source-id");
+        source.setArtifact("registry/demo:v1");
+        source.setPublishConfig(new GitPublishConfig("repo", "main"));
+
+        Pipeline rollback = Pipeline.rollback(source, "user-2");
+        assertEquals(PipelineStatus.INITIALIZED, rollback.getStatus());
+        assertEquals(PipelineTriggerType.ROLLBACK, rollback.getTriggerType());
+        assertEquals(DeployMode.IMMEDIATE, rollback.getDeployMode());
+        assertEquals("registry/demo:v1", rollback.getArtifact());
+        assertEquals(source.getPublishConfig(), rollback.getPublishConfig());
+        assertEquals("source-id", rollback.getRollbackFromPipelineId());
+        assertEquals("user-2", rollback.getOperatorId());
+    }
+
+    @Test
+    void getNameCombinesApplicationAndId() {
+        Pipeline pipeline = new Pipeline();
+        pipeline.setApplicationName("demo");
+        pipeline.setId("abc123");
+        assertEquals("demo-pipeline-abc123", pipeline.getName());
+    }
+
+    @Test
+    void finishedTrueForTerminalStatuses() {
+        assertTrue(pipelineWithStatus(PipelineStatus.SUCCEEDED).finished());
+        assertTrue(pipelineWithStatus(PipelineStatus.ERROR).finished());
+        assertTrue(pipelineWithStatus(PipelineStatus.STOPPED).finished());
+        assertTrue(pipelineWithStatus(PipelineStatus.BUILD_SUCCEEDED).finished());
+    }
+
+    @Test
+    void finishedFalseForInFlightStatuses() {
+        assertFalse(pipelineWithStatus(PipelineStatus.INITIALIZED).finished());
+        assertFalse(pipelineWithStatus(PipelineStatus.RUNNING).finished());
+        assertFalse(pipelineWithStatus(PipelineStatus.DEPLOYING).finished());
+        assertFalse(pipelineWithStatus(PipelineStatus.ROLLING_OUT).finished());
+    }
+
+    @Test
+    void startBuildStoresArtifactAndTransitionsToRunning() {
+        Pipeline pipeline = pipelineWithStatus(PipelineStatus.INITIALIZED);
+        pipeline.startBuild("registry/demo:v2");
+        assertEquals("registry/demo:v2", pipeline.getArtifact());
+        assertEquals(PipelineStatus.RUNNING, pipeline.getStatus());
+    }
+
+    @Test
+    void markFailedStoresMessageAndTransitionsToError() {
+        Pipeline pipeline = pipelineWithStatus(PipelineStatus.RUNNING);
+        pipeline.markFailed("boom");
+        assertEquals("boom", pipeline.getMessage());
+        assertEquals(PipelineStatus.ERROR, pipeline.getStatus());
+    }
+
+    @Test
+    void illegalTransitionThrows() {
+        Pipeline pipeline = pipelineWithStatus(PipelineStatus.INITIALIZED);
+        assertThrows(BizException.class, pipeline::markSucceeded);
+    }
+
+    @Test
+    void publishConfigNullByDefault() {
+        assertNull(new Pipeline().getPublishConfig());
+    }
+
+    private static Pipeline pipelineWithStatus(PipelineStatus status) {
+        Pipeline pipeline = new Pipeline();
+        pipeline.setApplicationName("demo");
+        pipeline.setStatus(status);
+        return pipeline;
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/environment/EnvironmentTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/environment/EnvironmentTests.java
@@ -1,0 +1,31 @@
+package com.github.wellch4n.oops.domain.environment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.domain.environment.Environment.GitCredential;
+import com.github.wellch4n.oops.domain.environment.Environment.ImageRepository;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentTests {
+
+    @Test
+    void imageRepositoryHasCredentialsRequiresAllFields() {
+        assertTrue(ImageRepository.of("registry", "user", "pass").hasCredentials());
+        assertFalse(ImageRepository.of("registry", "user", "").hasCredentials());
+        assertFalse(ImageRepository.of("registry", "user", null).hasCredentials());
+        assertFalse(ImageRepository.of("", "", "").hasCredentials());
+    }
+
+    @Test
+    void gitCredentialIsEmptyWhenAllBlank() {
+        assertTrue(GitCredential.of(null, null, null).isEmpty());
+        assertTrue(GitCredential.of("", "  ", "").isEmpty());
+    }
+
+    @Test
+    void gitCredentialNotEmptyWhenAnyFieldPresent() {
+        assertFalse(GitCredential.of("user", null, null).isEmpty());
+        assertFalse(GitCredential.of(null, null, "private-key").isEmpty());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/routing/DomainPolicyTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/routing/DomainPolicyTests.java
@@ -1,0 +1,97 @@
+package com.github.wellch4n.oops.domain.routing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.shared.exception.BizException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class DomainPolicyTests {
+
+    private final DomainPolicy policy = new DomainPolicy();
+    private final Function<String, String> identity = host -> host;
+
+    @Test
+    void normalizeHostStripsWildcardPrefixAndTrims() {
+        assertEquals("example.com", policy.normalizeHost("  *.example.com  "));
+        assertEquals("example.com", policy.normalizeHost("example.com"));
+    }
+
+    @Test
+    void normalizeHostHandlesNull() {
+        assertEquals("", policy.normalizeHost(null));
+    }
+
+    @Test
+    void validateHostRejectsBlank() {
+        assertThrows(BizException.class, () -> policy.validateHost(null));
+        assertThrows(BizException.class, () -> policy.validateHost("   "));
+    }
+
+    @Test
+    void validateHostRejectsUppercase() {
+        assertThrows(BizException.class, () -> policy.validateHost("Example.com"));
+    }
+
+    @Test
+    void validateHostRejectsInvalidFormat() {
+        assertThrows(BizException.class, () -> policy.validateHost("nodot"));
+        assertThrows(BizException.class, () -> policy.validateHost("-leading.com"));
+        assertThrows(BizException.class, () -> policy.validateHost("trailing-.com"));
+    }
+
+    @Test
+    void validateHostAcceptsValidHosts() {
+        policy.validateHost("example.com");
+        policy.validateHost("a.b.example.com");
+        policy.validateHost("my-app.example.com");
+    }
+
+    @Test
+    void findBestMatchPrefersLongestSuffix() {
+        List<String> candidates = List.of("example.com", "a.example.com");
+        Optional<String> match = policy.findBestMatch("foo.a.example.com", candidates, identity);
+        assertTrue(match.isPresent());
+        assertEquals("a.example.com", match.get());
+    }
+
+    @Test
+    void findBestMatchAllowsExactMatch() {
+        List<String> candidates = List.of("example.com");
+        assertEquals(Optional.of("example.com"),
+                policy.findBestMatch("example.com", candidates, identity));
+    }
+
+    @Test
+    void findBestMatchRequiresDotBoundary() {
+        // "barexample.com" must NOT match candidate "example.com"
+        List<String> candidates = List.of("example.com");
+        assertTrue(policy.findBestMatch("barexample.com", candidates, identity).isEmpty());
+    }
+
+    @Test
+    void findBestMatchIsCaseInsensitive() {
+        List<String> candidates = List.of("example.com");
+        assertEquals(Optional.of("example.com"),
+                policy.findBestMatch("API.EXAMPLE.COM", candidates, identity));
+    }
+
+    @Test
+    void findBestMatchReturnsEmptyForNullOrEmptyInputs() {
+        assertTrue(policy.findBestMatch(null, List.of("example.com"), identity).isEmpty());
+        assertTrue(policy.findBestMatch("example.com", List.of(), identity).isEmpty());
+        assertTrue(policy.findBestMatch("example.com", null, identity).isEmpty());
+        assertTrue(policy.findBestMatch("   ", List.of("example.com"), identity).isEmpty());
+    }
+
+    @Test
+    void findBestMatchSkipsCandidatesWithNullHost() {
+        List<String> candidates = java.util.Arrays.asList(null, "example.com");
+        assertEquals(Optional.of("example.com"),
+                policy.findBestMatch("a.example.com", candidates, identity));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/domain/sandbox/BuiltinSandboxRuntimeTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/sandbox/BuiltinSandboxRuntimeTests.java
@@ -1,0 +1,24 @@
+package com.github.wellch4n.oops.domain.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class BuiltinSandboxRuntimeTests {
+
+    @Test
+    void fromResolvesKnownKey() {
+        Optional<BuiltinSandboxRuntime> runtime = BuiltinSandboxRuntime.from("alpine-mate");
+        assertTrue(runtime.isPresent());
+        assertEquals(BuiltinSandboxRuntime.ALPINE_MATE, runtime.get());
+        assertEquals("linuxserver/webtop:alpine-mate", runtime.get().getImage());
+    }
+
+    @Test
+    void fromReturnsEmptyForUnknownOrNull() {
+        assertTrue(BuiltinSandboxRuntime.from("does-not-exist").isEmpty());
+        assertTrue(BuiltinSandboxRuntime.from(null).isEmpty());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/kubernetes/container/clone/CloneStrategyTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/kubernetes/container/clone/CloneStrategyTests.java
@@ -1,0 +1,74 @@
+package com.github.wellch4n.oops.infrastructure.kubernetes.container.clone;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.domain.application.Application;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CloneStrategyTests {
+
+    private final GitCloneStrategy gitStrategy = new GitCloneStrategy();
+    private final ZipCloneStrategy zipStrategy = new ZipCloneStrategy();
+
+    private Application application() {
+        Application application = new Application();
+        application.setName("demo");
+        return application;
+    }
+
+    @Test
+    void gitSupportsOnlyGitParam() {
+        assertTrue(gitStrategy.supports(new GitCloneParam("img", "repo", "main", true)));
+        assertFalse(gitStrategy.supports(new ZipCloneParam("img", "url", List.of())));
+    }
+
+    @Test
+    void gitBuildsShallowBranchedClone() {
+        String command = gitStrategy.buildCommand(application(),
+                new GitCloneParam("img", "https://host/repo.git", "develop", true));
+        assertTrue(command.contains("git clone --progress"));
+        assertTrue(command.contains("--depth 1"));
+        assertTrue(command.contains("-b develop"));
+        assertTrue(command.endsWith("https://host/repo.git /workspace"));
+    }
+
+    @Test
+    void gitOmitsDepthWhenNotShallow() {
+        String command = gitStrategy.buildCommand(application(),
+                new GitCloneParam("img", "https://host/repo.git", null, false));
+        assertFalse(command.contains("--depth"));
+        assertFalse(command.contains("-b "));
+    }
+
+    @Test
+    void gitRejectsBlankRepository() {
+        assertThrows(IllegalArgumentException.class,
+                () -> gitStrategy.buildCommand(application(), new GitCloneParam("img", "  ", "main", true)));
+    }
+
+    @Test
+    void zipSupportsOnlyZipParam() {
+        assertTrue(zipStrategy.supports(new ZipCloneParam("img", "url", List.of())));
+        assertFalse(zipStrategy.supports(new GitCloneParam("img", "repo", "main", true)));
+    }
+
+    @Test
+    void zipBuildsDownloadCommandWithUrlAndExcludes() {
+        String command = zipStrategy.buildCommand(application(),
+                new ZipCloneParam("img", "https://host/source.zip", List.of("node_modules/*", ".git/*")));
+        assertTrue(command.contains("curl -fL"));
+        assertTrue(command.contains("'https://host/source.zip'"));
+        assertTrue(command.contains("unzip -o /tmp/source.zip"));
+        assertTrue(command.contains("'node_modules/*'"));
+        assertTrue(command.contains("'.git/*'"));
+    }
+
+    @Test
+    void zipRejectsBlankDownloadUrl() {
+        assertThrows(IllegalArgumentException.class,
+                () -> zipStrategy.buildCommand(application(), new ZipCloneParam("img", " ", List.of())));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/converter/ConfigConverterTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/converter/ConfigConverterTests.java
@@ -1,0 +1,69 @@
+package com.github.wellch4n.oops.infrastructure.persistence.jpa.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.github.wellch4n.oops.domain.application.GitSourceConfig;
+import com.github.wellch4n.oops.domain.application.SourceConfig;
+import com.github.wellch4n.oops.domain.application.ZipSourceConfig;
+import com.github.wellch4n.oops.domain.delivery.GitPublishConfig;
+import com.github.wellch4n.oops.domain.delivery.PublishConfig;
+import com.github.wellch4n.oops.domain.delivery.ZipPublishConfig;
+import org.junit.jupiter.api.Test;
+
+class ConfigConverterTests {
+
+    private final PublishConfigConverter publishConverter = new PublishConfigConverter();
+    private final SourceConfigConverter sourceConverter = new SourceConfigConverter();
+
+    @Test
+    void publishConfigGitRoundTrips() {
+        GitPublishConfig original = new GitPublishConfig("https://host/repo.git", "main");
+        String json = publishConverter.convertToDatabaseColumn(original);
+        PublishConfig restored = publishConverter.convertToEntityAttribute(json);
+        GitPublishConfig git = assertInstanceOf(GitPublishConfig.class, restored);
+        assertEquals("https://host/repo.git", git.repository());
+        assertEquals("main", git.branch());
+    }
+
+    @Test
+    void publishConfigZipRoundTripsPolymorphically() {
+        ZipPublishConfig original = ZipPublishConfig.ofObjectKey("uploads/a.zip");
+        String json = publishConverter.convertToDatabaseColumn(original);
+        PublishConfig restored = publishConverter.convertToEntityAttribute(json);
+        ZipPublishConfig zip = assertInstanceOf(ZipPublishConfig.class, restored);
+        assertEquals("uploads/a.zip", zip.objectKey());
+        assertNull(zip.url());
+    }
+
+    @Test
+    void publishConfigHandlesNullAndBlank() {
+        assertNull(publishConverter.convertToDatabaseColumn(null));
+        assertNull(publishConverter.convertToEntityAttribute(null));
+        assertNull(publishConverter.convertToEntityAttribute("   "));
+    }
+
+    @Test
+    void sourceConfigGitRoundTrips() {
+        GitSourceConfig original = new GitSourceConfig("repo-url");
+        String json = sourceConverter.convertToDatabaseColumn(original);
+        SourceConfig restored = sourceConverter.convertToEntityAttribute(json);
+        assertEquals("repo-url", assertInstanceOf(GitSourceConfig.class, restored).repository());
+    }
+
+    @Test
+    void sourceConfigZipRoundTripsEvenWithNoFields() {
+        ZipSourceConfig original = new ZipSourceConfig();
+        String json = sourceConverter.convertToDatabaseColumn(original);
+        SourceConfig restored = sourceConverter.convertToEntityAttribute(json);
+        assertInstanceOf(ZipSourceConfig.class, restored);
+    }
+
+    @Test
+    void sourceConfigHandlesNullAndBlank() {
+        assertNull(sourceConverter.convertToDatabaseColumn(null));
+        assertNull(sourceConverter.convertToEntityAttribute(null));
+        assertNull(sourceConverter.convertToEntityAttribute(""));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/shared/util/EncryptionUtilsTests.java
+++ b/src/test/java/com/github/wellch4n/oops/shared/util/EncryptionUtilsTests.java
@@ -1,0 +1,52 @@
+package com.github.wellch4n.oops.shared.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class EncryptionUtilsTests {
+
+    @AfterEach
+    void clearKey() {
+        EncryptionUtils.setSecretKey(null);
+    }
+
+    @Test
+    void encryptDecryptRoundTrips() {
+        EncryptionUtils.setSecretKey("a-test-secret-key-value");
+        String plaintext = "sensitive-k8s-token";
+        String encrypted = EncryptionUtils.encrypt(plaintext);
+        assertNotEquals(plaintext, encrypted);
+        assertEquals(plaintext, EncryptionUtils.decrypt(encrypted));
+    }
+
+    @Test
+    void encryptionUsesRandomIvSoCiphertextDiffers() {
+        EncryptionUtils.setSecretKey("a-test-secret-key-value");
+        String plaintext = "same-input";
+        assertNotEquals(EncryptionUtils.encrypt(plaintext), EncryptionUtils.encrypt(plaintext));
+    }
+
+    @Test
+    void passthroughWhenNoKeyConfigured() {
+        EncryptionUtils.setSecretKey(null);
+        assertEquals("plain", EncryptionUtils.encrypt("plain"));
+        assertEquals("plain", EncryptionUtils.decrypt("plain"));
+    }
+
+    @Test
+    void passthroughForBlankKey() {
+        EncryptionUtils.setSecretKey("   ");
+        assertEquals("plain", EncryptionUtils.encrypt("plain"));
+    }
+
+    @Test
+    void nullInputReturnsNull() {
+        EncryptionUtils.setSecretKey("a-test-secret-key-value");
+        assertNull(EncryptionUtils.encrypt(null));
+        assertNull(EncryptionUtils.decrypt(null));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/shared/util/PemCertificateParserTests.java
+++ b/src/test/java/com/github/wellch4n/oops/shared/util/PemCertificateParserTests.java
@@ -1,0 +1,121 @@
+package com.github.wellch4n.oops.shared.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.shared.util.PemCertificateParser.CertMeta;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PemCertificateParserTests {
+
+    // Public self-signed certificate (CN=example.com, SAN: example.com, www.example.com), valid until 2126.
+    // Inlined rather than kept as a resource file so the repository carries no certificate/key files.
+    // A public certificate contains no secret material; the JDK has no public API to generate an X.509
+    // certificate at runtime, so this is the lightest way to exercise parseCertificate(). Private keys,
+    // by contrast, ARE generated at runtime below.
+    private static final String CERT_PEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIDODCCAiCgAwIBAgIUXLJgQPqvuUGvVNO99rZFBlE/3QswDQYJKoZIhvcNAQEL
+            BQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wIBcNMjYwNjI3MTY1ODMyWhgPMjEy
+            NjA2MDMxNjU4MzJaMBYxFDASBgNVBAMMC2V4YW1wbGUuY29tMIIBIjANBgkqhkiG
+            9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3WTEOFXnBHacY7n5j8ILq21FISdqq9Zo6g3E
+            7mN/ro1NTnscdgxU7n7ivbz61sl3eKnSC+e/xyCEDi+DMZWsiDQjeFTWsjKUssy7
+            QI4VR1IAqtkQmLPQNlqWmeAcYWXdYj/LymDs1iczicPgHQSVJBj5Y5siAjPwSTq6
+            HEuakZoaYogte44bQl74Wb/H34KmrOuPWjw7nQP7fNjA/7Ilj8fTSh8FROmviFsG
+            s9OjEI1p1nkvUaMPHa4KSmZnBFNFHmW7fsGH4ohNBwtOZSl/+c+U3NfQ5vqhdGoK
+            00FliYmX+DpjuYeXq82WciaaQxi+P32hXrb7Dpxk6TiqTeNk2wIDAQABo3wwejAd
+            BgNVHQ4EFgQUOh0PHxI8U0Qk8KDfb6+pg23T0k4wHwYDVR0jBBgwFoAUOh0PHxI8
+            U0Qk8KDfb6+pg23T0k4wDwYDVR0TAQH/BAUwAwEB/zAnBgNVHREEIDAeggtleGFt
+            cGxlLmNvbYIPd3d3LmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQCdbjSJ
+            26E7xtLoywxyHz/uYbeVMW+ZtQqHpDD5TgvZDLB5yAGShq3wJli22imsLyloHjjG
+            R6D7yPcJt9Fs+pXfxNNV+odZ1N6T3GWNZeatOBQpr1wmh1Ij7wu59IE+Tw6vLPMa
+            LjEE3vXtTUzINX2Z2eE1cabKppuB9xXoxQqan3R8iAxuuJeG4ngXdaJQO36U4c3t
+            jZr9QsqIRRvBSCYohZGX5cJizhrbUKMQBt+uNxMGSVo9OWt4Ff9luiS8muTOGCs1
+            Mds/9p3lJdzsNpYcuimh9h2A00Z84Xb6qc0dYExrcpDmZG85ip4UcP/d6NuZuBDl
+            +6O0CtYxit3sgmtb
+            -----END CERTIFICATE-----
+            """;
+
+    private String pkcs8Pem(String algorithm, ECGenParameterSpec ecSpec) throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm);
+        if (ecSpec != null) {
+            generator.initialize(ecSpec);
+        } else {
+            generator.initialize(2048);
+        }
+        PrivateKey privateKey = generator.generateKeyPair().getPrivate();
+        // PrivateKey.getEncoded() is PKCS#8 DER by contract.
+        String base64 = Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8))
+                .encodeToString(privateKey.getEncoded());
+        return "-----BEGIN PRIVATE KEY-----\n" + base64 + "\n-----END PRIVATE KEY-----\n";
+    }
+
+    @Test
+    void parseCertificateExtractsSubjectAndDnsNames() {
+        CertMeta meta = PemCertificateParser.parseCertificate(CERT_PEM);
+        assertTrue(meta.getSubject().contains("CN=example.com"));
+        assertTrue(meta.getNotAfter().isAfter(LocalDateTime.now()));
+        // CN + SAN entries, lowercased and de-duplicated
+        assertTrue(meta.getDnsNames().contains("example.com"));
+        assertTrue(meta.getDnsNames().contains("www.example.com"));
+        // "example.com" appears as both CN and SAN but must be de-duplicated
+        long exampleCount = meta.getDnsNames().stream().filter("example.com"::equals).count();
+        assertEquals(1, exampleCount, "example.com should not be duplicated");
+    }
+
+    @Test
+    void parseCertificateRejectsEmptyAndInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> PemCertificateParser.parseCertificate(null));
+        assertThrows(IllegalArgumentException.class, () -> PemCertificateParser.parseCertificate("  "));
+        assertThrows(IllegalArgumentException.class, () -> PemCertificateParser.parseCertificate("not a pem"));
+    }
+
+    @Test
+    void hostMatchesIsCaseInsensitiveAndWildcardAware() {
+        List<String> dnsNames = List.of("example.com", "*.example.com");
+        assertTrue(PemCertificateParser.hostMatches("example.com", dnsNames));
+        assertTrue(PemCertificateParser.hostMatches("EXAMPLE.COM", dnsNames));
+        // both sides strip the wildcard prefix before comparing
+        assertTrue(PemCertificateParser.hostMatches("*.example.com", dnsNames));
+    }
+
+    @Test
+    void hostMatchesFalseForNoMatchOrEmptyInputs() {
+        assertFalse(PemCertificateParser.hostMatches("other.com", List.of("example.com")));
+        assertFalse(PemCertificateParser.hostMatches(null, List.of("example.com")));
+        assertFalse(PemCertificateParser.hostMatches("example.com", List.of()));
+        assertFalse(PemCertificateParser.hostMatches("example.com", null));
+    }
+
+    @Test
+    void validatePrivateKeyAcceptsPkcs8RsaAndEc() throws Exception {
+        assertDoesNotThrow(() -> PemCertificateParser.validatePrivateKey(pkcs8Pem("RSA", null)));
+        assertDoesNotThrow(() ->
+                PemCertificateParser.validatePrivateKey(pkcs8Pem("EC", new ECGenParameterSpec("secp256r1"))));
+    }
+
+    @Test
+    void validatePrivateKeyRejectsLegacyPkcs1() {
+        String pkcs1 = "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJB\n-----END RSA PRIVATE KEY-----\n";
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> PemCertificateParser.validatePrivateKey(pkcs1));
+        assertTrue(exception.getMessage().contains("PKCS#1"));
+    }
+
+    @Test
+    void validatePrivateKeyRejectsEmptyAndNonPem() {
+        assertThrows(IllegalArgumentException.class, () -> PemCertificateParser.validatePrivateKey(null));
+        assertThrows(IllegalArgumentException.class, () -> PemCertificateParser.validatePrivateKey("  "));
+        assertThrows(IllegalArgumentException.class, () -> PemCertificateParser.validatePrivateKey("garbage"));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/shared/util/ResourceNameCheckerTests.java
+++ b/src/test/java/com/github/wellch4n/oops/shared/util/ResourceNameCheckerTests.java
@@ -1,0 +1,62 @@
+package com.github.wellch4n.oops.shared.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceNameCheckerTests {
+
+    @Test
+    void checkAcceptsValidLowercaseName() {
+        assertDoesNotThrow(() -> ResourceNameChecker.check("my-app1"));
+        assertDoesNotThrow(() -> ResourceNameChecker.check("a"));
+    }
+
+    @Test
+    void checkRejectsBlank() {
+        assertThrows(IllegalArgumentException.class, () -> ResourceNameChecker.check(null));
+        assertThrows(IllegalArgumentException.class, () -> ResourceNameChecker.check("   "));
+    }
+
+    @Test
+    void checkRejectsNamesOver24Characters() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ResourceNameChecker.check("a".repeat(25)));
+        assertDoesNotThrow(() -> ResourceNameChecker.check("a".repeat(24)));
+    }
+
+    @Test
+    void checkRejectsUppercase() {
+        assertThrows(IllegalArgumentException.class, () -> ResourceNameChecker.check("MyApp"));
+    }
+
+    @Test
+    void checkRejectsLeadingDigitOrHyphenAndTrailingHyphen() {
+        assertThrows(IllegalArgumentException.class, () -> ResourceNameChecker.check("1app"));
+        assertThrows(IllegalArgumentException.class, () -> ResourceNameChecker.check("-app"));
+        assertThrows(IllegalArgumentException.class, () -> ResourceNameChecker.check("app-"));
+    }
+
+    @Test
+    void environmentNameAllowsUppercase() {
+        assertDoesNotThrow(() -> ResourceNameChecker.checkEnvironmentName("Prod-1"));
+        assertDoesNotThrow(() -> ResourceNameChecker.checkEnvironmentName("A"));
+    }
+
+    @Test
+    void environmentNameRejectsBlankAndTooLong() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ResourceNameChecker.checkEnvironmentName(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> ResourceNameChecker.checkEnvironmentName("A".repeat(25)));
+    }
+
+    @Test
+    void environmentNameRejectsLeadingDigitAndTrailingHyphen() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ResourceNameChecker.checkEnvironmentName("1env"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ResourceNameChecker.checkEnvironmentName("env-"));
+    }
+}


### PR DESCRIPTION
Cover domain models, policies, value objects, converters, utilities, and command builders that contain branching/validation/transformation logic and have no Kubernetes or external-service dependencies. Tests follow the existing plain JUnit 5 style and run fully offline.

Areas covered:
- Routing: DomainPolicy longest-suffix host matching, wildcard stripping, validation
- Delivery: DeployStrategyPolicy ZIP resolution, Pipeline factories/predicates
- Application: collaborator dedup, source-type defaulting, build/health policies, service-config port handling, runtime Probe defaults, priority parsing
- Environment: credential/redaction helpers and DTO mapping
- Sandbox: SandboxDefaults sanitization, builtin runtime lookup
- Shared utils: ResourceNameChecker, EncryptionUtils round-trip, PemCertificateParser cert/key handling, Page pagination math
- Persistence: polymorphic PublishConfig/SourceConfig JSON converters
- Build: Git/Zip clone command builders

Private keys for PemCertificateParser are generated at runtime and the public test certificate is inlined, so no certificate or key files are committed.