### PR TITLE
feat(pipeline): spread build pods across nodes via topology constraints

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PipelineBuildPod.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PipelineBuildPod.java
@@ -54,6 +54,14 @@ public class PipelineBuildPod extends Job {
                 .withInitContainers(stepContainers)
                 .withContainers(finishContainer)
                 .withRestartPolicy("Never")
+                .withTopologySpreadConstraints(new TopologySpreadConstraintBuilder()
+                        .withMaxSkew(1)
+                        .withTopologyKey("kubernetes.io/hostname")
+                        .withWhenUnsatisfiable("ScheduleAnyway")
+                        .withLabelSelector(new LabelSelectorBuilder()
+                                .addToMatchLabels("oops.type", OopsTypes.PIPELINE.name())
+                                .build())
+                        .build())
                 .endSpec()
                 .build();
 


### PR DESCRIPTION
Add TopologySpreadConstraints to pipeline build Job pod spec so that build pods are distributed across different nodes, preventing disk exhaustion on a single node.