### PR TITLE
feat(application): restrict pipeline operations to owner, collaborators, and admins

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/service/DeploymentService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/DeploymentService.java
@@ -5,6 +5,7 @@ import com.github.wellch4n.oops.application.port.PipelineBuildSubmission;
 import com.github.wellch4n.oops.application.port.repository.ApplicationRepository;
 import com.github.wellch4n.oops.application.port.repository.PipelineRepository;
 import com.github.wellch4n.oops.domain.application.Application;
+import com.github.wellch4n.oops.domain.application.ApplicationAccessPolicy;
 import com.github.wellch4n.oops.domain.application.ApplicationBuildConfig;
 import com.github.wellch4n.oops.domain.delivery.DeployStrategyPolicy;
 import com.github.wellch4n.oops.domain.delivery.DeploymentConcurrencyPolicy;
@@ -37,6 +38,8 @@ public class DeploymentService {
     private final PipelineBuildExecutor pipelineBuildExecutor;
     private final DeployStrategyPolicy deployStrategyPolicy;
     private final DeploymentConcurrencyPolicy deploymentConcurrencyPolicy;
+    private final ApplicationAccessPolicy applicationAccessPolicy;
+    private final UserService userService;
 
     public DeploymentService(ApplicationRepository applicationRepository,
                              PipelineRepository pipelineRepository,
@@ -44,7 +47,9 @@ public class DeploymentService {
                              PipelineBuildExecutor pipelineBuildExecutor,
                              ApplicationEventPublisher eventPublisher,
                              DeployStrategyPolicy deployStrategyPolicy,
-                             DeploymentConcurrencyPolicy deploymentConcurrencyPolicy) {
+                             DeploymentConcurrencyPolicy deploymentConcurrencyPolicy,
+                             ApplicationAccessPolicy applicationAccessPolicy,
+                             UserService userService) {
         this.applicationRepository = applicationRepository;
         this.pipelineRepository = pipelineRepository;
         this.environmentService = environmentService;
@@ -52,6 +57,8 @@ public class DeploymentService {
         this.eventPublisher = eventPublisher;
         this.deployStrategyPolicy = deployStrategyPolicy;
         this.deploymentConcurrencyPolicy = deploymentConcurrencyPolicy;
+        this.applicationAccessPolicy = applicationAccessPolicy;
+        this.userService = userService;
     }
 
     public String deployApplication(String namespace,
@@ -64,16 +71,18 @@ public class DeploymentService {
         if (request.strategy() == null) {
             throw new BizException("Deploy strategy is required");
         }
+        Application application = applicationRepository.findAggregate(namespace, applicationName);
+        if (application == null) {
+            throw new BizException("Application not found");
+        }
+        applicationAccessPolicy.ensureCanOperate(application, userService.findOperatorById(operatorUserId));
+
         deploymentConcurrencyPolicy.ensureNoActivePipeline(pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(
                 namespace, applicationName, deploymentConcurrencyPolicy.activePipelineStatuses()
         ));
 
         Environment environment = requireEnvironment(request.environment());
 
-        Application application = applicationRepository.findAggregate(namespace, applicationName);
-        if (application == null) {
-            throw new BizException("Application not found");
-        }
         ApplicationBuildConfig buildConfig = application.getBuildConfig();
         ApplicationSourceType sourceType = application.sourceType();
         ApplicationSourceType publishType = request.strategy().getType();

--- a/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
@@ -6,6 +6,7 @@ import com.github.wellch4n.oops.application.port.PipelineLogGateway;
 import com.github.wellch4n.oops.application.port.repository.ApplicationRepository;
 import com.github.wellch4n.oops.application.port.repository.PipelineRepository;
 import com.github.wellch4n.oops.domain.application.Application;
+import com.github.wellch4n.oops.domain.application.ApplicationAccessPolicy;
 import com.github.wellch4n.oops.domain.application.ApplicationExpertConfig;
 import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
 import com.github.wellch4n.oops.domain.application.ApplicationServiceConfig;
@@ -46,6 +47,7 @@ public class PipelineService {
     private final PipelineLogGateway pipelineLogGateway;
     private final PipelineStateMachine pipelineStateMachine;
     private final DeploymentConcurrencyPolicy deploymentConcurrencyPolicy;
+    private final ApplicationAccessPolicy applicationAccessPolicy;
 
     public PipelineService(PipelineRepository pipelineRepository, EnvironmentService environmentService,
                            ApplicationRepository applicationRepository,
@@ -55,7 +57,8 @@ public class PipelineService {
                            PipelineJobGateway pipelineJobGateway,
                            PipelineLogGateway pipelineLogGateway,
                            PipelineStateMachine pipelineStateMachine,
-                           DeploymentConcurrencyPolicy deploymentConcurrencyPolicy) {
+                           DeploymentConcurrencyPolicy deploymentConcurrencyPolicy,
+                           ApplicationAccessPolicy applicationAccessPolicy) {
         this.pipelineRepository = pipelineRepository;
         this.environmentService = environmentService;
         this.applicationRepository = applicationRepository;
@@ -66,6 +69,7 @@ public class PipelineService {
         this.pipelineLogGateway = pipelineLogGateway;
         this.pipelineStateMachine = pipelineStateMachine;
         this.deploymentConcurrencyPolicy = deploymentConcurrencyPolicy;
+        this.applicationAccessPolicy = applicationAccessPolicy;
     }
 
     public Page<PipelineDto> getPipelines(String namespace, String applicationName, String environment, Integer page, Integer size) {
@@ -136,11 +140,12 @@ public class PipelineService {
         return pipelineLogGateway.watch(pipeline, environment);
     }
 
-    public Boolean deployPipeline(String namespace, String applicationName, String id) {
+    public Boolean deployPipeline(String namespace, String applicationName, String id, String operatorUserId) {
         Pipeline pipeline = pipelineRepository.findByNamespaceAndApplicationNameAndId(namespace, applicationName, id);
         if (pipeline == null) {
             throw new BizException("Pipeline not found");
         }
+        Application application = requireOperableApplication(namespace, applicationName, operatorUserId);
         pipelineStateMachine.ensureManualDeployable(pipeline.getStatus());
         deploymentConcurrencyPolicy.ensureNoActivePipeline(pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(
                 namespace, applicationName, deploymentConcurrencyPolicy.activePipelineStatuses()
@@ -158,10 +163,6 @@ public class PipelineService {
 
         try {
             Environment environment = requireEnvironment(pipeline.getEnvironment());
-            Application application = applicationRepository.findAggregate(namespace, applicationName);
-            if (application == null) {
-                throw new BizException("Application not found");
-            }
             ApplicationRuntimeSpec.EnvironmentConfig runtimeSpec =
                     application.runtimeEnvironmentConfigOrDefault(pipeline.getEnvironment());
             ApplicationRuntimeSpec.HealthCheck healthCheck = application.healthCheckOrDefault();
@@ -197,6 +198,7 @@ public class PipelineService {
         if (StringUtils.isBlank(source.getArtifact())) {
             throw new BizException("Target pipeline has no artifact to deploy");
         }
+        Application application = requireOperableApplication(namespace, applicationName, operatorUserId);
 
         deploymentConcurrencyPolicy.ensureNoActivePipeline(pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(
                 namespace, applicationName, deploymentConcurrencyPolicy.activePipelineStatuses()
@@ -219,10 +221,6 @@ public class PipelineService {
 
         try {
             Environment environment = requireEnvironment(rollbackPipeline.getEnvironment());
-            Application application = applicationRepository.findAggregate(namespace, applicationName);
-            if (application == null) {
-                throw new BizException("Application not found");
-            }
             ApplicationRuntimeSpec.EnvironmentConfig runtimeSpec =
                     application.runtimeEnvironmentConfigOrDefault(rollbackPipeline.getEnvironment());
             ApplicationRuntimeSpec.HealthCheck healthCheck = application.healthCheckOrDefault();
@@ -247,11 +245,12 @@ public class PipelineService {
         return rollbackPipeline.getId();
     }
 
-    public Boolean stopPipeline(String namespace, String applicationName, String id) {
+    public Boolean stopPipeline(String namespace, String applicationName, String id, String operatorUserId) {
         Pipeline pipeline = pipelineRepository.findByNamespaceAndApplicationNameAndId(namespace, applicationName, id);
         if (pipeline == null) {
             throw new BizException("Pipeline not found");
         }
+        requireOperableApplication(namespace, applicationName, operatorUserId);
         pipelineStateMachine.ensureCanTransition(pipeline.getStatus(), PipelineStatus.STOPPED);
 
         if (pipeline.getStatus() == PipelineStatus.BUILD_SUCCEEDED) {
@@ -295,5 +294,11 @@ public class PipelineService {
             throw new BizException("Environment not found: " + environmentName);
         }
         return environment;
+    }
+
+    private Application requireOperableApplication(String namespace, String applicationName, String operatorUserId) {
+        Application application = applicationRepository.findAggregate(namespace, applicationName);
+        applicationAccessPolicy.ensureCanOperate(application, userService.findOperatorById(operatorUserId));
+        return application;
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/application/service/UserService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/UserService.java
@@ -4,6 +4,7 @@ import com.github.wellch4n.oops.application.dto.Page;
 import com.github.wellch4n.oops.application.port.repository.PageResult;
 import com.github.wellch4n.oops.application.port.repository.UserRepository;
 import com.github.wellch4n.oops.domain.identity.User;
+import com.github.wellch4n.oops.domain.shared.Operator;
 import com.github.wellch4n.oops.domain.shared.UserRole;
 import com.github.wellch4n.oops.shared.exception.BizException;
 import com.github.wellch4n.oops.shared.util.NanoIdUtils;
@@ -34,6 +35,12 @@ public class UserService {
 
     public Optional<User> findById(String id) {
         return userRepository.findById(id);
+    }
+
+    public Operator findOperatorById(String userId) {
+        return userRepository.findById(userId)
+                .map(user -> new Operator(user.getId(), user.getRole(), !Boolean.FALSE.equals(user.getEnabled())))
+                .orElse(null);
     }
 
     public Optional<User> findByEmail(String email) {

--- a/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationAccessPolicy.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/application/ApplicationAccessPolicy.java
@@ -1,0 +1,29 @@
+package com.github.wellch4n.oops.domain.application;
+
+import com.github.wellch4n.oops.domain.shared.Operator;
+import com.github.wellch4n.oops.shared.exception.BizException;
+
+/**
+ * Access rules for operating an application: only the owner, collaborators,
+ * or an admin may deploy (release, manual deploy, rollback) or stop a pipeline.
+ */
+public class ApplicationAccessPolicy {
+
+    public void ensureCanOperate(Application application, Operator operator) {
+        if (application == null) {
+            throw new BizException("Application not found");
+        }
+        if (operator == null || !operator.enabled()) {
+            throw new BizException("Permission denied");
+        }
+        if (operator.isAdmin()) {
+            return;
+        }
+        String userId = operator.userId();
+        if (userId != null && !userId.isBlank()
+                && (userId.equals(application.getOwner()) || application.collaboratorUserIds().contains(userId))) {
+            return;
+        }
+        throw new BizException("Permission denied");
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/domain/shared/Operator.java
+++ b/src/main/java/com/github/wellch4n/oops/domain/shared/Operator.java
@@ -1,0 +1,12 @@
+package com.github.wellch4n.oops.domain.shared;
+
+/**
+ * Minimal view of the user performing an operation, carrying only what
+ * access policies need — never credentials or tokens.
+ */
+public record Operator(String userId, UserRole role, boolean enabled) {
+
+    public boolean isAdmin() {
+        return role == UserRole.ADMIN;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/config/PolicyConfiguration.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/config/PolicyConfiguration.java
@@ -1,5 +1,6 @@
 package com.github.wellch4n.oops.infrastructure.config;
 
+import com.github.wellch4n.oops.domain.application.ApplicationAccessPolicy;
 import com.github.wellch4n.oops.domain.application.ApplicationBuildConfigPolicy;
 import com.github.wellch4n.oops.domain.application.HealthCheckPolicy;
 import com.github.wellch4n.oops.domain.delivery.DeployStrategyPolicy;
@@ -11,6 +12,11 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class PolicyConfiguration {
+
+    @Bean
+    public ApplicationAccessPolicy applicationAccessPolicy() {
+        return new ApplicationAccessPolicy();
+    }
 
     @Bean
     public ApplicationBuildConfigPolicy applicationBuildConfigPolicy() {

--- a/src/main/java/com/github/wellch4n/oops/interfaces/rest/PipelineController.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/rest/PipelineController.java
@@ -47,16 +47,20 @@ public class PipelineController {
     @PreAuthorize("isAuthenticated()")
     public Result<Boolean> stopPipeline(@PathVariable String namespace,
                                         @PathVariable String name,
-                                        @PathVariable String id) {
-        return Result.success(pipelineService.stopPipeline(namespace, name, id));
+                                        @PathVariable String id,
+                                        Authentication authentication) {
+        AuthUserPrincipal principal = (AuthUserPrincipal) authentication.getPrincipal();
+        return Result.success(pipelineService.stopPipeline(namespace, name, id, principal.userId()));
     }
 
     @PutMapping("/{id}/deploy")
     @PreAuthorize("isAuthenticated()")
     public Result<Boolean> deployPipeline(@PathVariable String namespace,
                                           @PathVariable String name,
-                                          @PathVariable String id) {
-        return Result.success(pipelineService.deployPipeline(namespace, name, id));
+                                          @PathVariable String id,
+                                          Authentication authentication) {
+        AuthUserPrincipal principal = (AuthUserPrincipal) authentication.getPrincipal();
+        return Result.success(pipelineService.deployPipeline(namespace, name, id, principal.userId()));
     }
 
     @PostMapping("/{id}/rollback")

--- a/src/test/java/com/github/wellch4n/oops/application/service/PipelineHealthVerificationTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/service/PipelineHealthVerificationTests.java
@@ -14,11 +14,14 @@ import com.github.wellch4n.oops.application.port.PipelineLogGateway;
 import com.github.wellch4n.oops.application.port.repository.ApplicationRepository;
 import com.github.wellch4n.oops.application.port.repository.PipelineRepository;
 import com.github.wellch4n.oops.domain.application.Application;
+import com.github.wellch4n.oops.domain.application.ApplicationAccessPolicy;
 import com.github.wellch4n.oops.domain.delivery.DeploymentConcurrencyPolicy;
 import com.github.wellch4n.oops.domain.delivery.Pipeline;
 import com.github.wellch4n.oops.domain.delivery.PipelineStateMachine;
 import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.shared.Operator;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.domain.shared.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -40,6 +43,7 @@ class PipelineHealthVerificationTests {
     private EnvironmentService environmentService;
     private ApplicationRepository applicationRepository;
     private ArtifactDeploymentExecutor artifactDeploymentExecutor;
+    private UserService userService;
     private PipelineService pipelineService;
 
     @BeforeEach
@@ -47,7 +51,7 @@ class PipelineHealthVerificationTests {
         pipelineRepository = Mockito.mock(PipelineRepository.class);
         environmentService = Mockito.mock(EnvironmentService.class);
         applicationRepository = Mockito.mock(ApplicationRepository.class);
-        UserService userService = Mockito.mock(UserService.class);
+        userService = Mockito.mock(UserService.class);
         ApplicationEventPublisher eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
         artifactDeploymentExecutor = Mockito.mock(ArtifactDeploymentExecutor.class);
         PipelineJobGateway pipelineJobGateway = Mockito.mock(PipelineJobGateway.class);
@@ -63,7 +67,8 @@ class PipelineHealthVerificationTests {
                 pipelineJobGateway,
                 pipelineLogGateway,
                 PipelineStateMachine.getInstance(),
-                new DeploymentConcurrencyPolicy()
+                new DeploymentConcurrencyPolicy(),
+                new ApplicationAccessPolicy()
         );
     }
 
@@ -99,7 +104,11 @@ class PipelineHealthVerificationTests {
         Application application = new Application();
         application.setName(APP_NAME);
         application.setNamespace(NAMESPACE);
+        application.setOwner("operator-1");
         when(applicationRepository.findAggregate(NAMESPACE, APP_NAME)).thenReturn(application);
+
+        when(userService.findOperatorById("operator-1"))
+                .thenReturn(new Operator("operator-1", UserRole.USER, true));
 
         String resultId = pipelineService.rollback(NAMESPACE, APP_NAME, SOURCE_ID, "operator-1");
 

--- a/src/test/java/com/github/wellch4n/oops/application/service/PipelineRollbackTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/service/PipelineRollbackTests.java
@@ -15,6 +15,7 @@ import com.github.wellch4n.oops.application.port.PipelineLogGateway;
 import com.github.wellch4n.oops.application.port.repository.ApplicationRepository;
 import com.github.wellch4n.oops.application.port.repository.PipelineRepository;
 import com.github.wellch4n.oops.domain.application.Application;
+import com.github.wellch4n.oops.domain.application.ApplicationAccessPolicy;
 import com.github.wellch4n.oops.domain.application.ApplicationExpertConfig;
 import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
 import com.github.wellch4n.oops.domain.application.ApplicationServiceConfig;
@@ -22,8 +23,10 @@ import com.github.wellch4n.oops.domain.delivery.DeploymentConcurrencyPolicy;
 import com.github.wellch4n.oops.domain.delivery.Pipeline;
 import com.github.wellch4n.oops.domain.delivery.PipelineStateMachine;
 import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.domain.shared.Operator;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
 import com.github.wellch4n.oops.domain.shared.PipelineTriggerType;
+import com.github.wellch4n.oops.domain.shared.UserRole;
 import com.github.wellch4n.oops.shared.exception.BizException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +70,8 @@ class PipelineRollbackTests {
                 pipelineJobGateway,
                 pipelineLogGateway,
                 PipelineStateMachine.getInstance(),
-                new DeploymentConcurrencyPolicy()
+                new DeploymentConcurrencyPolicy(),
+                new ApplicationAccessPolicy()
         );
     }
 
@@ -100,7 +104,13 @@ class PipelineRollbackTests {
         Application application = new Application();
         application.setName(APP_NAME);
         application.setNamespace(NAMESPACE);
+        application.setOwner("operator-1");
         when(applicationRepository.findAggregate(NAMESPACE, APP_NAME)).thenReturn(application);
+        when(userService.findOperatorById("operator-1")).thenReturn(operator());
+    }
+
+    private Operator operator() {
+        return new Operator("operator-1", UserRole.USER, true);
     }
 
     @Test
@@ -165,6 +175,12 @@ class PipelineRollbackTests {
     void rollbackBlockedByActivePipeline() {
         when(pipelineRepository.findByNamespaceAndApplicationNameAndId(NAMESPACE, APP_NAME, SOURCE_ID))
                 .thenReturn(succeededSource());
+        Application application = new Application();
+        application.setName(APP_NAME);
+        application.setNamespace(NAMESPACE);
+        application.setOwner("operator-1");
+        when(applicationRepository.findAggregate(NAMESPACE, APP_NAME)).thenReturn(application);
+        when(userService.findOperatorById("operator-1")).thenReturn(operator());
         when(pipelineRepository.existsByNamespaceAndApplicationNameAndStatusIn(eq(NAMESPACE), eq(APP_NAME), anyList()))
                 .thenReturn(true);
 

--- a/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationAccessPolicyTests.java
+++ b/src/test/java/com/github/wellch4n/oops/domain/application/ApplicationAccessPolicyTests.java
@@ -1,0 +1,74 @@
+package com.github.wellch4n.oops.domain.application;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.wellch4n.oops.domain.shared.Operator;
+import com.github.wellch4n.oops.domain.shared.UserRole;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApplicationAccessPolicyTests {
+
+    private final ApplicationAccessPolicy policy = new ApplicationAccessPolicy();
+
+    private Application application;
+
+    @BeforeEach
+    void setUp() {
+        application = new Application();
+        application.setNamespace("default");
+        application.setName("demo");
+        application.setOwner("owner-1");
+        application.changeCollaborators(List.of("collaborator-1"));
+    }
+
+    @Test
+    void ownerCanDeploy() {
+        assertDoesNotThrow(() -> policy.ensureCanOperate(application,
+                new Operator("owner-1", UserRole.USER, true)));
+    }
+
+    @Test
+    void collaboratorCanDeploy() {
+        assertDoesNotThrow(() -> policy.ensureCanOperate(application,
+                new Operator("collaborator-1", UserRole.USER, true)));
+    }
+
+    @Test
+    void adminCanDeploy() {
+        assertDoesNotThrow(() -> policy.ensureCanOperate(application,
+                new Operator("someone-else", UserRole.ADMIN, true)));
+    }
+
+    @Test
+    void otherUserCannotDeploy() {
+        assertThrows(BizException.class, () -> policy.ensureCanOperate(application,
+                new Operator("someone-else", UserRole.USER, true)));
+    }
+
+    @Test
+    void missingOperatorCannotDeploy() {
+        assertThrows(BizException.class, () -> policy.ensureCanOperate(application, null));
+    }
+
+    @Test
+    void disabledOperatorCannotDeploy() {
+        assertThrows(BizException.class, () -> policy.ensureCanOperate(application,
+                new Operator("owner-1", UserRole.USER, false)));
+    }
+
+    @Test
+    void blankOperatorIdCannotDeploy() {
+        assertThrows(BizException.class, () -> policy.ensureCanOperate(application,
+                new Operator(" ", UserRole.USER, true)));
+    }
+
+    @Test
+    void missingApplicationIsRejected() {
+        assertThrows(BizException.class, () -> policy.ensureCanOperate(null,
+                new Operator("owner-1", UserRole.ADMIN, true)));
+    }
+}


### PR DESCRIPTION
Previously every authenticated user could deploy, manually deploy, roll back, or stop any application's pipelines - the only server-side ownership check in the codebase guarded application deletion.

Introduce ApplicationAccessPolicy, a pure domain policy that allows an operation only when the operator is the application owner, a collaborator, or an admin. Disabled or deleted user accounts are rejected outright. The policy consumes a new Operator value object in domain/shared (userId, role, enabled) so the application aggregate does not depend on the identity aggregate and access decisions never see credential fields such as password or accessToken. UserService gains findOperatorById to map User to Operator at the application layer.

Wire the check into all four user-triggered pipeline entry points: DeploymentService.deployApplication, PipelineService.deployPipeline, PipelineService.rollback, and PipelineService.stopPipeline. The latter two controller endpoints now pass the authenticated principal through. Authorization runs before the concurrency pre-check so unauthorized callers get "Permission denied" without triggering extra queries, and the access helper returns the loaded Application aggregate, removing a duplicate findAggregate call from the deploy and rollback paths.

Covered by ApplicationAccessPolicyTests (owner, collaborator, admin, stranger, disabled, missing user/application); existing pipeline tests updated for the new constructor and operator stubs.