### PR TITLE
feat(nodes): pause/resume node scheduling and show scheduling status

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/dto/NodeStatusView.java
+++ b/src/main/java/com/github/wellch4n/oops/application/dto/NodeStatusView.java
@@ -8,6 +8,7 @@ public class NodeStatusView {
     private String name;
     private String hostname;
     private Boolean ready;
+    private Boolean schedulable;
     private String roles;
     private String internalIP;
     private String kubeletVersion;

--- a/src/main/java/com/github/wellch4n/oops/application/port/ClusterNodeGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/application/port/ClusterNodeGateway.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface ClusterNodeGateway {
     List<NodeStatusView> getNodes(Environment environment);
+
+    void setSchedulable(Environment environment, String nodeName, boolean schedulable);
 }

--- a/src/main/java/com/github/wellch4n/oops/application/service/NodeService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/NodeService.java
@@ -26,4 +26,12 @@ public class NodeService {
         }
         return clusterNodeGateway.getNodes(environment);
     }
+
+    public void setSchedulable(String environmentName, String nodeName, boolean schedulable) {
+        Environment environment = environmentRepository.findFirstByName(environmentName);
+        if (environment == null) {
+            throw new IllegalArgumentException("Environment not found: " + environmentName);
+        }
+        clusterNodeGateway.setSchedulable(environment, nodeName, schedulable);
+    }
 }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesClusterNodeGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesClusterNodeGateway.java
@@ -5,6 +5,7 @@ import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.application.dto.NodeStatusView;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeAddress;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -34,6 +35,18 @@ public class KubernetesClusterNodeGateway implements ClusterNodeGateway {
                 .toList();
     }
 
+    @Override
+    public void setSchedulable(Environment environment, String nodeName, boolean schedulable) {
+        var client = clientPool.get(environment.getKubernetesApiServer());
+        client.nodes().withName(nodeName).edit(node ->
+                new NodeBuilder(node)
+                        .editOrNewSpec()
+                        // Kubernetes treats a null/absent unschedulable flag as schedulable; only set true to cordon.
+                        .withUnschedulable(schedulable ? null : Boolean.TRUE)
+                        .endSpec()
+                        .build());
+    }
+
     private NodeStatusView toResponse(Node node) {
         NodeStatusView response = new NodeStatusView();
         response.setName(node.getMetadata() != null ? node.getMetadata().getName() : null);
@@ -41,6 +54,7 @@ public class KubernetesClusterNodeGateway implements ClusterNodeGateway {
         response.setCreationTimestamp(node.getMetadata() != null ? node.getMetadata().getCreationTimestamp() : null);
 
         response.setReady(isNodeReady(node));
+        response.setSchedulable(isSchedulable(node));
         response.setRoles(extractRoles(node));
         response.setInternalIP(extractInternalIP(node));
         if (node.getStatus() != null && node.getStatus().getNodeInfo() != null) {
@@ -61,6 +75,11 @@ public class KubernetesClusterNodeGateway implements ClusterNodeGateway {
         return node.getStatus().getConditions().stream()
                 .filter(Objects::nonNull)
                 .anyMatch(condition -> "Ready".equals(condition.getType()) && "True".equals(condition.getStatus()));
+    }
+
+    private boolean isSchedulable(Node node) {
+        Boolean unschedulable = node.getSpec() != null ? node.getSpec().getUnschedulable() : null;
+        return unschedulable == null || !unschedulable;
     }
 
     private String extractRoles(Node node) {

--- a/src/main/java/com/github/wellch4n/oops/interfaces/rest/NodeController.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/rest/NodeController.java
@@ -4,7 +4,10 @@ import com.github.wellch4n.oops.application.dto.NodeStatusView;
 import com.github.wellch4n.oops.interfaces.dto.Result;
 import com.github.wellch4n.oops.application.service.NodeService;
 import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +25,15 @@ public class NodeController {
     @GetMapping
     public Result<List<NodeStatusView>> getNodes(@RequestParam String env) {
         return Result.success(nodeService.getNodes(env));
+    }
+
+    @PostMapping("/{name}/schedulable")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<Boolean> setSchedulable(@PathVariable String name,
+                                          @RequestParam String env,
+                                          @RequestParam boolean schedulable) {
+        nodeService.setSchedulable(env, name, schedulable);
+        return Result.success(true);
     }
 }
 

--- a/web/app/clusters/nodes/columns.tsx
+++ b/web/app/clusters/nodes/columns.tsx
@@ -1,52 +1,108 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
+import { PauseCircle, PlayCircle } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { NodeStatus } from "@/lib/api/types"
 
-export const getColumns = (t: (key: string) => string): ColumnDef<NodeStatus>[] => [
-  {
-    accessorKey: "name",
-    header: t("nodes.col.name"),
-    cell: ({ row }) => <span className="font-medium">{row.original.name}</span>,
-  },
-  {
-    id: "status",
-    header: t("nodes.col.status"),
-    cell: ({ row }) => (
-      <Badge variant={row.original.ready ? "default" : "destructive"}>
-        {row.original.ready ? t("nodes.status.ready") : t("nodes.status.notReady")}
-      </Badge>
-    ),
-  },
-  {
-    accessorKey: "roles",
-    header: t("nodes.col.role"),
-    cell: ({ row }) => row.original.roles || "-",
-  },
-  {
-    accessorKey: "internalIP",
-    header: t("nodes.col.ip"),
-    cell: ({ row }) => row.original.internalIP || "-",
-  },
-  {
-    accessorKey: "cpu",
-    header: t("nodes.col.cpu"),
-    cell: ({ row }) => row.original.cpu || "-",
-  },
-  {
-    accessorKey: "memory",
-    header: t("nodes.col.memory"),
-    cell: ({ row }) => row.original.memory || "-",
-  },
-  {
-    accessorKey: "pods",
-    header: t("nodes.col.pods"),
-    cell: ({ row }) => row.original.pods || "-",
-  },
-  {
-    accessorKey: "kubeletVersion",
-    header: t("nodes.col.version"),
-    cell: ({ row }) => row.original.kubeletVersion || "-",
-  },
-]
+interface ColumnOptions {
+  canManage?: boolean
+  onToggleSchedulable?: (node: NodeStatus) => void
+}
+
+export const getColumns = (
+  t: (key: string) => string,
+  options: ColumnOptions = {}
+): ColumnDef<NodeStatus>[] => {
+  const { canManage = false, onToggleSchedulable } = options
+
+  const columns: ColumnDef<NodeStatus>[] = [
+    {
+      accessorKey: "name",
+      header: t("nodes.col.name"),
+      cell: ({ row }) => <span className="font-medium">{row.original.name}</span>,
+    },
+    {
+      id: "status",
+      header: t("nodes.col.status"),
+      cell: ({ row }) => (
+        <Badge variant={row.original.ready ? "default" : "destructive"}>
+          {row.original.ready ? t("nodes.status.ready") : t("nodes.status.notReady")}
+        </Badge>
+      ),
+    },
+    {
+      id: "scheduling",
+      header: t("nodes.col.scheduling"),
+      cell: ({ row }) => (
+        <Badge variant={row.original.schedulable ? "success" : "warning"}>
+          {row.original.schedulable
+            ? t("nodes.scheduling.enabled")
+            : t("nodes.scheduling.disabled")}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "roles",
+      header: t("nodes.col.role"),
+      cell: ({ row }) => row.original.roles || "-",
+    },
+    {
+      accessorKey: "internalIP",
+      header: t("nodes.col.ip"),
+      cell: ({ row }) => row.original.internalIP || "-",
+    },
+    {
+      accessorKey: "cpu",
+      header: t("nodes.col.cpu"),
+      cell: ({ row }) => row.original.cpu || "-",
+    },
+    {
+      accessorKey: "memory",
+      header: t("nodes.col.memory"),
+      cell: ({ row }) => row.original.memory || "-",
+    },
+    {
+      accessorKey: "pods",
+      header: t("nodes.col.pods"),
+      cell: ({ row }) => row.original.pods || "-",
+    },
+    {
+      accessorKey: "kubeletVersion",
+      header: t("nodes.col.version"),
+      cell: ({ row }) => row.original.kubeletVersion || "-",
+    },
+  ]
+
+  if (canManage) {
+    columns.push({
+      id: "actions",
+      header: "",
+      cell: ({ row }) => (
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            className="cursor-pointer"
+            onClick={() => onToggleSchedulable?.(row.original)}
+          >
+            {row.original.schedulable ? (
+              <>
+                <PauseCircle className="size-4" />
+                {t("nodes.action.cordon")}
+              </>
+            ) : (
+              <>
+                <PlayCircle className="size-4" />
+                {t("nodes.action.uncordon")}
+              </>
+            )}
+          </Button>
+        </div>
+      ),
+    })
+  }
+
+  return columns
+}

--- a/web/app/clusters/nodes/page.tsx
+++ b/web/app/clusters/nodes/page.tsx
@@ -4,12 +4,17 @@ import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import { Server } from "lucide-react"
 import { fetchEnvironments } from "@/lib/api/environments"
-import { fetchNodes } from "@/lib/api/nodes"
+import { fetchNodes, setNodeSchedulable } from "@/lib/api/nodes"
 import { Environment, NodeStatus } from "@/lib/api/types"
+import { isAdmin } from "@/lib/auth"
 import { SelectWithSearch } from "@/components/ui/select-with-search"
 import { DataTable } from "@/components/ui/data-table"
 import { ContentPage } from "@/components/content-page"
 import { TableForm } from "@/components/ui/table-form"
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { useLanguage } from "@/contexts/language-context"
 import { getColumns } from "./columns"
 
@@ -18,8 +23,36 @@ export default function NodesPage() {
   const [selectedEnv, setSelectedEnv] = useState("")
   const [nodes, setNodes] = useState<NodeStatus[]>([])
   const [loading, setLoading] = useState(false)
+  const [pendingNode, setPendingNode] = useState<NodeStatus | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [canManage, setCanManage] = useState(false)
   const { t } = useLanguage()
-  const columns = useMemo(() => getColumns(t), [t])
+
+  useEffect(() => {
+    setCanManage(isAdmin())
+  }, [])
+
+  const loadNodes = useMemo(
+    () => async (env: string) => {
+      if (!env) return
+      setLoading(true)
+      try {
+        const res = await fetchNodes(env)
+        setNodes(res.data ?? [])
+      } catch {
+        toast.error(t("nodes.fetchError"))
+        setNodes([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [t]
+  )
+
+  const columns = useMemo(
+    () => getColumns(t, { canManage, onToggleSchedulable: (node) => setPendingNode(node) }),
+    [t, canManage]
+  )
 
   useEffect(() => {
     void (async () => {
@@ -37,20 +70,24 @@ export default function NodesPage() {
   }, [t])
 
   useEffect(() => {
-    if (!selectedEnv) return
-    void (async () => {
-      setLoading(true)
-      try {
-        const res = await fetchNodes(selectedEnv)
-        setNodes(res.data ?? [])
-      } catch {
-        toast.error(t("nodes.fetchError"))
-        setNodes([])
-      } finally {
-        setLoading(false)
-      }
-    })()
-  }, [selectedEnv, t])
+    void loadNodes(selectedEnv)
+  }, [selectedEnv, loadNodes])
+
+  const confirmToggle = async () => {
+    if (!pendingNode) return
+    const nextSchedulable = !pendingNode.schedulable
+    setSubmitting(true)
+    try {
+      await setNodeSchedulable(selectedEnv, pendingNode.name, nextSchedulable)
+      toast.success(nextSchedulable ? t("nodes.uncordonSuccess") : t("nodes.cordonSuccess"))
+      setPendingNode(null)
+      await loadNodes(selectedEnv)
+    } catch {
+      toast.error(t("nodes.updateError"))
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   return (
     <ContentPage title={t("nodes.title")}>
@@ -78,6 +115,26 @@ export default function NodesPage() {
           />
         }
       />
+
+      <AlertDialog open={!!pendingNode} onOpenChange={(open) => { if (!open) setPendingNode(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingNode?.schedulable ? t("nodes.cordonConfirmTitle") : t("nodes.uncordonConfirmTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {(pendingNode?.schedulable ? t("nodes.cordonConfirmDesc") : t("nodes.uncordonConfirmDesc"))
+                .replace("{name}", pendingNode?.name ?? "")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={submitting} className="cursor-pointer">{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction disabled={submitting} onClick={(e) => { e.preventDefault(); void confirmToggle() }} className="cursor-pointer">
+              {t("common.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </ContentPage>
   )
 }

--- a/web/lib/api/nodes.ts
+++ b/web/lib/api/nodes.ts
@@ -12,3 +12,21 @@ export async function fetchNodes(env: string): Promise<ApiResponse<NodeStatus[]>
   return res.json() as Promise<ApiResponse<NodeStatus[]>>
 }
 
+export async function setNodeSchedulable(
+  env: string,
+  name: string,
+  schedulable: boolean
+): Promise<ApiResponse<boolean>> {
+  const params = new URLSearchParams()
+  params.set("env", env)
+  params.set("schedulable", String(schedulable))
+
+  const res = await apiFetch(`/api/nodes/${encodeURIComponent(name)}/schedulable?${params.toString()}`, {
+    method: "POST",
+  })
+  if (!res.ok) {
+    throw new Error("Failed to update node scheduling")
+  }
+  return res.json() as Promise<ApiResponse<boolean>>
+}
+

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -53,6 +53,7 @@ export interface NodeStatus {
   name: string
   hostname: string
   ready: boolean
+  schedulable: boolean
   roles: string
   internalIP: string
   kubeletVersion: string

--- a/web/locales/en-US/nodes.ts
+++ b/web/locales/en-US/nodes.ts
@@ -2,8 +2,12 @@ const nodes = {
   "nodes.title": "Nodes",
   "nodes.fetchEnvError": "Failed to fetch environments",
   "nodes.fetchError": "Failed to fetch nodes",
+  "nodes.updateError": "Failed to update node scheduling",
+  "nodes.cordonSuccess": "Scheduling paused",
+  "nodes.uncordonSuccess": "Scheduling resumed",
   "nodes.col.name": "Node",
   "nodes.col.status": "Status",
+  "nodes.col.scheduling": "Scheduling",
   "nodes.col.role": "Role",
   "nodes.col.ip": "Internal IP",
   "nodes.col.cpu": "CPU",
@@ -12,6 +16,14 @@ const nodes = {
   "nodes.col.version": "Version",
   "nodes.status.ready": "Ready",
   "nodes.status.notReady": "NotReady",
+  "nodes.scheduling.enabled": "Schedulable",
+  "nodes.scheduling.disabled": "Paused",
+  "nodes.action.cordon": "Pause scheduling",
+  "nodes.action.uncordon": "Resume scheduling",
+  "nodes.cordonConfirmTitle": "Pause scheduling?",
+  "nodes.cordonConfirmDesc": "New pods will no longer be scheduled to node \"{name}\". Existing pods keep running.",
+  "nodes.uncordonConfirmTitle": "Resume scheduling?",
+  "nodes.uncordonConfirmDesc": "Node \"{name}\" will become schedulable again for new pods.",
 }
 
 export default nodes

--- a/web/locales/ja-JP/nodes.ts
+++ b/web/locales/ja-JP/nodes.ts
@@ -2,8 +2,12 @@ const nodes = {
   "nodes.title": "ノード",
   "nodes.fetchEnvError": "環境リストの取得に失敗しました",
   "nodes.fetchError": "ノードステータスの取得に失敗しました",
+  "nodes.updateError": "ノードのスケジューリング更新に失敗しました",
+  "nodes.cordonSuccess": "スケジューリングを一時停止しました",
+  "nodes.uncordonSuccess": "スケジューリングを再開しました",
   "nodes.col.name": "ノード",
   "nodes.col.status": "ステータス",
+  "nodes.col.scheduling": "スケジューリング",
   "nodes.col.role": "役割",
   "nodes.col.ip": "内部IP",
   "nodes.col.cpu": "CPU",
@@ -12,6 +16,14 @@ const nodes = {
   "nodes.col.version": "バージョン",
   "nodes.status.ready": "Ready",
   "nodes.status.notReady": "NotReady",
+  "nodes.scheduling.enabled": "スケジュール可能",
+  "nodes.scheduling.disabled": "一時停止",
+  "nodes.action.cordon": "スケジューリング停止",
+  "nodes.action.uncordon": "スケジューリング再開",
+  "nodes.cordonConfirmTitle": "スケジューリングを一時停止しますか？",
+  "nodes.cordonConfirmDesc": "新しいPodはノード「{name}」にスケジュールされなくなります。既存のPodは実行を継続します。",
+  "nodes.uncordonConfirmTitle": "スケジューリングを再開しますか？",
+  "nodes.uncordonConfirmDesc": "ノード「{name}」は新しいPodのスケジュール対象に戻ります。",
 }
 
 export default nodes

--- a/web/locales/zh-CN/nodes.ts
+++ b/web/locales/zh-CN/nodes.ts
@@ -2,8 +2,12 @@ const nodes = {
   "nodes.title": "节点",
   "nodes.fetchEnvError": "获取环境列表失败",
   "nodes.fetchError": "获取节点状态失败",
+  "nodes.updateError": "更新节点调度状态失败",
+  "nodes.cordonSuccess": "已暂停调度",
+  "nodes.uncordonSuccess": "已恢复调度",
   "nodes.col.name": "节点",
   "nodes.col.status": "状态",
+  "nodes.col.scheduling": "调度",
   "nodes.col.role": "角色",
   "nodes.col.ip": "内网IP",
   "nodes.col.cpu": "CPU",
@@ -12,6 +16,14 @@ const nodes = {
   "nodes.col.version": "版本",
   "nodes.status.ready": "Ready",
   "nodes.status.notReady": "NotReady",
+  "nodes.scheduling.enabled": "可调度",
+  "nodes.scheduling.disabled": "已暂停",
+  "nodes.action.cordon": "暂停调度",
+  "nodes.action.uncordon": "恢复调度",
+  "nodes.cordonConfirmTitle": "暂停调度？",
+  "nodes.cordonConfirmDesc": "新的 Pod 将不再被调度到节点“{name}”，已有 Pod 会继续运行。",
+  "nodes.uncordonConfirmTitle": "恢复调度？",
+  "nodes.uncordonConfirmDesc": "节点“{name}”将重新接受新的 Pod 调度。",
 }
 
 export default nodes

--- a/web/locales/zh-TW/nodes.ts
+++ b/web/locales/zh-TW/nodes.ts
@@ -2,8 +2,12 @@ const nodes = {
   "nodes.title": "節點",
   "nodes.fetchEnvError": "取得環境列表失敗",
   "nodes.fetchError": "取得節點狀態失敗",
+  "nodes.updateError": "更新節點調度狀態失敗",
+  "nodes.cordonSuccess": "已暫停調度",
+  "nodes.uncordonSuccess": "已恢復調度",
   "nodes.col.name": "節點",
   "nodes.col.status": "狀態",
+  "nodes.col.scheduling": "調度",
   "nodes.col.role": "角色",
   "nodes.col.ip": "內網IP",
   "nodes.col.cpu": "中央處理器",
@@ -12,6 +16,14 @@ const nodes = {
   "nodes.col.version": "版本",
   "nodes.status.ready": "準備好",
   "nodes.status.notReady": "未準備好",
+  "nodes.scheduling.enabled": "可調度",
+  "nodes.scheduling.disabled": "已暫停",
+  "nodes.action.cordon": "暫停調度",
+  "nodes.action.uncordon": "恢復調度",
+  "nodes.cordonConfirmTitle": "暫停調度？",
+  "nodes.cordonConfirmDesc": "新的 Pod 將不再被調度到節點「{name}」，已有 Pod 會繼續執行。",
+  "nodes.uncordonConfirmTitle": "恢復調度？",
+  "nodes.uncordonConfirmDesc": "節點「{name}」將重新接受新的 Pod 調度。",
 }
 
 export default nodes


### PR DESCRIPTION
Add cordon/uncordon support on the nodes page so operators can pause a node from accepting new pods without evicting existing ones. Scheduling state is derived from the node's spec.unschedulable flag (kubectl cordon semantics) and surfaced as a dedicated column.

Backend:
- NodeStatusView carries a schedulable field, mapped from node.spec.unschedulable in KubernetesClusterNodeGateway
- ClusterNodeGateway/NodeService gain setSchedulable; the K8s adapter edits the node's spec.unschedulable (null to schedule, true to cordon)
- NodeController exposes POST /api/nodes/{name}/schedulable, ADMIN-only

Frontend:
- Nodes table shows a Scheduling badge and an admin-only pause/resume action with a confirmation dialog, refreshing the list on success
- setNodeSchedulable API client, NodeStatus.schedulable type, and locale keys for zh-CN/en-US/zh-TW/ja-JP