### PR TITLE
refactor(web): align colors and radii to the theme token scale

### DIFF
--- a/web/app/apps/[namespace]/[name]/pipelines/[pipelineId]/page.tsx
+++ b/web/app/apps/[namespace]/[name]/pipelines/[pipelineId]/page.tsx
@@ -8,6 +8,7 @@ import { API_BASE_URL } from "@/lib/api/config"
 import { getToken } from "@/lib/auth"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { ConnectionLostBanner } from "@/components/connection-lost-banner"
 import { Copyable } from "@/components/ui/copyable"
 import {
   AlertDialog,
@@ -24,7 +25,7 @@ import { DataTable } from "@/components/ui/data-table"
 import { getPipelineStatusColumns } from "../columns"
 import { toast } from "sonner"
 import dayjs from "dayjs"
-import { AlertTriangle, ExternalLink, Check, ArrowUpRight, RefreshCw, Rocket, Ban, WifiOff, FileText, ChevronDown } from "lucide-react"
+import { AlertTriangle, ExternalLink, Check, ArrowUpRight, Rocket, Ban, FileText, ChevronDown } from "lucide-react"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import Link from "next/link"
 import { useLanguage } from "@/contexts/language-context"
@@ -378,32 +379,19 @@ export default function PipelineDetailPage({ params }: PageProps) {
     <ContentPage title={t("apps.pipeline.title")} fullHeight>
       <div className="flex flex-1 min-h-0 flex-col gap-4">
         {wsDisconnected && (
-          <div
-            role="status"
-            className="flex shrink-0 items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100"
-          >
-            <div className="flex min-w-0 items-center gap-2 text-sm">
-              <WifiOff className="size-4 shrink-0" />
-              <span className="truncate">{t("common.disconnected")}</span>
-            </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => window.location.reload()}
-              className="shrink-0 bg-background/80 text-foreground hover:bg-background"
-            >
-              <RefreshCw className="size-3" />
-              {t("common.refresh")}
-            </Button>
-          </div>
+          <ConnectionLostBanner
+            className="rounded-md"
+            message={t("common.disconnected")}
+            retryLabel={t("common.refresh")}
+          />
         )}
 
         {pipeline?.status === "ERROR" && pipeline.message && (
           <div
             role="alert"
-            className="flex shrink-0 items-start gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-100"
+            className="flex shrink-0 items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-foreground"
           >
-            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
             <div className="min-w-0">
               <div className="font-medium">{t("apps.pipeline.message")}</div>
               <div className="mt-1 flex flex-wrap items-center gap-2">

--- a/web/app/apps/[namespace]/[name]/pipelines/columns.tsx
+++ b/web/app/apps/[namespace]/[name]/pipelines/columns.tsx
@@ -21,10 +21,10 @@ const DeployStatusCell = memo(({ images, namespace, appName, pipelineId }: Deplo
   const tag = firstImage.includes(":") ? firstImage.split(":").pop()! : ""
   const versionMached = tag === pipelineId
   const icon = !tag ? null : versionMached ? (
-    <Check className="size-4 text-green-500" />
+    <Check className="size-4 text-success" />
   ) : (
     <Link href={`/apps/${namespace}/${appName}/pipelines/${tag}`}>
-      <X className="size-4 text-red-500 cursor-pointer" />
+      <X className="size-4 text-destructive cursor-pointer" />
     </Link>
   )
   return (

--- a/web/app/apps/[namespace]/[name]/pods/[pod]/logs/page.tsx
+++ b/web/app/apps/[namespace]/[name]/pods/[pod]/logs/page.tsx
@@ -4,12 +4,11 @@ import { Suspense, useEffect, useRef, useState } from "react"
 import { useParams, useSearchParams } from "next/navigation"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { ConnectionLostBanner } from "@/components/connection-lost-banner"
 import { API_BASE_URL } from "@/lib/api/config"
 import { getToken } from "@/lib/auth"
 import { useLanguage } from "@/contexts/language-context"
 import { ContentPage } from "@/components/content-page"
-import { RefreshCw, WifiOff } from "lucide-react"
 
 interface LogLine {
   id: number
@@ -110,7 +109,7 @@ function ApplicationPodLogsContent() {
       actions={
         <div className="flex items-center gap-3">
           <span
-            className={`size-2 rounded-full ${isConnected ? "bg-green-500" : "bg-gray-400"}`}
+            className={`size-2 rounded-full ${isConnected ? "bg-success" : "bg-muted-foreground"}`}
           />
           <Badge className="bg-orange-500 text-white">{env}</Badge>
         </div>
@@ -118,24 +117,10 @@ function ApplicationPodLogsContent() {
     >
       <div className="flex h-full min-h-0 flex-col">
         {connectionStatus === "disconnected" && (
-          <div
-            role="status"
-            className="flex shrink-0 items-center justify-between gap-3 border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100"
-          >
-            <div className="flex min-w-0 items-center gap-2 text-sm">
-              <WifiOff className="size-4 shrink-0" />
-              <span className="truncate">{t("common.disconnected")}</span>
-            </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => window.location.reload()}
-              className="shrink-0 bg-background/80 text-foreground hover:bg-background"
-            >
-              <RefreshCw className="size-3" />
-              {t("common.refresh")}
-            </Button>
-          </div>
+          <ConnectionLostBanner
+            message={t("common.disconnected")}
+            retryLabel={t("common.refresh")}
+          />
         )}
 
         <div className="flex-1 min-h-0 bg-zinc-950 p-4 overflow-hidden font-mono text-xs text-white">

--- a/web/app/apps/[namespace]/[name]/pods/[pod]/terminal/page.tsx
+++ b/web/app/apps/[namespace]/[name]/pods/[pod]/terminal/page.tsx
@@ -5,8 +5,7 @@ import dynamic from "next/dynamic"
 import { useParams, useSearchParams } from "next/navigation"
 import { ContentPage } from "@/components/content-page"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { RefreshCw, WifiOff } from "lucide-react"
+import { ConnectionLostBanner } from "@/components/connection-lost-banner"
 import { useLanguage } from "@/contexts/language-context"
 import { createPodDirectory, deletePodPath, getPodFileContent, getPodFileDownloadUrl, listPodDirectory, renamePodPath, savePodFileContent, uploadPodFile } from "@/lib/api/pod-files"
 
@@ -140,7 +139,7 @@ function TerminalPageContent() {
       actions={
         <div className="flex items-center gap-3">
           <span
-            className={`size-2 rounded-full ${isConnected ? "bg-green-500" : "bg-gray-400"}`}
+            className={`size-2 rounded-full ${isConnected ? "bg-success" : "bg-muted-foreground"}`}
           />
           <Badge className="bg-orange-500 text-white">{env}</Badge>
         </div>
@@ -148,24 +147,10 @@ function TerminalPageContent() {
     >
       <div className="flex h-full min-h-0 flex-col">
         {connectionStatus === "disconnected" && (
-          <div
-            role="status"
-            className="flex shrink-0 items-center justify-between gap-3 border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100"
-          >
-            <div className="flex min-w-0 items-center gap-2 text-sm">
-              <WifiOff className="size-4 shrink-0" />
-              <span className="truncate">{t("common.disconnected")}</span>
-            </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => window.location.reload()}
-              className="shrink-0 bg-background/80 text-foreground hover:bg-background"
-            >
-              <RefreshCw className="size-3" />
-              {t("common.refresh")}
-            </Button>
-          </div>
+          <ConnectionLostBanner
+            message={t("common.disconnected")}
+            retryLabel={t("common.refresh")}
+          />
         )}
         <div
           ref={containerRef}

--- a/web/app/apps/application-form.tsx
+++ b/web/app/apps/application-form.tsx
@@ -234,7 +234,7 @@ function ApplicationFormContent({
               <TabsTrigger value="config-info" className="px-6 cursor-pointer">{t("apps.tab.configMgmt")}</TabsTrigger>
               <TabsTrigger value="expert-config" className="px-6 cursor-pointer">{t("apps.tab.expertConfig")}</TabsTrigger>
               {canSeeDangerZone && (
-                <TabsTrigger value="danger-zone" className="px-6 cursor-pointer data-[state=active]:bg-red-600 data-[state=active]:text-white dark:data-[state=active]:bg-red-600 dark:data-[state=active]:text-white dark:data-[state=active]:border-red-600">{t("apps.tab.dangerZone")}</TabsTrigger>
+                <TabsTrigger value="danger-zone" className="px-6 cursor-pointer data-[state=active]:bg-destructive data-[state=active]:text-white dark:data-[state=active]:border-destructive">{t("apps.tab.dangerZone")}</TabsTrigger>
               )}
             </TabsList>
           )}
@@ -316,7 +316,7 @@ function ApplicationFormContent({
         </TabsContent>
 
         {canSeeDangerZone && (
-          <TabsContent value="danger-zone" className="rounded-md border border-red-200 dark:border-red-900 bg-background p-4">
+          <TabsContent value="danger-zone" className="rounded-md border border-destructive/30 bg-background p-4">
             <ApplicationDangerZone
               namespace={formState.application?.namespace ?? ""}
               name={formState.application?.name ?? ""}

--- a/web/app/apps/components/application-config-info.tsx
+++ b/web/app/apps/components/application-config-info.tsx
@@ -201,7 +201,7 @@ function SortableConfigRow({
                   </div>
                 </FormControl>
                 {showEnvNameWarning && (
-                  <p className="mt-1 text-xs text-amber-600">{t("apps.config.envNameWarning")}</p>
+                  <p className="mt-1 text-xs text-warning">{t("apps.config.envNameWarning")}</p>
                 )}
                 <FormMessage />
               </FormItem>
@@ -388,7 +388,7 @@ function SortableConfigRow({
                         <button
                           key={group}
                           type="button"
-                          className="flex w-full items-center rounded px-2 py-1.5 text-sm hover:bg-accent cursor-pointer"
+                          className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent cursor-pointer"
                           onMouseDown={(event) => {
                             // mousedown (before blur) so the click registers before the list unmounts.
                             event.preventDefault()

--- a/web/app/apps/components/application-danger-zone.tsx
+++ b/web/app/apps/components/application-danger-zone.tsx
@@ -110,11 +110,11 @@ export function ApplicationDangerZone({ namespace, name }: ApplicationDangerZone
   return (
     <div className="w-full space-y-6">
       <div className="space-y-2">
-        <h3 className="text-base font-medium text-red-500">{t("apps.danger.title")}</h3>
+        <h3 className="text-base font-medium text-destructive">{t("apps.danger.title")}</h3>
         <p className="text-sm text-muted-foreground">{t("apps.danger.desc")}</p>
       </div>
 
-      <div className="flex items-center justify-between gap-4 rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/20 p-4">
+      <div className="flex items-center justify-between gap-4 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
         <div className="space-y-1">
           <p className="text-sm font-medium">{t("apps.danger.migrateBtn")}</p>
           <p className="text-xs text-muted-foreground">{t("apps.danger.migrateDesc")}</p>
@@ -147,7 +147,7 @@ export function ApplicationDangerZone({ namespace, name }: ApplicationDangerZone
         </div>
       </div>
 
-      <div className="flex items-center justify-between rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/20 p-4">
+      <div className="flex items-center justify-between rounded-lg border border-destructive/30 bg-destructive/5 p-4">
         <div className="space-y-1">
           <p className="text-sm font-medium">{t("apps.danger.deleteBtn")}</p>
           <p className="text-xs text-muted-foreground">

--- a/web/app/apps/components/env-import-dialog.tsx
+++ b/web/app/apps/components/env-import-dialog.tsx
@@ -144,21 +144,21 @@ export function EnvImportDialog({
             {/* New config items to add */}
             {toAdd.length > 0 && (
               <div className="space-y-2">
-                <Label className="text-sm font-medium text-green-600">
+                <Label className="text-sm font-medium text-success">
                   {t("apps.config.newEntries")} ({toAdd.length})
                 </Label>
-                <div className="rounded-md border bg-green-50 dark:bg-green-950/20 p-3 space-y-2">
+                <div className="rounded-md border bg-success/10 p-3 space-y-2">
                   {toAdd.map(entry => (
                     <div key={entry.key} className="flex items-center gap-2 text-sm">
-                      <span className="font-mono text-green-700 dark:text-green-400">{entry.key}</span>
+                      <span className="font-mono text-success">{entry.key}</span>
                       {importMode === "key-value" && (
                         <>
                           <span className="text-muted-foreground">=</span>
-                          <span className="font-mono text-green-600 dark:text-green-500 truncate">{entry.value}</span>
+                          <span className="font-mono text-success truncate">{entry.value}</span>
                         </>
                       )}
                       {entry.group && (
-                        <span className="rounded bg-green-100 dark:bg-green-900/40 px-1.5 py-0.5 text-xs text-green-700 dark:text-green-400">
+                        <span className="rounded-sm bg-success/15 px-1.5 py-0.5 text-xs text-success">
                           {entry.group}
                         </span>
                       )}
@@ -171,10 +171,10 @@ export function EnvImportDialog({
             {/* Config items to replace (key-value mode only) */}
             {importMode === "key-value" && toReplace.length > 0 && (
               <div className="space-y-2">
-                <Label className="text-sm font-medium text-amber-600">
+                <Label className="text-sm font-medium text-warning">
                   {t("apps.config.valueConflict")} ({toReplace.length})
                 </Label>
-                <div className="rounded-md border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-900 p-3 space-y-3">
+                <div className="rounded-md border border-warning/30 bg-warning/10 p-3 space-y-3">
                   {toReplace.map(entry => (
                     <div key={entry.new.key} className="space-y-1">
                       <div className="flex items-center gap-2">
@@ -195,13 +195,13 @@ export function EnvImportDialog({
                           <>
                             <div className="flex items-center gap-2">
                               <span className="text-muted-foreground">{t("apps.config.currentValue")}：</span>
-                              <span className="font-mono text-red-600 dark:text-red-400 line-through">
+                              <span className="font-mono text-destructive line-through">
                                 {entry.old.value || `(${t("common.empty")})`}
                               </span>
                             </div>
                             <div className="flex items-center gap-2">
                               <span className="text-muted-foreground">{t("apps.config.newValue")}：</span>
-                              <span className="font-mono text-green-600 dark:text-green-400">
+                              <span className="font-mono text-success">
                                 {entry.new.value || `(${t("common.empty")})`}
                               </span>
                             </div>
@@ -251,7 +251,7 @@ export function EnvImportDialog({
                     {noConflict.map(entry => (
                       <span
                         key={entry.key}
-                        className="font-mono text-xs px-2 py-1 bg-muted rounded text-muted-foreground"
+                        className="font-mono text-xs px-2 py-1 bg-muted rounded-sm text-muted-foreground"
                       >
                         {entry.key}
                       </span>

--- a/web/app/assets/columns.tsx
+++ b/web/app/assets/columns.tsx
@@ -56,7 +56,7 @@ export const getColumns = (t: (key: string) => string): ColumnDef<AssetEntry>[] 
               width={32}
               height={32}
               unoptimized
-              className="size-8 rounded object-cover border"
+              className="size-8 rounded-sm object-cover border"
             />
           ) : (
             <FileText className="size-4 text-muted-foreground" />

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -27,6 +27,8 @@
   --color-destructive: var(--destructive);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -67,6 +69,8 @@
   --destructive: oklch(0.577 0.245 27.325);
   --warning: oklch(0.78 0.15 70);
   --warning-foreground: oklch(0.145 0 0);
+  --success: oklch(0.6 0.145 150);
+  --success-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.58 0.23 254);
@@ -103,6 +107,8 @@
   --destructive: oklch(0.704 0.191 22.216);
   --warning: oklch(0.7 0.16 70);
   --warning-foreground: oklch(0.145 0 0);
+  --success: oklch(0.696 0.17 162.48);
+  --success-foreground: oklch(0.145 0 0);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.58 0.23 254);

--- a/web/app/ides/page.tsx
+++ b/web/app/ides/page.tsx
@@ -426,7 +426,7 @@ function IDEPageContent() {
                     >
                       <div className="flex items-center gap-2 min-w-0">
                         <span
-                          className={`shrink-0 size-2 rounded-full ${ide.ready ? "bg-green-500" : "bg-yellow-400 animate-pulse"}`}
+                          className={`shrink-0 size-2 rounded-full ${ide.ready ? "bg-success" : "bg-warning animate-pulse"}`}
                           title={ide.ready ? t("ide.statusReady") : t("ide.statusPending")}
                         />
                         <div className="flex flex-col gap-0.5 min-w-0">

--- a/web/app/sandboxes/[id]/page.tsx
+++ b/web/app/sandboxes/[id]/page.tsx
@@ -4,11 +4,11 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import Link from "next/link"
 import dynamic from "next/dynamic"
 import { useParams } from "next/navigation"
-import { Info, RefreshCw, WifiOff } from "lucide-react"
+import { Info } from "lucide-react"
 import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { ConnectionLostBanner } from "@/components/connection-lost-banner"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { ContentPage } from "@/components/content-page"
@@ -204,31 +204,17 @@ export default function SandboxDetailPage() {
       bodyClassName="flex flex-1 min-h-0 flex-col pt-0 pb-0 overflow-hidden"
       actions={
         <div className="flex items-center gap-3">
-          <span className={`size-2 rounded-full ${isConnected ? "bg-green-500" : "bg-gray-400"}`} />
+          <span className={`size-2 rounded-full ${isConnected ? "bg-success" : "bg-muted-foreground"}`} />
           <StatusBadge status={sandbox.status} />
         </div>
       }
     >
       <div className="flex h-full min-h-0 flex-col">
         {connectionStatus === "disconnected" && (
-          <div
-            role="status"
-            className="flex shrink-0 items-center justify-between gap-3 border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100"
-          >
-            <div className="flex min-w-0 items-center gap-2 text-sm">
-              <WifiOff className="size-4 shrink-0" />
-              <span className="truncate">{t("common.disconnected")}</span>
-            </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => window.location.reload()}
-              className="shrink-0 bg-background/80 text-foreground hover:bg-background"
-            >
-              <RefreshCw className="size-3" />
-              {t("common.refresh")}
-            </Button>
-          </div>
+          <ConnectionLostBanner
+            message={t("common.disconnected")}
+            retryLabel={t("common.refresh")}
+          />
         )}
         {sandbox.status === "RUNNING" ? (
           <div ref={containerRef} className="flex min-h-0 flex-1 flex-row overflow-hidden">

--- a/web/app/settings/environments/[id]/page.tsx
+++ b/web/app/settings/environments/[id]/page.tsx
@@ -307,7 +307,7 @@ export default function EnvironmentEditPage() {
                         size="sm"
                         onClick={handleValidateK8s}
                         disabled={isValidatingK8s || isK8sValidated}
-                        className={isK8sValidated ? "text-green-600 border-green-600 hover:text-green-600" : ""}
+                        className={isK8sValidated ? "text-success border-success hover:text-success" : ""}
                       >
                         {isValidatingK8s && <Loader2 className="size-3 animate-spin" />}
                         {isK8sValidated ? (
@@ -412,7 +412,7 @@ export default function EnvironmentEditPage() {
                         size="sm"
                         onClick={handleValidateRepo}
                         disabled={isValidatingRepo || isRepoValidated}
-                        className={isRepoValidated ? "text-green-600 border-green-600 hover:text-green-600" : ""}
+                        className={isRepoValidated ? "text-success border-success hover:text-success" : ""}
                       >
                         {isValidatingRepo && <Loader2 className="size-3 animate-spin" />}
                         {isRepoValidated ? (
@@ -588,12 +588,12 @@ export default function EnvironmentEditPage() {
                   </div>
 
                   {/* Danger Zone Block */}
-                  <div className="border border-red-200 dark:border-red-900 rounded-lg overflow-hidden">
-                    <div className="flex items-center gap-2 px-4 py-3 bg-red-50 dark:bg-red-950/30 border-b border-red-200 dark:border-red-900">
-                      <AlertTriangle className="size-4 text-red-500" />
-                      <span className="text-sm font-semibold text-red-500">{t("env.dangerZone")}</span>
+                  <div className="border border-destructive/30 rounded-lg overflow-hidden">
+                    <div className="flex items-center gap-2 px-4 py-3 bg-destructive/10 border-b border-destructive/30">
+                      <AlertTriangle className="size-4 text-destructive" />
+                      <span className="text-sm font-semibold text-destructive">{t("env.dangerZone")}</span>
                     </div>
-                    <div className="flex items-center justify-between p-4 bg-red-50/50 dark:bg-red-950/20">
+                    <div className="flex items-center justify-between p-4 bg-destructive/5">
                       <div className="space-y-1">
                         <p className="text-sm font-medium">{t("env.delete")}</p>
                         <p className="text-xs text-muted-foreground">

--- a/web/app/settings/users/columns.tsx
+++ b/web/app/settings/users/columns.tsx
@@ -49,7 +49,7 @@ export const getColumns = (t: (key: string) => string): ColumnDef<User>[] => [
     header: t("users.col.status"),
     cell: ({ row }) => row.original.enabled === false
       ? <Badge variant="secondary" className="text-muted-foreground">{t("users.status.disabled")}</Badge>
-      : <Badge variant="outline" className="text-emerald-600 border-emerald-200 dark:text-emerald-400 dark:border-emerald-900">{t("users.status.enabled")}</Badge>,
+      : <Badge variant="outline" className="text-success border-success/40">{t("users.status.enabled")}</Badge>,
   },
   {
     accessorKey: "createdTime",

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -215,7 +215,7 @@ function AppSidebarContent({ onOpenCommandPalette }: { onOpenCommandPalette: () 
               >
                 <Keyboard className="size-4" />
                 <span>{t("cmd.hint")}</span>
-                <kbd className="bg-sidebar-border px-1.5 py-0.5 rounded text-[10px] font-mono ml-auto">/</kbd>
+                <kbd className="bg-sidebar-border px-1.5 py-0.5 rounded-sm text-[10px] font-mono ml-auto">/</kbd>
               </SidebarMenuButton>
             </SidebarMenuItem>
           )}

--- a/web/components/command-palette.tsx
+++ b/web/components/command-palette.tsx
@@ -328,11 +328,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                           <span className="font-medium truncate">
                             {recentApp.name}
                           </span>
-                          <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                          <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-sm">
                             {t("common.namespace")}: {recentApp.namespace}
                           </span>
                           {recentApp.ownerName && (
-                            <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                            <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-sm">
                               {t("common.owner")}: {recentApp.ownerName}
                             </span>
                           )}
@@ -367,11 +367,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                             <span className="font-medium truncate">
                               {app.name}
                             </span>
-                            <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                            <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-sm">
                               {t("common.namespace")}: {app.namespace}
                             </span>
                             {app.ownerName && (
-                              <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                              <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-sm">
                                 {t("common.owner")}: {app.ownerName}
                               </span>
                             )}
@@ -402,22 +402,22 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             <div className="flex items-center justify-between px-3 py-2 border-t text-xs text-muted-foreground">
               <div className="flex items-center gap-4">
                 <span className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1.5 py-0.5 rounded">/</kbd>
+                  <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">/</kbd>
                   {t("cmd.toggle")}
                 </span>
                 {selectedCommand && (
                   <span className="flex items-center gap-1">
-                    <kbd className="bg-muted px-1.5 py-0.5 rounded">←</kbd>
+                    <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">←</kbd>
                     {t("cmd.back")}
                   </span>
                 )}
                 <span className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1.5 py-0.5 rounded">esc</kbd>
+                  <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">esc</kbd>
                   {t("cmd.close")}
                 </span>
               </div>
               <span className="flex items-center gap-1">
-                <kbd className="bg-muted px-1.5 py-0.5 rounded">↵</kbd>
+                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">↵</kbd>
                 {t("cmd.select")}
               </span>
             </div>

--- a/web/components/connection-lost-banner.tsx
+++ b/web/components/connection-lost-banner.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { RefreshCw, WifiOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface ConnectionLostBannerProps {
+  /** Translated message shown next to the disconnect icon. */
+  message: string
+  /** Translated label for the retry button. */
+  retryLabel: string
+  /** Retry handler; defaults to a full page reload. */
+  onRetry?: () => void
+  /** Extra classes for the banner container (e.g. `rounded-md`). */
+  className?: string
+}
+
+/**
+ * Warning banner shown when a live WebSocket/SSE connection drops
+ * (pipeline logs, pod logs, pod terminal, sandbox terminal).
+ * Uses the `--warning` theme token rather than hardcoded amber shades.
+ */
+export function ConnectionLostBanner({
+  message,
+  retryLabel,
+  onRetry,
+  className,
+}: ConnectionLostBannerProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex shrink-0 items-center justify-between gap-3 border border-warning/40 bg-warning/10 px-3 py-2 text-foreground",
+        className
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2 text-sm">
+        <WifiOff className="size-4 shrink-0 text-warning" />
+        <span className="truncate">{message}</span>
+      </div>
+      <Button
+        variant="outline"
+        size="xs"
+        onClick={onRetry ?? (() => window.location.reload())}
+        className="shrink-0 bg-background/80 text-foreground hover:bg-background"
+      >
+        <RefreshCw className="size-3" />
+        {retryLabel}
+      </Button>
+    </div>
+  )
+}

--- a/web/components/doc/code-block.tsx
+++ b/web/components/doc/code-block.tsx
@@ -33,6 +33,6 @@ export function CodeBlock({ children, language, className }: CodeBlockProps) {
 
 export function InlineCode({ children }: { children: string }) {
   return (
-    <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{children}</code>
+    <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-xs">{children}</code>
   )
 }

--- a/web/components/doc/doc-layout.tsx
+++ b/web/components/doc/doc-layout.tsx
@@ -55,7 +55,7 @@ function AnchorHeading({
         onClick={handleCopy}
         aria-label={t("doc.copyAnchor")}
         title={t("doc.copyAnchor")}
-        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
       >
         <Link2 className="h-3.5 w-3.5" />
       </button>

--- a/web/components/doc/endpoint.tsx
+++ b/web/components/doc/endpoint.tsx
@@ -60,7 +60,7 @@ export function Endpoint({ method, path, summary }: EndpointProps) {
       <div className="flex items-center gap-2 flex-wrap">
         <span
           className={cn(
-            "inline-flex items-center justify-center rounded px-2 py-0.5 text-xs font-semibold font-mono",
+            "inline-flex items-center justify-center rounded-sm px-2 py-0.5 text-xs font-semibold font-mono",
             methodStyles[method]
           )}
         >
@@ -70,7 +70,7 @@ export function Endpoint({ method, path, summary }: EndpointProps) {
       </div>
       {summary && <div className="text-sm text-muted-foreground">{summary}</div>}
       <div className="relative">
-        <pre className="overflow-x-auto rounded border bg-background/60 p-2 pr-9 text-[11px] leading-relaxed font-mono [font-variant-ligatures:none] [font-feature-settings:'liga'_0,'clig'_0,'calt'_0]">
+        <pre className="overflow-x-auto rounded-md border bg-background/60 p-2 pr-9 text-[11px] leading-relaxed font-mono [font-variant-ligatures:none] [font-feature-settings:'liga'_0,'clig'_0,'calt'_0]">
           <code>{curl}</code>
         </pre>
         <Button

--- a/web/components/file-tree.tsx
+++ b/web/components/file-tree.tsx
@@ -453,7 +453,7 @@ export default function FileTree({
             <button
               type="button"
               onClick={() => openMkdir(rootPath)}
-              className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer"
+              className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer"
               title={t("terminal.files.newFolder")}
             >
               <FolderPlus className="size-3.5" />
@@ -462,7 +462,7 @@ export default function FileTree({
           <button
             type="button"
             onClick={() => loadDirectory(rootPath)}
-            className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer"
+            className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer"
             title={t("common.refresh")}
           >
             {rootState?.loading ? (
@@ -521,7 +521,7 @@ export default function FileTree({
               {edit?.path}
             </DialogDescription>
           </DialogHeader>
-          <div className="h-[60vh] overflow-hidden rounded border">
+          <div className="h-[60vh] overflow-hidden rounded-md border">
             {edit?.loading ? (
               <div className="flex h-full items-center justify-center text-muted-foreground gap-2 text-sm">
                 <Loader2 className="size-4 animate-spin" />

--- a/web/components/ui/badge.tsx
+++ b/web/components/ui/badge.tsx
@@ -14,6 +14,10 @@ const badgeVariants = cva(
           "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
           "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        warning:
+          "bg-warning text-warning-foreground [a&]:hover:bg-warning/90 focus-visible:ring-warning/20 dark:focus-visible:ring-warning/40",
+        success:
+          "bg-success text-success-foreground [a&]:hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40",
         outline:
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",

--- a/web/components/ui/button.tsx
+++ b/web/components/ui/button.tsx
@@ -13,7 +13,9 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         warning:
-          "bg-warning text-white hover:bg-warning/90 focus-visible:ring-warning/20 dark:focus-visible:ring-warning/40",
+          "bg-warning text-warning-foreground hover:bg-warning/90 focus-visible:ring-warning/20 dark:focus-visible:ring-warning/40",
+        success:
+          "bg-success text-success-foreground hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
Standardize semantic colors and border radii on the shadcn design tokens so status, danger, and warning UI derive from theme variables and every corner sits on the sm/md/lg radius scale.

Colors:
- Add --success / --success-foreground tokens to globals.css (light + dark) and wire them into the @theme inline scale.
- Fix the warning button/badge contrast bug: bg-warning paired with text-white had too little contrast; use text-warning-foreground.
- Add warning/success variants to Badge and a success variant to Button.
- Extract a shared ConnectionLostBanner (warning tokens) and replace the four duplicated disconnect banners in pipeline, pod logs, pod terminal, and sandbox pages.
- Migrate danger-zone red blocks to --destructive across the app config, application form, and environment settings pages.
- Migrate hardcoded red/amber/green/emerald/gray status colors to the --destructive / --warning / --success tokens.
- Leave intentionally-standalone colors untouched: xterm/log consoles on permanently-dark surfaces, HTTP-method coding, brand logos.

Radii:
- Promote off-scale bare `rounded` (4px, not on the token scale) to `rounded-sm` for chips/kbd/inline code/icon buttons, and to `rounded-md` for the code block and file preview containers, matching existing usage.
- Leave the lg/md panel split as-is: it is a coherent card-vs-nested hierarchy (section cards = rounded-lg, tables/collapsibles/nested widgets = rounded-md), not an inconsistency.

Tinted alert bodies use text-foreground with a colored icon accent rather than *-foreground tokens, since the fixed foreground tokens only read correctly on solid fills, not on 10% tints in dark mode.