### PR TITLE
fix(web): tidy up filter labels, the app mark and the metrics drawer

### DIFF
--- a/web/app/apps/components/application-metrics-drawer.tsx
+++ b/web/app/apps/components/application-metrics-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Area, AreaChart, CartesianGrid, ReferenceLine, XAxis, YAxis } from "recharts"
-import { Loader2, RefreshCw } from "lucide-react"
+import { Loader2, RefreshCw, X } from "lucide-react"
 
 import {
   getApplicationMetricsHistory,
@@ -13,6 +13,7 @@ import {
 import type { ApplicationRuntimeSpecEnvironmentConfig, PodMetricHistory } from "@/lib/api/types"
 import {
   Drawer,
+  DrawerClose,
   DrawerContent,
   DrawerDescription,
   DrawerHeader,
@@ -389,15 +390,25 @@ export function ApplicationMetricsDrawer({
                 {applicationName} · {environmentName}
               </DrawerDescription>
             </div>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => load(true)}
-              disabled={loading}
-              aria-label={t("apps.metrics.refresh")}
-            >
-              <RefreshCw className={loading ? "animate-spin" : undefined} />
-            </Button>
+            {/* Clicking the scrim closes the drawer too, but nothing on screen
+                says so — Dialog puts an explicit X in the same corner, so this
+                one does as well. */}
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => load(true)}
+                disabled={loading}
+                aria-label={t("apps.metrics.refresh")}
+              >
+                <RefreshCw className={loading ? "animate-spin" : undefined} />
+              </Button>
+              <DrawerClose
+                render={<Button variant="ghost" size="icon-sm" aria-label={t("common.close")} />}
+              >
+                <X />
+              </DrawerClose>
+            </div>
           </div>
 
           <div className="mt-3 flex flex-wrap items-center gap-3">

--- a/web/app/apps/page.tsx
+++ b/web/app/apps/page.tsx
@@ -130,7 +130,7 @@ function AppsContent() {
                 />
               </div>
               <div className="flex flex-col gap-1.5">
-                <span className="text-sm font-medium leading-none whitespace-nowrap flex items-center gap-1.5"><User className="size-4" />{t("common.owner")}:</span>
+                <span className="text-sm font-medium leading-none whitespace-nowrap flex items-center gap-1.5"><User className="size-4" />{t("apps.ownerFilter")}</span>
                 <div className="inline-flex rounded-lg border bg-muted p-0.5 h-9">
                   <button
                     type="button"

--- a/web/app/assets/[[...path]]/page.tsx
+++ b/web/app/assets/[[...path]]/page.tsx
@@ -122,7 +122,7 @@ export default function AssetsPage() {
             <div className="flex flex-col gap-1.5">
               <span className="text-sm font-medium leading-none whitespace-nowrap flex items-center gap-1.5">
                 <Search className="size-4" />
-                {t("assets.col.fileName")}:
+                {t("assets.searchLabel")}
               </span>
               <div className="flex items-center gap-2">
                 <Input

--- a/web/app/networks/domains/page.tsx
+++ b/web/app/networks/domains/page.tsx
@@ -60,7 +60,7 @@ export default function DomainsPage() {
             <div className="flex flex-col gap-1.5">
               <span className="text-sm font-medium leading-none whitespace-nowrap flex items-center gap-1.5">
                 <Search className="size-4" />
-                {t("domains.title")}
+                {t("domains.searchLabel")}
               </span>
               <div className="flex items-center gap-2">
                 <Input

--- a/web/components/app-identity-mark.tsx
+++ b/web/components/app-identity-mark.tsx
@@ -25,9 +25,12 @@ export function AppIdentityMark({ seed, className }: AppIdentityMarkProps) {
         aria-hidden
         className={cn(
           MARK_BASE,
-          // 16px fills the 18px inner box, so the glyph carries the same visual
-          // weight as the gradient block, which covers its square edge to edge.
-          "inline-flex items-center justify-center overflow-hidden bg-muted/40 text-[16px] leading-none",
+          // The gradient block paints all 20px edge to edge, so the emoji has to
+          // match the inner box exactly — 18px, the 20px square minus its border —
+          // to carry the same weight. Anything smaller reads as a little glyph on
+          // a plate, since colour-emoji fonts already inset their own ink and the
+          // faint plate contributes nothing the eye measures the mark by.
+          "inline-flex items-center justify-center overflow-hidden bg-muted/40 text-[18px] leading-none",
           // The emoji stands in for an image, so it must not behave like text:
           // no caret, no drag-select, and nothing picked up by a copied selection.
           "select-none",

--- a/web/components/ui/select-with-search.tsx
+++ b/web/components/ui/select-with-search.tsx
@@ -182,7 +182,7 @@ function OptionColorMark({ option }: { option?: Option }) {
     return (
       <span
         aria-hidden
-        className={cn(OPTION_MARK_BASE, "inline-flex select-none items-center justify-center overflow-hidden bg-muted/40 text-[16px] leading-none")}
+        className={cn(OPTION_MARK_BASE, "inline-flex select-none items-center justify-center overflow-hidden bg-muted/40 text-[18px] leading-none")}
       >
         {option.icon}
       </span>

--- a/web/locales/en-US/apps.ts
+++ b/web/locales/en-US/apps.ts
@@ -4,6 +4,7 @@ const apps = {
   "apps.fetchError": "Failed to fetch applications",
   "apps.namespaceFilter": "Namespace:",
   "apps.appNameFilter": "Application:",
+  "apps.ownerFilter": "Owner:",
   "apps.searchPlaceholder": "Search by name or description...",
   "apps.searchBtn": "Search",
   "apps.ownerAll": "All",

--- a/web/locales/en-US/assets.ts
+++ b/web/locales/en-US/assets.ts
@@ -2,6 +2,7 @@ const assets = {
   "assets.title": "Static Assets",
   "assets.uploadBtn": "Upload",
   "assets.refresh": "Refresh",
+  "assets.searchLabel": "Name:",
   "assets.searchPlaceholder": "Search by name prefix, current folder",
   "assets.folder": "Folder",
   "assets.col.fileName": "Name",

--- a/web/locales/en-US/common.ts
+++ b/web/locales/en-US/common.ts
@@ -9,6 +9,7 @@ const common = {
   "common.save": "Save",
   "common.saving": "Saving...",
   "common.cancel": "Cancel",
+  "common.close": "Close",
   "common.create": "Create",
   "common.confirm": "Confirm",
   "common.namespace": "Namespace",

--- a/web/locales/en-US/domains.ts
+++ b/web/locales/en-US/domains.ts
@@ -5,6 +5,7 @@ const domains = {
   "domains.createDesc": "Add a new domain to manage.",
   "domains.editTitle": "Edit Domain",
   "domains.editDesc": "Update domain settings and certificates.",
+  "domains.searchLabel": "Host or description:",
   "domains.searchPlaceholder": "Search host",
   "domains.col.host": "Host",
   "domains.col.certMode": "Cert Mode",

--- a/web/locales/ja-JP/apps.ts
+++ b/web/locales/ja-JP/apps.ts
@@ -4,6 +4,7 @@ const apps = {
   "apps.fetchError": "アプリ一覧の取得に失敗しました",
   "apps.namespaceFilter": "名前空間:",
   "apps.appNameFilter": "アプリ:",
+  "apps.ownerFilter": "担当者:",
   "apps.searchPlaceholder": "名前または説明で検索...",
   "apps.searchBtn": "検索",
   "apps.ownerAll": "全員",

--- a/web/locales/ja-JP/assets.ts
+++ b/web/locales/ja-JP/assets.ts
@@ -2,6 +2,7 @@ const assets = {
   "assets.title": "静的リソース",
   "assets.uploadBtn": "アップロード",
   "assets.refresh": "更新",
+  "assets.searchLabel": "名前:",
   "assets.searchPlaceholder": "名前のプレフィックスで検索（現在のフォルダ）",
   "assets.folder": "フォルダ",
   "assets.col.fileName": "名前",

--- a/web/locales/ja-JP/common.ts
+++ b/web/locales/ja-JP/common.ts
@@ -9,6 +9,7 @@ const common = {
   "common.save": "保存",
   "common.saving": "保存中...",
   "common.cancel": "キャンセル",
+  "common.close": "閉じる",
   "common.create": "作成",
   "common.confirm": "確認",
   "common.namespace": "名前空間",

--- a/web/locales/ja-JP/domains.ts
+++ b/web/locales/ja-JP/domains.ts
@@ -5,6 +5,7 @@ const domains = {
   "domains.createDesc": "新しい管理対象ドメインを追加します。",
   "domains.editTitle": "ドメインを編集",
   "domains.editDesc": "ドメインの設定と証明書を更新します。",
+  "domains.searchLabel": "ホストまたは説明:",
   "domains.searchPlaceholder": "ホストで検索",
   "domains.col.host": "ホスト",
   "domains.col.certMode": "証明書モード",

--- a/web/locales/zh-CN/apps.ts
+++ b/web/locales/zh-CN/apps.ts
@@ -4,6 +4,7 @@ const apps = {
   "apps.fetchError": "获取应用列表失败",
   "apps.namespaceFilter": "命名空间:",
   "apps.appNameFilter": "应用:",
+  "apps.ownerFilter": "负责人:",
   "apps.searchPlaceholder": "搜索应用名或描述...",
   "apps.searchBtn": "搜索",
   "apps.ownerAll": "所有人",

--- a/web/locales/zh-CN/assets.ts
+++ b/web/locales/zh-CN/assets.ts
@@ -2,6 +2,7 @@ const assets = {
   "assets.title": "静态资源",
   "assets.uploadBtn": "上传文件",
   "assets.refresh": "刷新",
+  "assets.searchLabel": "文件名:",
   "assets.searchPlaceholder": "按文件名前缀搜索，仅当前目录",
   "assets.folder": "目录",
   "assets.col.fileName": "文件名",

--- a/web/locales/zh-CN/common.ts
+++ b/web/locales/zh-CN/common.ts
@@ -9,6 +9,7 @@ const common = {
   "common.save": "保存",
   "common.saving": "保存中...",
   "common.cancel": "取消",
+  "common.close": "关闭",
   "common.create": "创建",
   "common.confirm": "确认",
   "common.namespace": "命名空间",

--- a/web/locales/zh-CN/domains.ts
+++ b/web/locales/zh-CN/domains.ts
@@ -5,6 +5,7 @@ const domains = {
   "domains.createDesc": "添加一个新的托管域名。",
   "domains.editTitle": "编辑域名",
   "domains.editDesc": "更新域名设置和证书。",
+  "domains.searchLabel": "域名或描述:",
   "domains.searchPlaceholder": "按域名搜索",
   "domains.col.host": "域名",
   "domains.col.certMode": "证书模式",

--- a/web/locales/zh-TW/apps.ts
+++ b/web/locales/zh-TW/apps.ts
@@ -4,6 +4,7 @@ const apps = {
   "apps.fetchError": "取得應用程式清單失敗",
   "apps.namespaceFilter": "命名空間:",
   "apps.appNameFilter": "應用程式:",
+  "apps.ownerFilter": "負責人:",
   "apps.searchPlaceholder": "搜尋應用名稱或描述...",
   "apps.searchBtn": "搜尋",
   "apps.ownerAll": "所有人",

--- a/web/locales/zh-TW/assets.ts
+++ b/web/locales/zh-TW/assets.ts
@@ -2,6 +2,7 @@ const assets = {
   "assets.title": "靜態資源",
   "assets.uploadBtn": "上傳檔案",
   "assets.refresh": "重新整理",
+  "assets.searchLabel": "檔名:",
   "assets.searchPlaceholder": "依檔名前綴搜尋，僅目前目錄",
   "assets.folder": "目錄",
   "assets.col.fileName": "檔名",

--- a/web/locales/zh-TW/common.ts
+++ b/web/locales/zh-TW/common.ts
@@ -9,6 +9,7 @@ const common = {
   "common.save": "儲存",
   "common.saving": "儲存中...",
   "common.cancel": "取消",
+  "common.close": "關閉",
   "common.create": "創建",
   "common.confirm": "確認",
   "common.namespace": "命名空間",

--- a/web/locales/zh-TW/domains.ts
+++ b/web/locales/zh-TW/domains.ts
@@ -5,6 +5,7 @@ const domains = {
   "domains.createDesc": "新增一個受管網域。",
   "domains.editTitle": "編輯網域",
   "domains.editDesc": "更新網域設定與憑證。",
+  "domains.searchLabel": "網域或描述:",
   "domains.searchPlaceholder": "依網域搜尋",
   "domains.col.host": "網域",
   "domains.col.certMode": "憑證模式",


### PR DESCRIPTION
Three small frontend fixes found while looking at the application list.

The search label on the domains page rendered without a trailing colon while every other filter label had one. The cause was that three pages reused a key meant for something else: domains used domains.title, the apps owner filter used common.owner, and the assets search used assets.col.fileName. Two of them papered over it by concatenating a literal ":" in JSX, and the domains page simply forgot. Punctuation belongs in the translation rather than the layout — CJK wants a full-width colon and French wants a space before it, neither reachable once the character is hardcoded in a component — and the reused keys cannot carry it either, since common.owner and assets.col.fileName are also table headers where a colon would be wrong. Add domains.searchLabel, apps.ownerFilter and assets.searchLabel across all four locales, leaving one rule: filter labels are dedicated keys that include their own colon. The existing values still use a half-width colon in zh-CN, zh-TW and ja-JP, which is not correct typographically, but that touches a dozen keys and is left for a separate change.

An application showing a picked emoji read as visibly lighter than one showing the derived gradient block, though both marks occupy the same 20px square. The gradient paints all 20px edge to edge while the emoji was set at 16px inside an 18px content box, and colour-emoji fonts inset their own ink on top of that, leaving roughly 14px of visible glyph — close to half the area missing. Raise the glyph to 18px, exactly the square minus its border, which is the largest size that cannot clip since even a font whose ink fills the em box lands flush with the content box. Applied to both places that draw the mark, the standalone component and the copy inside the select options.

The usage drawer could only be dismissed by clicking the scrim, swiping, or pressing Escape, none of which is visible on screen. Add a close button in the header next to refresh, using the DrawerClose part that components/ui/drawer.tsx already exported but nothing used, styled as the same ghost icon-sm X that Dialog renders in its own corner. It stays at the call site rather than becoming a showCloseButton prop on DrawerContent like Dialog has, because that file comes from the shadcn registry and a later `shadcn add` would overwrite the customization.