### PR TITLE
feat(metrics): warn an application's owner when it sits against its limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ Key properties to configure:
 - `oops.sandbox.*`: Sandbox runtime image allowlist and execution defaults
 - `oops.pod-filesystem.*`: Pod file browser limits, especially max download size
 - `oops.metrics.history.*`: usage-chart data source — `backend.namespace` / `backend.service-name` / `backend.port` locate the cluster's Prometheus-compatible Service (one convention for every environment, defaulting to kube-prometheus-stack's `monitoring/prometheus-operated:9090`; blank the namespace to hide the charts), plus `interval-seconds` and `max-range-hours` which shape the chart buckets
+- `oops.metrics.alert.*`: resource alert thresholds — `enabled`, `cpu.{threshold-percent,sustained-minutes}`, `memory.{threshold-percent,sustained-minutes}`, `repeat-interval-minutes`. One set for the whole installation; there is no per-application alert config
 
 ## Key Concepts
 
@@ -204,6 +205,12 @@ The K8s client is created per-task and closed via try-with-resources in `Artifac
 Frontend: `apps/[namespace]/[name]/status/page.tsx`; the charts live in `apps/components/application-metrics-drawer.tsx`, which also draws the environment's `ApplicationRuntimeSpec` request/limit as reference lines.
 
 `resources/vmsingle.yaml` is a minimal VictoriaMetrics manifest for clusters with no monitoring installed — one pod scraping the kubelet `/metrics/resource` endpoint, which carries exactly the two series the charts read.
+
+**Resource alerts**: `ResourceAlertScanJob` (`infrastructure/scheduler/`, `@Scheduled(cron = "0 * * * * *")`) warns an application's owner when CPU or memory sits against its limit. **Off unless `oops.metrics.alert.enabled` is set** — it messages real people and queries a backend not every cluster runs, so it is opt-in. Configured **only globally** under `oops.metrics.alert` (`ResourceAlertProperties`) — there is no per-application alert setting; once on, an application becomes alertable by having limits in its `ApplicationRuntimeSpec` for that environment, and one without limits is skipped because `/metrics/resource` carries no limits series to take a percentage of (that would need kube-state-metrics). Thresholds differ per metric by design: memory 90%/5min (an OOMKill is fatal, so warn early), CPU 95%/10min (throttling only degrades latency, and `container_cpu_cfs_throttled_seconds_total` — the metric that would really show it — is cAdvisor-only, so "sitting against the limit" is a proxy that needs headroom).
+
+The whole "sustained for N minutes" condition lives in PromQL: `ResourceAlertProbe` → `PrometheusResourceAlertProbe` runs one instant query per target of the form `min_over_time((…)[Ns:Is]) > threshold`, so a returned row *is* a pod that never dropped below the line — OOPS keeps no time series and no rolling buffer. `PrometheusSelectors` holds the pod matcher shared with the charts.
+
+The scan is three phases and only the middle one fans out: targets and previous state are each read in one query on the scan thread, the network-bound probes run on virtual threads touching no database, and transitions are written back in one batch. `application_alert_state` (one row per app + environment + metric) makes it edge-triggered — notify on OK→FIRING, repeat every `repeat-interval-minutes`, notify once on recovery; a failed probe leaves state untouched so an unreachable backend neither repeats nor falsely resolves. Transitions publish `ApplicationAlertEvent`, and `ApplicationAlertListener` (`@Async("notificationTaskExecutor")`) resolves the owner and sends via `ExternalMessageService` — one message per application listing the offending pods, not one per pod.
 
 **Scheduled rolling restart**: `ScheduledRestartJob` (`infrastructure/scheduler/`, `@Scheduled(cron = "0 * * * * *")`) scans every minute for applications whose `ApplicationExpertConfig` has `scheduledRestartEnabled` for an environment, matches the per-environment `scheduledRestartCron` (5-field cron, evaluated via `shared/util/CronSchedule`), and calls `ApplicationRuntimeGateway.rolloutRestart()`. `CronController` exposes `GET /api/cron/next?expression=...&count=N` to preview upcoming fire times for the UI.
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -58,6 +58,26 @@ oops:
         namespace: monitoring
         service-name: prometheus-operated
         port: 9090
+    # Resource alerts. Off unless enabled is set to true here: alerting messages real people and queries a monitoring
+    # backend that not every cluster runs, so it waits to be asked for.
+    # One set of thresholds for the whole installation — there is nothing to configure per application. Once on, an
+    # application is covered by having CPU/memory limits set for an environment; without a limit there is no
+    # denominator for the percentage, so it is skipped.
+    # Notifications go to the application's owner over the configured external channel (e.g. Feishu).
+    alert:
+      enabled: false
+      # CPU and memory are not given the same threshold on purpose. Exceeding a memory limit is an OOMKill —
+      # discrete and fatal — so it warns earlier. Exceeding a CPU limit is throttling: latency degrades but nothing
+      # dies, so the bar is higher and the window longer.
+      cpu:
+        threshold-percent: 95
+        sustained-minutes: 10
+      memory:
+        threshold-percent: 90
+        sustained-minutes: 5
+      # How long a still-firing alert stays quiet before it is repeated. The scan runs every minute, so without this
+      # one sustained problem would send one message a minute.
+      repeat-interval-minutes: 30
   pod-filesystem:
     max-download-size-bytes: 52428800
     max-upload-size-bytes: 52428800

--- a/docker/application.yml.example
+++ b/docker/application.yml.example
@@ -70,6 +70,26 @@ oops:
         namespace: monitoring
         service-name: prometheus-operated
         port: 9090
+    # Resource alerts. Off unless enabled is set to true here: alerting messages real people and queries a monitoring
+    # backend that not every cluster runs, so it waits to be asked for.
+    # One set of thresholds for the whole installation — there is nothing to configure per application. Once on, an
+    # application is covered by having CPU/memory limits set for an environment; without a limit there is no
+    # denominator for the percentage, so it is skipped.
+    # Notifications go to the application's owner over the configured external channel (e.g. Feishu).
+    alert:
+      enabled: false
+      # CPU and memory are not given the same threshold on purpose. Exceeding a memory limit is an OOMKill —
+      # discrete and fatal — so it warns earlier. Exceeding a CPU limit is throttling: latency degrades but nothing
+      # dies, so the bar is higher and the window longer.
+      cpu:
+        threshold-percent: 95
+        sustained-minutes: 10
+      memory:
+        threshold-percent: 90
+        sustained-minutes: 5
+      # How long a still-firing alert stays quiet before it is repeated. The scan runs every minute, so without this
+      # one sustained problem would send one message a minute.
+      repeat-interval-minutes: 30
   pod-filesystem:
     max-download-size-bytes: 52428800
     max-upload-size-bytes: 52428800

--- a/src/main/java/com/github/wellch4n/oops/application/dto/ResourceMetric.java
+++ b/src/main/java/com/github/wellch4n/oops/application/dto/ResourceMetric.java
@@ -1,0 +1,11 @@
+package com.github.wellch4n.oops.application.dto;
+
+/**
+ * The two resources OOPS alerts on. Both are available from kubelet's {@code /metrics/resource} endpoint, so alerting
+ * works on a minimal monitoring install without kube-state-metrics or full cAdvisor scraping.
+ */
+public enum ResourceMetric {
+
+    CPU,
+    MEMORY
+}

--- a/src/main/java/com/github/wellch4n/oops/application/event/ApplicationAlertEvent.java
+++ b/src/main/java/com/github/wellch4n/oops/application/event/ApplicationAlertEvent.java
@@ -1,0 +1,32 @@
+package com.github.wellch4n.oops.application.event;
+
+import com.github.wellch4n.oops.application.dto.ResourceMetric;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * One alert transition for one application, in one environment, on one metric.
+ *
+ * <p>Deliberately per application rather than per pod: the offending pods travel inside the event as a list, so a
+ * ten-replica application whose every pod is hot produces one message rather than ten.
+ *
+ * @param threshold      the crossing point, in millicores or bytes to match {@code metric}
+ * @param limitValue     the configured limit the threshold is a percentage of, same units
+ * @param repeated       true when the alert was already firing and this is the periodic reminder
+ * @param firingSince    when the streak began; on {@link ApplicationAlertType#RESOLVED} it gives the duration
+ */
+public record ApplicationAlertEvent(
+        ApplicationAlertType type,
+        String namespace,
+        String applicationName,
+        String environmentName,
+        ResourceMetric metric,
+        int thresholdPercent,
+        long threshold,
+        long limitValue,
+        List<String> pods,
+        boolean repeated,
+        LocalDateTime firingSince,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/github/wellch4n/oops/application/event/ApplicationAlertListener.java
+++ b/src/main/java/com/github/wellch4n/oops/application/event/ApplicationAlertListener.java
@@ -1,0 +1,159 @@
+package com.github.wellch4n.oops.application.event;
+
+import com.github.wellch4n.oops.application.dto.ResourceMetric;
+import com.github.wellch4n.oops.application.port.external.ExternalMessageLevel;
+import com.github.wellch4n.oops.application.port.external.ExternalUserFact;
+import com.github.wellch4n.oops.application.port.external.ExternalUserMessage;
+import com.github.wellch4n.oops.application.port.repository.ApplicationRepository;
+import com.github.wellch4n.oops.application.service.ExternalMessageService;
+import com.github.wellch4n.oops.domain.application.Application;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * Turns an alert transition into a message for the application's owner.
+ *
+ * <p>Runs on the notification executor rather than the scan thread, which is also why it can afford to look the
+ * application up in the database: transitions are rare, so this is not on the once-a-minute path.
+ */
+@Slf4j
+@Component
+public class ApplicationAlertListener {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private static final String[] BYTE_UNITS = {"B", "KiB", "MiB", "GiB", "TiB"};
+
+    /** Beyond this the pod list stops being information and starts being a wall of text. */
+    private static final int MAX_LISTED_PODS = 10;
+
+    private final ExternalMessageService externalMessageService;
+    private final ApplicationRepository applicationRepository;
+
+    public ApplicationAlertListener(ExternalMessageService externalMessageService,
+                                    ApplicationRepository applicationRepository) {
+        this.externalMessageService = externalMessageService;
+        this.applicationRepository = applicationRepository;
+    }
+
+    @Async("notificationTaskExecutor")
+    @EventListener
+    public void onApplicationAlert(ApplicationAlertEvent event) {
+        Application application = applicationRepository.findAggregate(event.namespace(), event.applicationName());
+        if (application == null || StringUtils.isBlank(application.getOwner())) {
+            // Nothing to do but say so: an application with no owner has no one to tell, and silently dropping the
+            // alert would look identical to the alert never having fired.
+            log.warn("Resource alert for {}/{} has no owner to notify",
+                    event.namespace(), event.applicationName());
+            return;
+        }
+
+        try {
+            externalMessageService.sendToUser(application.getOwner(), buildMessage(event));
+        } catch (Exception exception) {
+            log.warn("Failed to send resource alert for {}/{}: {}",
+                    event.namespace(), event.applicationName(), exception.getMessage(), exception);
+        }
+    }
+
+    private ExternalUserMessage buildMessage(ApplicationAlertEvent event) {
+        List<ExternalUserFact> facts = new ArrayList<>();
+        facts.add(new ExternalUserFact("应用", event.namespace() + "/" + event.applicationName()));
+        facts.add(new ExternalUserFact("环境", event.environmentName()));
+        facts.add(new ExternalUserFact("指标", metricName(event.metric())));
+        facts.add(new ExternalUserFact("阈值", event.thresholdPercent() + "%（"
+                + formatValue(event.metric(), event.threshold()) + " / "
+                + formatValue(event.metric(), event.limitValue()) + "）"));
+        facts.add(new ExternalUserFact("触发 Pod", formatPods(event.pods())));
+        if (event.firingSince() != null) {
+            facts.add(new ExternalUserFact("开始时间", event.firingSince().format(TIME_FORMATTER)));
+        }
+        facts.add(new ExternalUserFact("时间", event.occurredAt().format(TIME_FORMATTER)));
+
+        return new ExternalUserMessage(
+                "Oops 资源告警｜" + resolveTitle(event),
+                resolveLevel(event.type()),
+                facts,
+                resolveDetail(event),
+                null);
+    }
+
+    private String resolveTitle(ApplicationAlertEvent event) {
+        String metric = metricName(event.metric());
+        if (event.type() == ApplicationAlertType.RESOLVED) {
+            return metric + "已恢复";
+        }
+        return event.repeated() ? metric + "持续超限" : metric + "超过阈值";
+    }
+
+    private String resolveDetail(ApplicationAlertEvent event) {
+        String metric = metricName(event.metric());
+        if (event.type() == ApplicationAlertType.RESOLVED) {
+            String duration = formatDuration(event.firingSince(), event.occurredAt());
+            return duration == null
+                    ? metric + "已回落到阈值以下。"
+                    : metric + "已回落到阈值以下，本次持续 " + duration + "。";
+        }
+        String base = metric + "使用量持续高于 limit 的 " + event.thresholdPercent() + "%。";
+        if (event.metric() == ResourceMetric.MEMORY) {
+            return base + "继续上涨会触发 OOMKill，建议确认是否存在内存泄漏，或调高内存 limit。";
+        }
+        return base + "容器正在被 CPU 限流，延迟会因此上升，建议确认负载是否异常，或调高 CPU limit。";
+    }
+
+    private ExternalMessageLevel resolveLevel(ApplicationAlertType type) {
+        return type == ApplicationAlertType.RESOLVED ? ExternalMessageLevel.SUCCESS : ExternalMessageLevel.WARNING;
+    }
+
+    private String metricName(ResourceMetric metric) {
+        return metric == ResourceMetric.CPU ? "CPU" : "内存";
+    }
+
+    private String formatPods(List<String> pods) {
+        if (pods == null || pods.isEmpty()) {
+            return "-";
+        }
+        if (pods.size() <= MAX_LISTED_PODS) {
+            return String.join(", ", pods);
+        }
+        return String.join(", ", pods.subList(0, MAX_LISTED_PODS))
+                + " 等 " + pods.size() + " 个 Pod";
+    }
+
+    private String formatValue(ResourceMetric metric, long value) {
+        if (metric == ResourceMetric.CPU) {
+            return value + "m";
+        }
+        double amount = value;
+        int unit = 0;
+        while (amount >= 1024 && unit < BYTE_UNITS.length - 1) {
+            amount /= 1024;
+            unit++;
+        }
+        return unit == 0
+                ? (long) amount + BYTE_UNITS[unit]
+                : String.format("%.1f%s", amount, BYTE_UNITS[unit]);
+    }
+
+    private String formatDuration(LocalDateTime from, LocalDateTime to) {
+        if (from == null || to == null) {
+            return null;
+        }
+        long minutes = Duration.between(from, to).toMinutes();
+        if (minutes < 1) {
+            return "不足 1 分钟";
+        }
+        if (minutes < 60) {
+            return minutes + " 分钟";
+        }
+        return minutes / 60 + " 小时 " + minutes % 60 + " 分钟";
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/application/event/ApplicationAlertType.java
+++ b/src/main/java/com/github/wellch4n/oops/application/event/ApplicationAlertType.java
@@ -1,0 +1,10 @@
+package com.github.wellch4n.oops.application.event;
+
+public enum ApplicationAlertType {
+
+    /** Usage crossed the threshold and stayed there. Also used for the periodic reminder while it is still firing. */
+    FIRING,
+
+    /** Usage came back under the threshold. */
+    RESOLVED
+}

--- a/src/main/java/com/github/wellch4n/oops/application/port/ResourceAlertProbe.java
+++ b/src/main/java/com/github/wellch4n/oops/application/port/ResourceAlertProbe.java
@@ -1,0 +1,30 @@
+package com.github.wellch4n.oops.application.port;
+
+import com.github.wellch4n.oops.application.dto.ResourceMetric;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Answers one question against a cluster's monitoring backend: which of an application's pods have stayed above a
+ * usage threshold for an entire window.
+ *
+ * <p>The "for the entire window" part is deliberately the probe's job rather than the caller's. Pushing it into the
+ * backend's query language means OOPS keeps no time series of its own and no rolling buffer — the same reason the
+ * usage charts store nothing. A caller that sampled once a minute and counted consecutive hits would have to survive
+ * restarts and missed ticks to mean the same thing.
+ */
+public interface ResourceAlertProbe {
+
+    /**
+     * @param threshold millicores for {@link ResourceMetric#CPU}, bytes for {@link ResourceMetric#MEMORY}
+     * @param window    how long usage must have stayed above {@code threshold}
+     * @return names of the offending pods, empty when none — never null
+     */
+    List<String> podsSustainedAbove(Environment environment,
+                                    String namespace,
+                                    String applicationName,
+                                    ResourceMetric metric,
+                                    long threshold,
+                                    Duration window);
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/config/ResourceAlertProperties.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/config/ResourceAlertProperties.java
@@ -1,0 +1,61 @@
+package com.github.wellch4n.oops.infrastructure.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * The resource alert thresholds. There is one set of them for the whole installation — alerting is not configured per
+ * application.
+ *
+ * <p>Off until {@code enabled} is set. Alerting sends messages to real people and queries a backend that may not exist
+ * in a given cluster, so it waits to be asked for rather than starting on its own the first time someone upgrades.
+ *
+ * <p>Once on, applications are covered by having resource limits rather than by any further per-application switch: a
+ * per-application toggle would leave most applications unconfigured, which is the same as having no alerting at all.
+ *
+ * <p>CPU and memory deliberately do not share a threshold. Exceeding a memory limit is an OOMKill: discrete, fatal,
+ * and worth warning about early. Exceeding a CPU limit is throttling: latency degrades but nothing dies, so the bar
+ * is higher and the window longer. CPU is also the weaker signal here — the metric that really shows throttling,
+ * {@code container_cpu_cfs_throttled_seconds_total}, comes from cAdvisor and is absent on backends that scrape only
+ * kubelet's {@code /metrics/resource}, so "sitting against the limit" is the available approximation and needs
+ * headroom to avoid firing on workloads that are simply busy.
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "oops.metrics.alert")
+@ConditionalOnProperty(prefix = "oops.metrics.alert", name = "enabled", havingValue = "true")
+public class ResourceAlertProperties {
+
+    /** Opt-in: an installation that never mentions {@code oops.metrics.alert} sends nothing. */
+    private boolean enabled = false;
+
+    private Rule cpu = new Rule(95, 10);
+
+    private Rule memory = new Rule(90, 5);
+
+    /**
+     * How long a firing alert stays quiet before it is repeated. The scan runs every minute; without this, one
+     * sustained problem would send one message per minute until someone fixed it.
+     */
+    private int repeatIntervalMinutes = 30;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Rule {
+
+        /** Percentage of the environment's configured limit at which the alert fires. */
+        private int thresholdPercent;
+
+        /**
+         * How long usage must stay above the threshold before it counts. Shorter than a few minutes is not useful:
+         * at a 30s scrape interval a two-minute window holds only three or four samples, so a single scrape's jitter
+         * decides the outcome.
+         */
+        private int sustainedMinutes;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/ApiServerProxyPrometheusTransport.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/ApiServerProxyPrometheusTransport.java
@@ -17,6 +17,10 @@ import org.springframework.stereotype.Component;
  * <p>Prometheus and VictoriaMetrics are normally ClusterIP Services, unreachable from outside the cluster. Proxying
  * through the API server means OOPS needs no extra network path and no second credential — the environment's existing
  * token is what authorises the call. The cost is a {@code services/proxy} permission on that token.
+ *
+ * <p>It also fixes the direction of travel: OOPS pulls out through a path that already works for every environment it
+ * manages. A push-based design (Alertmanager or vmalert calling back) would need an inbound route from each cluster
+ * into OOPS, which for an out-of-cluster deployment generally does not exist.
  */
 @Slf4j
 @Component
@@ -35,16 +39,28 @@ class ApiServerProxyPrometheusTransport implements PrometheusQueryTransport {
                              long startSeconds,
                              long endSeconds,
                              int stepSeconds) {
+        String path = "query_range"
+                + "?query=" + URLEncoder.encode(query, StandardCharsets.UTF_8)
+                + "&start=" + startSeconds
+                + "&end=" + endSeconds
+                + "&step=" + stepSeconds;
+        return get(environment, backend, path);
+    }
+
+    @Override
+    public String query(Environment environment,
+                        MetricsHistoryProperties.Backend backend,
+                        String query) {
+        return get(environment, backend, "query?query=" + URLEncoder.encode(query, StandardCharsets.UTF_8));
+    }
+
+    private String get(Environment environment, MetricsHistoryProperties.Backend backend, String apiPath) {
         KubernetesClient client = clientPool.get(environment.getKubernetesApiServer());
 
         String url = client.getMasterUrl().toString().replaceAll("/+$", "")
                 + "/api/v1/namespaces/" + backend.getNamespace()
                 + "/services/" + backend.getServiceName() + ":" + backend.getPort()
-                + "/proxy/api/v1/query_range"
-                + "?query=" + URLEncoder.encode(query, StandardCharsets.UTF_8)
-                + "&start=" + startSeconds
-                + "&end=" + endSeconds
-                + "&step=" + stepSeconds;
+                + "/proxy/api/v1/" + apiPath;
 
         try {
             String body = client.raw(url);

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/MonitoringErrors.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/MonitoringErrors.java
@@ -2,15 +2,18 @@ package com.github.wellch4n.oops.infrastructure.metrics;
 
 /**
  * Error codes the charts recognise. Sent instead of prose so the browser can render a localised, actionable prompt.
+ *
+ * <p>The alert scan reads them too, to tell "this cluster has no monitoring" — which it must pass over quietly, once
+ * a minute, forever — apart from a backend that is present but answering badly, which is worth a warning.
  */
-final class MonitoringErrors {
+public final class MonitoringErrors {
 
     /**
      * No monitoring backend to talk to at all — either none is installed where the convention expects it, or the
      * charts have been turned off by blanking the configured namespace. Both mean the same thing to a viewer, so
      * they share a code; the server log says which.
      */
-    static final String NOT_AVAILABLE = "MONITORING_NOT_AVAILABLE";
+    public static final String NOT_AVAILABLE = "MONITORING_NOT_AVAILABLE";
 
     private MonitoringErrors() {
     }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusPodMetricHistoryProvider.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusPodMetricHistoryProvider.java
@@ -13,27 +13,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 /**
- * Reads the usage curves from an environment's Prometheus-compatible backend.
- *
- * <p>Pods are selected by name rather than by the {@code oops.app.name} label the deploy path stamps on them: kubelet
- * and cAdvisor metrics carry no pod labels, and joining against {@code kube_pod_labels} would force every user to also
- * run kube-state-metrics. Applications deploy as StatefulSets named after the application, so their pods are always
- * {@code {app}-0}, {@code {app}-1}, … — and PromQL matchers are fully anchored, so {@code foo-[0-9]+} cannot
- * accidentally match {@code foo-bar-0}.
+ * Reads the usage curves from an environment's Prometheus-compatible backend. Which series belong to the application
+ * is decided by {@link PrometheusSelectors}, shared with the resource alerts.
  */
 @Component
 public class PrometheusPodMetricHistoryProvider implements PodMetricHistoryProvider {
-
-    /**
-     * Namespaces and application names are interpolated into PromQL label matchers. Anything outside the Kubernetes
-     * name charset is rejected rather than escaped: a name containing a quote could otherwise close the matcher and
-     * read another namespace's series.
-     */
-    private static final Pattern SAFE_NAME = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$");
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -59,12 +46,9 @@ public class PrometheusPodMetricHistoryProvider implements PodMetricHistoryProvi
             // which is a different thing to show than a backend that is present but answering badly.
             throw new BizException(MonitoringErrors.NOT_AVAILABLE);
         }
-        requireSafeName(namespace, "namespace");
-        requireSafeName(applicationName, "application name");
-
         long startSeconds = startMillis / 1000L;
         long endSeconds = endMillis / 1000L;
-        String selector = selector(namespace, applicationName);
+        String selector = PrometheusSelectors.podSelector(namespace, applicationName);
 
         Map<String, List<double[]>> cpu = fetch(environment, backend,
                 cpuQuery(selector, stepSeconds, aggregation), startSeconds, endSeconds, stepSeconds);
@@ -72,14 +56,6 @@ public class PrometheusPodMetricHistoryProvider implements PodMetricHistoryProvi
                 memoryQuery(selector, stepSeconds, aggregation), startSeconds, endSeconds, stepSeconds);
 
         return merge(cpu, memory);
-    }
-
-    private String selector(String namespace, String applicationName) {
-        // container!="" drops the pod-level rollup series, container!="POD" drops the pause container; without both
-        // a pod's usage would be counted two or three times over.
-        return "namespace=\"" + namespace + "\","
-                + "pod=~\"" + applicationName + "-[0-9]+\","
-                + "container!=\"\",container!=\"POD\"";
     }
 
     /**
@@ -194,11 +170,5 @@ public class PrometheusPodMetricHistoryProvider implements PodMetricHistoryProvi
             }
         }
         return series;
-    }
-
-    private void requireSafeName(String value, String what) {
-        if (value == null || !SAFE_NAME.matcher(value).matches()) {
-            throw new BizException("Invalid " + what + ": " + value);
-        }
     }
 }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusQueryTransport.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusQueryTransport.java
@@ -4,17 +4,26 @@ import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.infrastructure.config.MetricsHistoryProperties;
 
 /**
- * Issues one {@code query_range} call against an environment's monitoring backend and hands back the raw JSON body.
+ * Issues one call against an environment's monitoring backend and hands back the raw JSON body.
  *
- * <p>Split out from {@link PrometheusPodMetricHistoryProvider} so query construction and response mapping — the parts
- * that are easy to get subtly wrong — can be tested without a cluster.
+ * <p>Split out from its callers so query construction and response mapping — the parts that are easy to get subtly
+ * wrong — can be tested without a cluster.
  */
 interface PrometheusQueryTransport {
 
+    /** Range query, evaluated on a fixed step grid. Backs the usage charts. */
     String queryRange(Environment environment,
                       MetricsHistoryProperties.Backend backend,
                       String query,
                       long startSeconds,
                       long endSeconds,
                       int stepSeconds);
+
+    /**
+     * Instant query, evaluated once at the backend's current time. Backs the alert evaluator, which pushes its whole
+     * "sustained for N minutes" condition into the expression rather than reducing a range client-side.
+     */
+    String query(Environment environment,
+                 MetricsHistoryProperties.Backend backend,
+                 String query);
 }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusResourceAlertProbe.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusResourceAlertProbe.java
@@ -1,0 +1,91 @@
+package com.github.wellch4n.oops.infrastructure.metrics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.wellch4n.oops.application.dto.ResourceMetric;
+import com.github.wellch4n.oops.application.port.ResourceAlertProbe;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.infrastructure.config.MetricsHistoryProperties;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Evaluates the alert condition as a single instant query.
+ *
+ * <p>The whole condition lives in the expression: {@code min_over_time} over the window means the <em>lowest</em>
+ * reading in that window was still above the threshold, which is exactly "it never dropped below". A result row is
+ * therefore a pod that has been over the line continuously, and an empty result means nothing is wrong — no
+ * client-side sampling, counting or buffering involved.
+ */
+@Component
+public class PrometheusResourceAlertProbe implements ResourceAlertProbe {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final PrometheusQueryTransport transport;
+    private final MetricsHistoryProperties properties;
+
+    PrometheusResourceAlertProbe(PrometheusQueryTransport transport, MetricsHistoryProperties properties) {
+        this.transport = transport;
+        this.properties = properties;
+    }
+
+    @Override
+    public List<String> podsSustainedAbove(Environment environment,
+                                           String namespace,
+                                           String applicationName,
+                                           ResourceMetric metric,
+                                           long threshold,
+                                           Duration window) {
+        MetricsHistoryProperties.Backend backend = properties.getBackend();
+        if (!backend.isConfigured()) {
+            throw new BizException(MonitoringErrors.NOT_AVAILABLE);
+        }
+        String selector = PrometheusSelectors.podSelector(namespace, applicationName);
+        String query = buildQuery(selector, metric, threshold, window);
+        return parseVectorPods(transport.query(environment, backend, query));
+    }
+
+    /**
+     * CPU is a counter, so the per-pod series is a {@code rate} before anything else; memory is a gauge and is read
+     * directly. The rate window must span at least two scrapes or {@code rate} has nothing to subtract.
+     */
+    String buildQuery(String selector, ResourceMetric metric, long threshold, Duration window) {
+        int interval = Math.max(1, properties.getIntervalSeconds());
+        long windowSeconds = Math.max(interval * 2L, window.toSeconds());
+
+        String perPod = metric == ResourceMetric.CPU
+                ? "sum by (pod) (rate(container_cpu_usage_seconds_total{" + selector + "}[" + (interval * 2) + "s])) * 1000"
+                : "sum by (pod) (container_memory_working_set_bytes{" + selector + "})";
+
+        return "min_over_time((" + perPod + ")[" + windowSeconds + "s:" + interval + "s]) > " + threshold;
+    }
+
+    /**
+     * Reads pod names out of an instant-query vector. The value itself is not needed — the comparison already
+     * happened in the backend, so every row that came back is a pod over the line.
+     */
+    static List<String> parseVectorPods(String body) {
+        JsonNode root;
+        try {
+            root = OBJECT_MAPPER.readTree(body);
+        } catch (Exception exception) {
+            throw new BizException("Monitoring backend returned a malformed response", exception);
+        }
+        if (!"success".equals(root.path("status").asText())) {
+            throw new BizException("Monitoring query rejected: " + root.path("error").asText("unknown error"));
+        }
+
+        List<String> pods = new ArrayList<>();
+        for (JsonNode series : root.path("data").path("result")) {
+            String podName = series.path("metric").path("pod").asText(null);
+            if (podName != null && !podName.isBlank() && !pods.contains(podName)) {
+                pods.add(podName);
+            }
+        }
+        return pods;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusSelectors.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusSelectors.java
@@ -1,0 +1,49 @@
+package com.github.wellch4n.oops.infrastructure.metrics;
+
+import com.github.wellch4n.oops.shared.exception.BizException;
+import java.util.regex.Pattern;
+
+/**
+ * Builds the PromQL label matcher that selects one application's containers, shared by the usage charts and the
+ * resource alerts so both always read the same series.
+ *
+ * <p>Pods are selected by name rather than by the {@code oops.app.name} label the deploy path stamps on them: kubelet
+ * and cAdvisor metrics carry no pod labels, and joining against {@code kube_pod_labels} would force every user to also
+ * run kube-state-metrics. Applications deploy as StatefulSets named after the application, so their pods are always
+ * {@code {app}-0}, {@code {app}-1}, … — and PromQL matchers are fully anchored, so {@code foo-[0-9]+} cannot
+ * accidentally match {@code foo-bar-0}.
+ */
+final class PrometheusSelectors {
+
+    /**
+     * Namespaces and application names are interpolated into PromQL label matchers. Anything outside the Kubernetes
+     * name charset is rejected rather than escaped: a name containing a quote could otherwise close the matcher and
+     * read another namespace's series.
+     */
+    private static final Pattern SAFE_NAME = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$");
+
+    private PrometheusSelectors() {
+    }
+
+    /**
+     * Selects every container of the application's pods in one namespace.
+     *
+     * <p>{@code container!=""} drops the pod-level rollup series and {@code container!="POD"} drops the pause
+     * container; without both, a pod's usage would be counted two or three times over. Both are cAdvisor traits —
+     * kubelet's {@code /metrics/resource} endpoint emits neither — so on a {@code /metrics/resource}-only backend
+     * they simply match everything, which is why they are safe to apply unconditionally.
+     */
+    static String podSelector(String namespace, String applicationName) {
+        requireSafeName(namespace, "namespace");
+        requireSafeName(applicationName, "application name");
+        return "namespace=\"" + namespace + "\","
+                + "pod=~\"" + applicationName + "-[0-9]+\","
+                + "container!=\"\",container!=\"POD\"";
+    }
+
+    static void requireSafeName(String value, String what) {
+        if (value == null || !SAFE_NAME.matcher(value).matches()) {
+            throw new BizException("Invalid " + what + ": " + value);
+        }
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationAlertState.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationAlertState.java
@@ -1,0 +1,40 @@
+package com.github.wellch4n.oops.infrastructure.persistence.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * One row per alertable thing: an application, in one environment, for one metric.
+ *
+ * <p>This exists purely to make the scan edge-triggered. The evaluator answers "is it above the threshold right now"
+ * every minute; without somewhere to remember the previous answer, a problem that lasts an afternoon would send one
+ * message per minute, and nobody would be able to tell when it started or when it cleared.
+ *
+ * <p>Persisted rather than held in memory so a restart does not re-announce every already-known problem.
+ */
+@Data
+@Entity
+@Table(name = "application_alert_state")
+@EqualsAndHashCode(callSuper = true)
+public class ApplicationAlertState extends BaseDataObject {
+
+    private String namespace;
+
+    private String applicationName;
+
+    /** Environment name, following every other table. */
+    private String environmentName;
+
+    /** {@link com.github.wellch4n.oops.application.dto.ResourceMetric} name. */
+    private String metric;
+
+    private boolean firing;
+
+    /** When the current firing streak began; kept after it clears so the resolved message can state a duration. */
+    private LocalDateTime firingSince;
+
+    private LocalDateTime lastNotifiedTime;
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationAlertStateRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationAlertStateRepository.java
@@ -1,0 +1,27 @@
+package com.github.wellch4n.oops.infrastructure.persistence.jpa;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplicationAlertStateRepository extends CrudRepository<ApplicationAlertState, String> {
+
+    Optional<ApplicationAlertState> findByNamespaceAndApplicationNameAndEnvironmentNameAndMetric(
+            String namespace, String applicationName, String environmentName, String metric);
+
+    List<ApplicationAlertState> findByNamespaceAndApplicationName(String namespace, String applicationName);
+
+    void deleteByNamespaceAndApplicationName(String namespace, String applicationName);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("update ApplicationAlertState s set s.namespace = :target "
+            + "where s.namespace = :source and s.applicationName = :applicationName")
+    void updateNamespace(@Param("source") String source,
+                         @Param("target") String target,
+                         @Param("applicationName") String applicationName);
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationPersistenceAdapter.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/ApplicationPersistenceAdapter.java
@@ -18,6 +18,7 @@ public class ApplicationPersistenceAdapter implements com.github.wellch4n.oops.a
     private final ApplicationServiceConfigRepository serviceConfigRepository;
     private final ApplicationCollaboratorRepository collaboratorRepository;
     private final ApplicationExpertConfigRepository expertConfigRepository;
+    private final ApplicationAlertStateRepository alertStateRepository;
 
     public ApplicationPersistenceAdapter(
             ApplicationRepository applicationRepository,
@@ -26,7 +27,8 @@ public class ApplicationPersistenceAdapter implements com.github.wellch4n.oops.a
             ApplicationEnvironmentRepository environmentRepository,
             ApplicationServiceConfigRepository serviceConfigRepository,
             ApplicationCollaboratorRepository collaboratorRepository,
-            ApplicationExpertConfigRepository expertConfigRepository
+            ApplicationExpertConfigRepository expertConfigRepository,
+            ApplicationAlertStateRepository alertStateRepository
     ) {
         this.applicationRepository = applicationRepository;
         this.buildConfigRepository = buildConfigRepository;
@@ -35,6 +37,7 @@ public class ApplicationPersistenceAdapter implements com.github.wellch4n.oops.a
         this.serviceConfigRepository = serviceConfigRepository;
         this.collaboratorRepository = collaboratorRepository;
         this.expertConfigRepository = expertConfigRepository;
+        this.alertStateRepository = alertStateRepository;
     }
 
     @Override
@@ -108,6 +111,7 @@ public class ApplicationPersistenceAdapter implements com.github.wellch4n.oops.a
         serviceConfigRepository.deleteByNamespaceAndApplicationName(namespace, name);
         expertConfigRepository.deleteByNamespaceAndApplicationName(namespace, name);
         collaboratorRepository.deleteByNamespaceAndApplicationName(namespace, name);
+        alertStateRepository.deleteByNamespaceAndApplicationName(namespace, name);
         applicationRepository.deleteByNamespaceAndName(namespace, name);
     }
 
@@ -120,6 +124,9 @@ public class ApplicationPersistenceAdapter implements com.github.wellch4n.oops.a
         expertConfigRepository.updateNamespace(fromNamespace, toNamespace, name);
         environmentRepository.updateNamespace(fromNamespace, toNamespace, name);
         collaboratorRepository.updateNamespace(fromNamespace, toNamespace, name);
+        // Carried over so a migration does not strand the row and re-announce an already-firing alert under the new
+        // namespace key.
+        alertStateRepository.updateNamespace(fromNamespace, toNamespace, name);
         applicationRepository.updateNamespace(fromNamespace, toNamespace, name);
     }
 

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/scheduler/ResourceAlertScanJob.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/scheduler/ResourceAlertScanJob.java
@@ -1,0 +1,333 @@
+package com.github.wellch4n.oops.infrastructure.scheduler;
+
+import com.github.wellch4n.oops.application.dto.ResourceMetric;
+import com.github.wellch4n.oops.application.event.ApplicationAlertEvent;
+import com.github.wellch4n.oops.application.event.ApplicationAlertType;
+import com.github.wellch4n.oops.application.port.ResourceAlertProbe;
+import com.github.wellch4n.oops.application.service.EnvironmentService;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.infrastructure.config.ResourceAlertProperties;
+import com.github.wellch4n.oops.infrastructure.metrics.MonitoringErrors;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationAlertState;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationAlertStateRepository;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationRuntimeSpec;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationRuntimeSpecRepository;
+import com.github.wellch4n.oops.shared.util.ResourceQuantities;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fires once per minute and asks the monitoring backend whether any application has been sitting above its CPU or
+ * memory threshold for the whole configured window.
+ *
+ * <p>Applications are picked up from their runtime specs rather than from any alert-specific configuration: a
+ * configured limit is what makes an application alertable, and one without limits has no denominator to take a
+ * percentage of, so it is skipped. There is nothing to switch on per application.
+ *
+ * <p>The three phases are separated on purpose. Everything touching the database happens on the scan thread — the
+ * targets and the previous alert state are each read in one query up front, and the transitions are written back in
+ * one batch at the end. Only the monitoring queries, which are network-bound and may hang on an unreachable cluster,
+ * are fanned out across virtual threads. Doing the state lookups inside the fan-out would issue one query per
+ * concurrent thread and exhaust the connection pool as soon as an installation had a few hundred applications.
+ *
+ * <p>Single-instance assumption matches {@link PipelineInstanceScanJob} and {@link ScheduledRestartJob}: two servers
+ * running this would each evaluate every application and could both notify on the same edge.
+ *
+ * <p>Conditional rather than a flag checked on each tick, following how the IDE beans opt in: an installation that
+ * has not asked for alerting does not get a scheduled task at all, instead of one that wakes up every minute to
+ * decide it has nothing to do.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "oops.metrics.alert", name = "enabled", havingValue = "true")
+public class ResourceAlertScanJob {
+
+    private record AlertTarget(String namespace,
+                               String applicationName,
+                               Environment environment,
+                               ResourceMetric metric,
+                               long limitValue,
+                               long threshold,
+                               int thresholdPercent,
+                               Duration window) {
+    }
+
+    /** {@code failure} is null on success; {@code monitoringMissing} separates "no backend here" from a real error. */
+    private record ProbeOutcome(AlertTarget target,
+                                List<String> firingPods,
+                                String failure,
+                                boolean monitoringMissing) {
+    }
+
+    private final AtomicBoolean scanInProgress = new AtomicBoolean(false);
+    private final ApplicationRuntimeSpecRepository runtimeSpecRepository;
+    private final ApplicationAlertStateRepository alertStateRepository;
+    private final EnvironmentService environmentService;
+    private final ResourceAlertProbe resourceAlertProbe;
+    private final ResourceAlertProperties properties;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ResourceAlertScanJob(ApplicationRuntimeSpecRepository runtimeSpecRepository,
+                                ApplicationAlertStateRepository alertStateRepository,
+                                EnvironmentService environmentService,
+                                ResourceAlertProbe resourceAlertProbe,
+                                ResourceAlertProperties properties,
+                                ApplicationEventPublisher eventPublisher) {
+        this.runtimeSpecRepository = runtimeSpecRepository;
+        this.alertStateRepository = alertStateRepository;
+        this.environmentService = environmentService;
+        this.resourceAlertProbe = resourceAlertProbe;
+        this.properties = properties;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    public void scanResourceAlerts() {
+        if (!scanInProgress.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            List<AlertTarget> targets = collectTargets();
+            if (targets.isEmpty()) {
+                return;
+            }
+            List<ProbeOutcome> outcomes = probe(targets);
+            reportProbeFailures(outcomes);
+            applyOutcomes(outcomes);
+        } catch (Exception exception) {
+            log.error("Resource alert scan failed: {}", exception.getMessage(), exception);
+        } finally {
+            scanInProgress.set(false);
+        }
+    }
+
+    private List<AlertTarget> collectTargets() {
+        Map<String, Environment> environmentsByName = environmentService.getEnvironments().stream()
+                .collect(Collectors.toMap(
+                        Environment::getName,
+                        environment -> environment,
+                        (first, second) -> first));
+
+        List<AlertTarget> targets = new ArrayList<>();
+        for (ApplicationRuntimeSpec runtimeSpec : runtimeSpecRepository.findAll()) {
+            List<ApplicationRuntimeSpec.EnvironmentConfig> environmentConfigs = runtimeSpec.getEnvironmentConfigs();
+            if (environmentConfigs == null) {
+                continue;
+            }
+            for (ApplicationRuntimeSpec.EnvironmentConfig environmentConfig : environmentConfigs) {
+                Environment environment = environmentsByName.get(environmentConfig.getEnvironmentName());
+                if (environment == null) {
+                    continue;
+                }
+                addTarget(targets, runtimeSpec, environment, ResourceMetric.CPU,
+                        ResourceQuantities.toMillicores(environmentConfig.getCpuLimit()), properties.getCpu());
+                addTarget(targets, runtimeSpec, environment, ResourceMetric.MEMORY,
+                        ResourceQuantities.toBytes(environmentConfig.getMemoryLimit()), properties.getMemory());
+            }
+        }
+        return targets;
+    }
+
+    /**
+     * Skips anything without a usable limit. Kubelet's {@code /metrics/resource} carries no limits series — that
+     * would need kube-state-metrics — so the percentage has to be resolved against the limit OOPS itself stores, and
+     * an application that never set one simply cannot be alerted on.
+     */
+    private void addTarget(List<AlertTarget> targets,
+                           ApplicationRuntimeSpec runtimeSpec,
+                           Environment environment,
+                           ResourceMetric metric,
+                           Long limitValue,
+                           ResourceAlertProperties.Rule rule) {
+        if (limitValue == null || limitValue <= 0 || rule == null) {
+            return;
+        }
+        long threshold = limitValue * rule.getThresholdPercent() / 100L;
+        if (threshold <= 0) {
+            return;
+        }
+        targets.add(new AlertTarget(
+                runtimeSpec.getNamespace(),
+                runtimeSpec.getApplicationName(),
+                environment,
+                metric,
+                limitValue,
+                threshold,
+                rule.getThresholdPercent(),
+                Duration.ofMinutes(Math.max(1, rule.getSustainedMinutes()))));
+    }
+
+    private List<ProbeOutcome> probe(List<AlertTarget> targets) {
+        List<ProbeOutcome> outcomes = new ArrayList<>(targets.size());
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<ProbeOutcome>> futures = new ArrayList<>(targets.size());
+            for (AlertTarget target : targets) {
+                futures.add(executor.submit(() -> probeOne(target)));
+            }
+            for (Future<ProbeOutcome> future : futures) {
+                try {
+                    outcomes.add(future.get());
+                } catch (Exception exception) {
+                    log.error("Resource alert probe task failed: {}", exception.getMessage(), exception);
+                }
+            }
+        }
+        return outcomes;
+    }
+
+    private ProbeOutcome probeOne(AlertTarget target) {
+        try {
+            List<String> firingPods = resourceAlertProbe.podsSustainedAbove(
+                    target.environment(),
+                    target.namespace(),
+                    target.applicationName(),
+                    target.metric(),
+                    target.threshold(),
+                    target.window());
+            return new ProbeOutcome(target, firingPods, null, false);
+        } catch (Exception exception) {
+            boolean monitoringMissing = MonitoringErrors.NOT_AVAILABLE.equals(exception.getMessage());
+            return new ProbeOutcome(target, List.of(), String.valueOf(exception.getMessage()), monitoringMissing);
+        }
+    }
+
+    /**
+     * Collapses failures to one line per environment. An environment with no monitoring backend fails every one of
+     * its targets, every minute, forever — logging that per target would bury everything else, and at warn level it
+     * would look like a fault rather than an installation that simply has no monitoring.
+     */
+    private void reportProbeFailures(List<ProbeOutcome> outcomes) {
+        Set<String> withoutMonitoring = new LinkedHashSet<>();
+        Map<String, String> failures = new LinkedHashMap<>();
+        for (ProbeOutcome outcome : outcomes) {
+            if (outcome.failure() == null) {
+                continue;
+            }
+            String environmentName = outcome.target().environment().getName();
+            if (outcome.monitoringMissing()) {
+                withoutMonitoring.add(environmentName);
+            } else {
+                failures.putIfAbsent(environmentName, outcome.failure());
+            }
+        }
+        if (!withoutMonitoring.isEmpty()) {
+            log.debug("Resource alerts skipped, no monitoring backend in environments {}", withoutMonitoring);
+        }
+        failures.forEach((environmentName, message) ->
+                log.warn("Resource alert probe failed in environment {}: {}", environmentName, message));
+    }
+
+    private void applyOutcomes(List<ProbeOutcome> outcomes) {
+        Map<String, ApplicationAlertState> statesByKey = new HashMap<>();
+        for (ApplicationAlertState state : alertStateRepository.findAll()) {
+            statesByKey.put(stateKey(state.getNamespace(), state.getApplicationName(),
+                    state.getEnvironmentName(), state.getMetric()), state);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        List<ApplicationAlertState> changed = new ArrayList<>();
+        List<ApplicationAlertEvent> events = new ArrayList<>();
+
+        for (ProbeOutcome outcome : outcomes) {
+            if (outcome.failure() != null) {
+                // A probe that could not run says nothing about the application. Leaving the state untouched means a
+                // firing alert is neither repeated nor falsely resolved while monitoring is unreachable.
+                continue;
+            }
+            AlertTarget target = outcome.target();
+            String key = stateKey(target.namespace(), target.applicationName(),
+                    target.environment().getName(), target.metric().name());
+            ApplicationAlertState state = statesByKey.get(key);
+            boolean firing = !outcome.firingPods().isEmpty();
+
+            if (firing && (state == null || !state.isFiring())) {
+                ApplicationAlertState updated = state != null ? state : newState(target);
+                updated.setFiring(true);
+                updated.setFiringSince(now);
+                updated.setLastNotifiedTime(now);
+                changed.add(updated);
+                events.add(event(target, ApplicationAlertType.FIRING, outcome.firingPods(), false, now, now));
+            } else if (firing && dueForRepeat(state, now)) {
+                state.setLastNotifiedTime(now);
+                changed.add(state);
+                events.add(event(target, ApplicationAlertType.FIRING, outcome.firingPods(), true,
+                        state.getFiringSince(), now));
+            } else if (!firing && state != null && state.isFiring()) {
+                state.setFiring(false);
+                state.setLastNotifiedTime(now);
+                changed.add(state);
+                events.add(event(target, ApplicationAlertType.RESOLVED, List.of(), false,
+                        state.getFiringSince(), now));
+            }
+        }
+
+        if (!changed.isEmpty()) {
+            alertStateRepository.saveAll(changed);
+        }
+        // Published only after the state is committed: a listener failure must not be able to leave the row saying
+        // "already notified" while nothing was sent, nor the reverse.
+        events.forEach(eventPublisher::publishEvent);
+    }
+
+    private boolean dueForRepeat(ApplicationAlertState state, LocalDateTime now) {
+        if (state == null || !state.isFiring()) {
+            return false;
+        }
+        if (state.getLastNotifiedTime() == null) {
+            return true;
+        }
+        return Duration.between(state.getLastNotifiedTime(), now).toMinutes()
+                >= Math.max(1, properties.getRepeatIntervalMinutes());
+    }
+
+    private ApplicationAlertState newState(AlertTarget target) {
+        ApplicationAlertState state = new ApplicationAlertState();
+        state.setNamespace(target.namespace());
+        state.setApplicationName(target.applicationName());
+        state.setEnvironmentName(target.environment().getName());
+        state.setMetric(target.metric().name());
+        return state;
+    }
+
+    private ApplicationAlertEvent event(AlertTarget target,
+                                        ApplicationAlertType type,
+                                        List<String> pods,
+                                        boolean repeated,
+                                        LocalDateTime firingSince,
+                                        LocalDateTime occurredAt) {
+        return new ApplicationAlertEvent(
+                type,
+                target.namespace(),
+                target.applicationName(),
+                target.environment().getName(),
+                target.metric(),
+                target.thresholdPercent(),
+                target.threshold(),
+                target.limitValue(),
+                List.copyOf(pods),
+                repeated,
+                firingSince,
+                occurredAt);
+    }
+
+    private String stateKey(String namespace, String applicationName, String environmentName, String metric) {
+        return namespace + "|" + applicationName + "|" + environmentName + "|" + metric;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/shared/util/ResourceQuantities.java
+++ b/src/main/java/com/github/wellch4n/oops/shared/util/ResourceQuantities.java
@@ -1,0 +1,72 @@
+package com.github.wellch4n.oops.shared.util;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses Kubernetes resource quantity strings ({@code 500m}, {@code 2}, {@code 512Mi}, {@code 1Gi}) into plain
+ * numbers.
+ *
+ * <p>Fabric8 has {@code Quantity} for this, but the application layer is not allowed to import Fabric8 — and the
+ * alert evaluator needs to turn a configured limit into a comparable number before it can build a PromQL threshold.
+ *
+ * <p>Every method returns {@code null} rather than throwing when the input is blank or malformed. The only caller
+ * treats "no usable limit" and "no limit configured" identically: both mean the application cannot be alerted on,
+ * which is the agreed behaviour when an application has no resource limits set.
+ */
+public final class ResourceQuantities {
+
+    private static final Pattern QUANTITY = Pattern.compile("^(\\d+(?:\\.\\d+)?(?:[eE][-+]?\\d+)?)\\s*([a-zA-Z]*)$");
+
+    private static final Map<String, Double> MULTIPLIERS = Map.ofEntries(
+            Map.entry("", 1d),
+            Map.entry("m", 1e-3),
+            Map.entry("k", 1e3),
+            Map.entry("K", 1e3),
+            Map.entry("M", 1e6),
+            Map.entry("G", 1e9),
+            Map.entry("T", 1e12),
+            Map.entry("P", 1e15),
+            Map.entry("E", 1e18),
+            Map.entry("Ki", 1024d),
+            Map.entry("Mi", 1024d * 1024),
+            Map.entry("Gi", 1024d * 1024 * 1024),
+            Map.entry("Ti", 1024d * 1024 * 1024 * 1024),
+            Map.entry("Pi", 1024d * 1024 * 1024 * 1024 * 1024),
+            Map.entry("Ei", 1024d * 1024 * 1024 * 1024 * 1024 * 1024));
+
+    private ResourceQuantities() {
+    }
+
+    /** {@code 500m} → 500, {@code 2} → 2000. Null when unparseable. */
+    public static Long toMillicores(String quantity) {
+        Double cores = parse(quantity);
+        return cores == null ? null : Math.round(cores * 1000d);
+    }
+
+    /** {@code 512Mi} → 536870912. Null when unparseable. */
+    public static Long toBytes(String quantity) {
+        Double bytes = parse(quantity);
+        return bytes == null ? null : Math.round(bytes);
+    }
+
+    private static Double parse(String quantity) {
+        if (quantity == null || quantity.isBlank()) {
+            return null;
+        }
+        Matcher matcher = QUANTITY.matcher(quantity.trim());
+        if (!matcher.matches()) {
+            return null;
+        }
+        Double multiplier = MULTIPLIERS.get(matcher.group(2));
+        if (multiplier == null) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(matcher.group(1)) * multiplier;
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/db/migration/V19__add_application_alert_state.sql
+++ b/src/main/resources/db/migration/V19__add_application_alert_state.sql
@@ -1,0 +1,21 @@
+-- Edge-trigger state for the resource alerts: one row per application + environment + metric.
+--
+-- The scan job re-evaluates every minute, so without somewhere to remember the previous answer a problem that lasts
+-- an afternoon would send one message per minute. Persisted rather than in-memory so a restart does not re-announce
+-- everything that was already known to be firing.
+CREATE TABLE `application_alert_state` (
+    `id` varchar(255) NOT NULL,
+    `created_time` datetime(6) DEFAULT NULL,
+    `namespace` varchar(255) DEFAULT NULL,
+    `application_name` varchar(255) DEFAULT NULL,
+    `environment_name` varchar(255) DEFAULT NULL,
+    `metric` varchar(32) DEFAULT NULL,
+    `firing` bit(1) NOT NULL DEFAULT b'0',
+    `firing_since` datetime(6) DEFAULT NULL,
+    `last_notified_time` datetime(6) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    -- Prefix lengths, not whole columns: four varchar(255) columns under utf8mb4 come to 4080 bytes and InnoDB caps an
+    -- index at 3072. 64 characters is comfortably above the 63-character ceiling Kubernetes puts on the names that
+    -- actually go in here, so the prefix cannot truncate two distinct targets into one.
+    UNIQUE KEY `uk_alert_state_target` (`namespace`(64), `application_name`(64), `environment_name`(64), `metric`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusPodMetricHistoryProviderTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusPodMetricHistoryProviderTests.java
@@ -30,6 +30,11 @@ class PrometheusPodMetricHistoryProviderTests {
             queries.add(query);
             return responses.get(queries.size() - 1);
         }
+
+        @Override
+        public String query(Environment environment, MetricsHistoryProperties.Backend backend, String query) {
+            throw new UnsupportedOperationException("the charts only use range queries");
+        }
     }
 
     private static final String CPU_BODY = """

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusResourceAlertProbeTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/metrics/PrometheusResourceAlertProbeTests.java
@@ -1,0 +1,121 @@
+package com.github.wellch4n.oops.infrastructure.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.wellch4n.oops.application.dto.ResourceMetric;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.infrastructure.config.MetricsHistoryProperties;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PrometheusResourceAlertProbeTests {
+
+    private static final class StubTransport implements PrometheusQueryTransport {
+
+        private String response = """
+                {"status":"success","data":{"resultType":"vector","result":[]}}""";
+
+        @Override
+        public String queryRange(Environment environment, MetricsHistoryProperties.Backend backend,
+                                 String query, long start, long end, int step) {
+            throw new UnsupportedOperationException("the alert probe only uses instant queries");
+        }
+
+        @Override
+        public String query(Environment environment, MetricsHistoryProperties.Backend backend, String query) {
+            return response;
+        }
+    }
+
+    private MetricsHistoryProperties properties;
+    private StubTransport transport;
+    private PrometheusResourceAlertProbe probe;
+    private Environment environment;
+
+    @BeforeEach
+    void setUp() {
+        properties = new MetricsHistoryProperties();
+        properties.setIntervalSeconds(30);
+        transport = new StubTransport();
+        probe = new PrometheusResourceAlertProbe(transport, properties);
+
+        environment = new Environment();
+        environment.setName("prod");
+    }
+
+    /**
+     * The entire alert condition has to be inside the expression. {@code min_over_time} over the window means the
+     * lowest reading never fell below the threshold — if this ever became {@code max_over_time} or lost the window,
+     * a single spike would page someone.
+     */
+    @Test
+    void memoryQueryAsksWhetherUsageNeverDroppedBelowThreshold() {
+        String query = probe.buildQuery("namespace=\"ns\"", ResourceMetric.MEMORY, 1000L, Duration.ofMinutes(5));
+
+        assertTrue(query.startsWith("min_over_time("), query);
+        assertTrue(query.contains("sum by (pod) (container_memory_working_set_bytes{namespace=\"ns\"})"), query);
+        assertTrue(query.contains("[300s:30s]"), query);
+        assertTrue(query.endsWith("> 1000"), query);
+    }
+
+    /** CPU is a counter, so it must go through rate, and the rate window must span at least two scrapes. */
+    @Test
+    void cpuQueryRatesTheCounterAndConvertsToMillicores() {
+        String query = probe.buildQuery("namespace=\"ns\"", ResourceMetric.CPU, 950L, Duration.ofMinutes(10));
+
+        assertTrue(query.contains("rate(container_cpu_usage_seconds_total{namespace=\"ns\"}[60s])"), query);
+        assertTrue(query.contains("* 1000"), query);
+        assertTrue(query.contains("[600s:30s]"), query);
+    }
+
+    /** A window shorter than two scrapes would leave the subquery with nothing to reduce. */
+    @Test
+    void windowNeverFallsBelowTwoScrapeIntervals() {
+        String query = probe.buildQuery("namespace=\"ns\"", ResourceMetric.MEMORY, 1L, Duration.ofSeconds(10));
+
+        assertTrue(query.contains("[60s:30s]"), query);
+    }
+
+    @Test
+    void readsPodNamesOutOfVectorResult() {
+        transport.response = """
+                {"status":"success","data":{"resultType":"vector","result":[
+                  {"metric":{"pod":"my-app-0","namespace":"ns"},"value":[1700000000,"1500"]},
+                  {"metric":{"pod":"my-app-2","namespace":"ns"},"value":[1700000000,"1600"]}
+                ]}}""";
+
+        List<String> pods = probe.podsSustainedAbove(
+                environment, "ns", "my-app", ResourceMetric.CPU, 950L, Duration.ofMinutes(10));
+
+        assertEquals(List.of("my-app-0", "my-app-2"), pods);
+    }
+
+    @Test
+    void emptyResultMeansNothingIsFiring() {
+        List<String> pods = probe.podsSustainedAbove(
+                environment, "ns", "my-app", ResourceMetric.MEMORY, 1L, Duration.ofMinutes(5));
+
+        assertTrue(pods.isEmpty());
+    }
+
+    /** Same guard as the charts: a name with a quote could close the matcher and read another namespace's series. */
+    @Test
+    void rejectsNamesThatWouldEscapeTheMatcher() {
+        assertThrows(BizException.class, () -> probe.podsSustainedAbove(
+                environment, "ns\"} or up{", "my-app", ResourceMetric.CPU, 1L, Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void reportsMonitoringAsUnavailableWhenNoBackendIsConfigured() {
+        properties.getBackend().setNamespace("");
+
+        BizException exception = assertThrows(BizException.class, () -> probe.podsSustainedAbove(
+                environment, "ns", "my-app", ResourceMetric.CPU, 1L, Duration.ofMinutes(5)));
+        assertEquals(MonitoringErrors.NOT_AVAILABLE, exception.getMessage());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/scheduler/ResourceAlertOptInTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/scheduler/ResourceAlertOptInTests.java
@@ -1,0 +1,54 @@
+package com.github.wellch4n.oops.infrastructure.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.github.wellch4n.oops.application.port.ResourceAlertProbe;
+import com.github.wellch4n.oops.application.service.EnvironmentService;
+import com.github.wellch4n.oops.infrastructure.config.ResourceAlertProperties;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationAlertStateRepository;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationRuntimeSpecRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Alerting is opt-in, and the mechanism is the bean condition rather than a flag read on each tick. These assertions
+ * are what stop an upgrade from quietly starting to message people: an installation whose config never mentions
+ * {@code oops.metrics.alert} must end up with no scheduled scan at all.
+ */
+class ResourceAlertOptInTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(ResourceAlertProperties.class, ResourceAlertScanJob.class)
+            .withBean(ApplicationRuntimeSpecRepository.class, () -> mock(ApplicationRuntimeSpecRepository.class))
+            .withBean(ApplicationAlertStateRepository.class, () -> mock(ApplicationAlertStateRepository.class))
+            .withBean(EnvironmentService.class, () -> mock(EnvironmentService.class))
+            .withBean(ResourceAlertProbe.class, () -> mock(ResourceAlertProbe.class));
+
+    @Test
+    void scanJobIsAbsentWhenNothingIsConfigured() {
+        runner.run(context -> assertNoAlerting(context));
+    }
+
+    @Test
+    void scanJobIsAbsentWhenExplicitlyDisabled() {
+        runner.withPropertyValues("oops.metrics.alert.enabled=false")
+                .run(context -> assertNoAlerting(context));
+    }
+
+    @Test
+    void scanJobIsLoadedOnceEnabled() {
+        runner.withPropertyValues("oops.metrics.alert.enabled=true")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ResourceAlertScanJob.class);
+                    assertThat(context).hasSingleBean(ResourceAlertProperties.class);
+                });
+    }
+
+    /** The properties bean goes too, so a stray injection cannot resurrect alerting on its own. */
+    private void assertNoAlerting(AssertableApplicationContext context) {
+        assertThat(context).doesNotHaveBean(ResourceAlertScanJob.class);
+        assertThat(context).doesNotHaveBean(ResourceAlertProperties.class);
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/scheduler/ResourceAlertScanJobTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/scheduler/ResourceAlertScanJobTests.java
@@ -1,0 +1,244 @@
+package com.github.wellch4n.oops.infrastructure.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.wellch4n.oops.application.dto.ResourceMetric;
+import com.github.wellch4n.oops.application.event.ApplicationAlertEvent;
+import com.github.wellch4n.oops.application.event.ApplicationAlertType;
+import com.github.wellch4n.oops.application.port.ResourceAlertProbe;
+import com.github.wellch4n.oops.application.service.EnvironmentService;
+import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.infrastructure.config.ResourceAlertProperties;
+import com.github.wellch4n.oops.infrastructure.metrics.MonitoringErrors;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationAlertState;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationAlertStateRepository;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationRuntimeSpec;
+import com.github.wellch4n.oops.infrastructure.persistence.jpa.ApplicationRuntimeSpecRepository;
+import com.github.wellch4n.oops.shared.exception.BizException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the edge-triggering rules. Getting these wrong is not a subtle failure: the scan runs every minute, so a
+ * missing suppression turns one problem into sixty messages an hour, and a missing transition means an alert that
+ * never arrives or never clears.
+ */
+class ResourceAlertScanJobTests {
+
+    private static final long TWO_GIB = 2L * 1024 * 1024 * 1024;
+
+    /** Returns whatever the test says is firing, and records what it was asked. */
+    private static final class StubProbe implements ResourceAlertProbe {
+
+        private final Map<ResourceMetric, List<String>> firingPods = new EnumMap<>(ResourceMetric.class);
+        private final Map<ResourceMetric, Long> thresholds = new EnumMap<>(ResourceMetric.class);
+        private final Map<ResourceMetric, Duration> windows = new EnumMap<>(ResourceMetric.class);
+        private RuntimeException failure;
+        private int calls;
+
+        @Override
+        public List<String> podsSustainedAbove(Environment environment, String namespace, String applicationName,
+                                               ResourceMetric metric, long threshold, Duration window) {
+            calls++;
+            thresholds.put(metric, threshold);
+            windows.put(metric, window);
+            if (failure != null) {
+                throw failure;
+            }
+            return firingPods.getOrDefault(metric, List.of());
+        }
+    }
+
+    private ApplicationRuntimeSpecRepository runtimeSpecRepository;
+    private ApplicationAlertStateRepository alertStateRepository;
+    private ResourceAlertProperties properties;
+    private StubProbe probe;
+    private List<ApplicationAlertEvent> published;
+    private ResourceAlertScanJob job;
+
+    @BeforeEach
+    void setUp() {
+        runtimeSpecRepository = mock(ApplicationRuntimeSpecRepository.class);
+        alertStateRepository = mock(ApplicationAlertStateRepository.class);
+        EnvironmentService environmentService = mock(EnvironmentService.class);
+        // The job only exists when alerting is switched on — see ResourceAlertOptInTests — so every test here is
+        // about what it does once it has been constructed.
+        properties = new ResourceAlertProperties();
+        probe = new StubProbe();
+        published = new ArrayList<>();
+
+        Environment environment = new Environment();
+        environment.setName("prod");
+        when(environmentService.getEnvironments()).thenReturn(List.of(environment));
+        when(alertStateRepository.findAll()).thenReturn(List.of());
+        when(runtimeSpecRepository.findAll()).thenReturn(List.of());
+
+        job = new ResourceAlertScanJob(runtimeSpecRepository, alertStateRepository, environmentService,
+                probe, properties, event -> {
+            if (event instanceof ApplicationAlertEvent alertEvent) {
+                published.add(alertEvent);
+            }
+        });
+    }
+
+    private void givenLimits(String cpuLimit, String memoryLimit) {
+        ApplicationRuntimeSpec runtimeSpec = new ApplicationRuntimeSpec();
+        runtimeSpec.setNamespace("ns");
+        runtimeSpec.setApplicationName("my-app");
+        ApplicationRuntimeSpec.EnvironmentConfig environmentConfig = new ApplicationRuntimeSpec.EnvironmentConfig();
+        environmentConfig.setEnvironmentName("prod");
+        environmentConfig.setCpuLimit(cpuLimit);
+        environmentConfig.setMemoryLimit(memoryLimit);
+        runtimeSpec.setEnvironmentConfigs(List.of(environmentConfig));
+        when(runtimeSpecRepository.findAll()).thenReturn(List.of(runtimeSpec));
+    }
+
+    private ApplicationAlertState givenFiringState(ResourceMetric metric, LocalDateTime lastNotified) {
+        ApplicationAlertState state = new ApplicationAlertState();
+        state.setNamespace("ns");
+        state.setApplicationName("my-app");
+        state.setEnvironmentName("prod");
+        state.setMetric(metric.name());
+        state.setFiring(true);
+        state.setFiringSince(lastNotified.minusMinutes(2));
+        state.setLastNotifiedTime(lastNotified);
+        when(alertStateRepository.findAll()).thenReturn(List.of(state));
+        return state;
+    }
+
+    @Test
+    void firesOnceWhenUsageFirstCrossesTheThreshold() {
+        givenLimits(null, "2Gi");
+        probe.firingPods.put(ResourceMetric.MEMORY, List.of("my-app-0"));
+
+        job.scanResourceAlerts();
+
+        assertEquals(1, published.size());
+        ApplicationAlertEvent event = published.getFirst();
+        assertEquals(ApplicationAlertType.FIRING, event.type());
+        assertEquals(ResourceMetric.MEMORY, event.metric());
+        assertFalse(event.repeated());
+        assertEquals(List.of("my-app-0"), event.pods());
+        assertNotNull(event.firingSince());
+    }
+
+    /** The threshold is a percentage of the limit OOPS stores, because the metrics backend carries no limits series. */
+    @Test
+    void thresholdIsAPercentageOfTheConfiguredLimit() {
+        givenLimits("1", "2Gi");
+
+        job.scanResourceAlerts();
+
+        assertEquals(950L, probe.thresholds.get(ResourceMetric.CPU));
+        assertEquals(TWO_GIB * 90 / 100, probe.thresholds.get(ResourceMetric.MEMORY));
+        assertEquals(Duration.ofMinutes(10), probe.windows.get(ResourceMetric.CPU));
+        assertEquals(Duration.ofMinutes(5), probe.windows.get(ResourceMetric.MEMORY));
+    }
+
+    /** No limit means no denominator, so there is nothing to take a percentage of and the target is skipped. */
+    @Test
+    void skipsApplicationsWithoutUsableLimits() {
+        givenLimits(null, "not-a-quantity");
+
+        job.scanResourceAlerts();
+
+        assertEquals(0, probe.calls);
+        assertTrue(published.isEmpty());
+    }
+
+    @Test
+    void staysSilentWhileStillFiringInsideTheRepeatInterval() {
+        givenLimits(null, "2Gi");
+        givenFiringState(ResourceMetric.MEMORY, LocalDateTime.now().minusMinutes(5));
+        probe.firingPods.put(ResourceMetric.MEMORY, List.of("my-app-0"));
+
+        job.scanResourceAlerts();
+
+        assertTrue(published.isEmpty());
+        verify(alertStateRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void repeatsOnceTheRepeatIntervalHasPassed() {
+        givenLimits(null, "2Gi");
+        LocalDateTime lastNotified = LocalDateTime.now().minusMinutes(31);
+        ApplicationAlertState state = givenFiringState(ResourceMetric.MEMORY, lastNotified);
+        probe.firingPods.put(ResourceMetric.MEMORY, List.of("my-app-0"));
+
+        job.scanResourceAlerts();
+
+        assertEquals(1, published.size());
+        ApplicationAlertEvent event = published.getFirst();
+        assertEquals(ApplicationAlertType.FIRING, event.type());
+        assertTrue(event.repeated());
+        // The streak start survives the repeat, so the message can still say how long this has been going on.
+        assertEquals(state.getFiringSince(), event.firingSince());
+    }
+
+    @Test
+    void resolvesWhenUsageFallsBackUnderTheThreshold() {
+        givenLimits(null, "2Gi");
+        ApplicationAlertState state = givenFiringState(ResourceMetric.MEMORY, LocalDateTime.now().minusMinutes(5));
+
+        job.scanResourceAlerts();
+
+        assertEquals(1, published.size());
+        assertEquals(ApplicationAlertType.RESOLVED, published.getFirst().type());
+        assertTrue(published.getFirst().pods().isEmpty());
+        assertFalse(state.isFiring());
+    }
+
+    @Test
+    void saysNothingWhenNothingIsFiring() {
+        givenLimits("1", "2Gi");
+
+        job.scanResourceAlerts();
+
+        assertTrue(published.isEmpty());
+        verify(alertStateRepository, never()).saveAll(any());
+    }
+
+    /**
+     * An unreachable backend must not be read as recovery. Clearing the state here would send an all-clear for a
+     * problem that is very possibly still happening, and then re-fire the moment monitoring came back.
+     */
+    @Test
+    void unreachableMonitoringLeavesFiringStateAlone() {
+        givenLimits(null, "2Gi");
+        ApplicationAlertState state = givenFiringState(ResourceMetric.MEMORY, LocalDateTime.now().minusMinutes(45));
+        probe.failure = new BizException(MonitoringErrors.NOT_AVAILABLE);
+
+        job.scanResourceAlerts();
+
+        assertTrue(published.isEmpty());
+        assertTrue(state.isFiring());
+        verify(alertStateRepository, never()).saveAll(any());
+    }
+
+    /** A ten-replica application with every pod hot is one problem, so it gets one message listing them. */
+    @Test
+    void sendsOneEventPerApplicationRatherThanPerPod() {
+        givenLimits(null, "2Gi");
+        probe.firingPods.put(ResourceMetric.MEMORY, List.of("my-app-0", "my-app-1", "my-app-2"));
+
+        job.scanResourceAlerts();
+
+        assertEquals(1, published.size());
+        assertEquals(3, published.getFirst().pods().size());
+    }
+
+}

--- a/src/test/java/com/github/wellch4n/oops/shared/util/ResourceQuantitiesTests.java
+++ b/src/test/java/com/github/wellch4n/oops/shared/util/ResourceQuantitiesTests.java
@@ -1,0 +1,45 @@
+package com.github.wellch4n.oops.shared.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceQuantitiesTests {
+
+    @Test
+    void parsesCpuQuantities() {
+        assertEquals(500L, ResourceQuantities.toMillicores("500m"));
+        assertEquals(2000L, ResourceQuantities.toMillicores("2"));
+        assertEquals(1500L, ResourceQuantities.toMillicores("1.5"));
+        assertEquals(250L, ResourceQuantities.toMillicores(" 250m "));
+    }
+
+    @Test
+    void parsesBinaryMemorySuffixes() {
+        assertEquals(536870912L, ResourceQuantities.toBytes("512Mi"));
+        assertEquals(1073741824L, ResourceQuantities.toBytes("1Gi"));
+        assertEquals(2147483648L, ResourceQuantities.toBytes("2Gi"));
+    }
+
+    @Test
+    void parsesDecimalMemorySuffixes() {
+        assertEquals(1_000_000_000L, ResourceQuantities.toBytes("1G"));
+        assertEquals(512_000_000L, ResourceQuantities.toBytes("512M"));
+        assertEquals(129_000_000L, ResourceQuantities.toBytes("129e6"));
+    }
+
+    /**
+     * Every unusable input has to come back null rather than throwing or defaulting: the alert scan reads these
+     * straight off user-entered limits, and one malformed value must skip that one target, not fail the whole scan.
+     */
+    @Test
+    void returnsNullForUnusableInput() {
+        assertNull(ResourceQuantities.toBytes(null));
+        assertNull(ResourceQuantities.toBytes(""));
+        assertNull(ResourceQuantities.toBytes("   "));
+        assertNull(ResourceQuantities.toBytes("lots"));
+        assertNull(ResourceQuantities.toBytes("512Zi"));
+        assertNull(ResourceQuantities.toMillicores("-1"));
+    }
+}


### PR DESCRIPTION
The usage charts show that an application is close to its CPU or memory ceiling, but only to whoever thinks to open them. Nothing told the owner, so the first sign of a memory problem was usually the OOMKill.

Adds a scan that runs once a minute and asks the cluster's Prometheus-compatible backend whether any application has stayed above a percentage of its configured limit for a whole window, then messages the owner over the existing external channel.

- Thresholds are configured once for the installation under oops.metrics.alert; there is nothing to set per application. An application becomes alertable by having limits in its runtime spec, because kubelet's /metrics/resource carries no limits series to take a percentage of — that would need kube-state-metrics — so the limit OOPS already stores is the only available denominator.
- CPU and memory do not share a threshold. Exceeding a memory limit is an OOMKill, discrete and fatal, so it warns early at 90% over 5 minutes. Exceeding a CPU limit only throttles, and the metric that would really show throttling is cAdvisor-only, so "sitting against the limit" is an approximation that needs headroom: 95% over 10 minutes.
- The whole "sustained for N minutes" condition is pushed into PromQL as min_over_time(...) > threshold, so a returned row is a pod that never dropped below the line and OOPS keeps no time series of its own. The pod matcher is shared with the charts through PrometheusSelectors.
- The scan reads its targets and its previous state in one query each on the scan thread and fans out only the network-bound probes, so an installation with a few hundred applications cannot exhaust the connection pool. application_alert_state makes it edge-triggered: one message when it starts, a reminder every 30 minutes, one when it clears, and nothing at all while the backend is unreachable — a probe that could not run leaves the state alone rather than reading as recovery. One message per application, listing the offending pods, rather than one per pod.
- Off unless oops.metrics.alert.enabled is set, via @ConditionalOnProperty like the IDE beans, so the bean and its scheduled task do not exist until an installation asks for them.