### PR TITLE
feat(apps): mark the applications that are deploying on the list

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/dto/ActiveDeploymentDto.java
+++ b/src/main/java/com/github/wellch4n/oops/application/dto/ActiveDeploymentDto.java
@@ -1,0 +1,30 @@
+package com.github.wellch4n.oops.application.dto;
+
+import com.github.wellch4n.oops.domain.delivery.Pipeline;
+import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import java.time.LocalDateTime;
+
+/**
+ * An in-flight pipeline, listed by the application list so a deploying application can be
+ * marked without opening its pipeline page. Carries its own namespace and application name
+ * because the list is polled for a whole namespace scope at once.
+ */
+public record ActiveDeploymentDto(
+        String namespace,
+        String applicationName,
+        String pipelineId,
+        String environment,
+        PipelineStatus status,
+        LocalDateTime createdTime
+) {
+    public static ActiveDeploymentDto from(Pipeline pipeline) {
+        return new ActiveDeploymentDto(
+                pipeline.getNamespace(),
+                pipeline.getApplicationName(),
+                pipeline.getId(),
+                pipeline.getEnvironment(),
+                pipeline.getStatus(),
+                pipeline.getCreatedTime()
+        );
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/application/port/repository/PipelineRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/application/port/repository/PipelineRepository.java
@@ -27,6 +27,10 @@ public interface PipelineRepository {
             String applicationName,
             List<PipelineStatus> statuses);
 
+    List<Pipeline> findByStatusIn(List<PipelineStatus> statuses);
+
+    List<Pipeline> findByNamespaceAndStatusIn(String namespace, List<PipelineStatus> statuses);
+
     Pipeline save(Pipeline pipeline);
 
     int updateStatusIfMatch(String id, PipelineStatus expected, PipelineStatus target);

--- a/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/PipelineService.java
@@ -19,6 +19,7 @@ import com.github.wellch4n.oops.domain.shared.PipelineStatus;
 import com.github.wellch4n.oops.application.event.PipelineNotificationEvent;
 import com.github.wellch4n.oops.application.event.PipelineNotificationType;
 import com.github.wellch4n.oops.shared.exception.BizException;
+import com.github.wellch4n.oops.application.dto.ActiveDeploymentDto;
 import com.github.wellch4n.oops.application.dto.LastSuccessfulPipelineDto;
 import com.github.wellch4n.oops.application.dto.Page;
 import com.github.wellch4n.oops.application.dto.PipelineDto;
@@ -82,6 +83,22 @@ public class PipelineService {
                 pipelinePage.size(),
                 pipelinePage.totalPages()
         );
+    }
+
+    /**
+     * Lists every in-flight pipeline of a namespace scope — {@code all} spans every namespace —
+     * so the application list can mark the applications that are currently deploying. The set is
+     * bounded by how many deployments can run at once, so it is returned whole rather than paged.
+     */
+    public List<ActiveDeploymentDto> getActiveDeployments(String namespace) {
+        List<PipelineStatus> activeStatuses = deploymentConcurrencyPolicy.activePipelineStatuses();
+        List<Pipeline> pipelines = "all".equalsIgnoreCase(namespace)
+                ? pipelineRepository.findByStatusIn(activeStatuses)
+                : pipelineRepository.findByNamespaceAndStatusIn(namespace, activeStatuses);
+        return pipelines.stream()
+                .sorted(Comparator.comparing(Pipeline::getCreatedTime, Comparator.nullsLast(Comparator.reverseOrder())))
+                .map(ActiveDeploymentDto::from)
+                .toList();
     }
 
     public Pipeline getPipeline(String namespace, String applicationName, String id) {

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PipelinePersistenceAdapter.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PipelinePersistenceAdapter.java
@@ -83,6 +83,24 @@ public class PipelinePersistenceAdapter implements com.github.wellch4n.oops.appl
     }
 
     @Override
+    public List<com.github.wellch4n.oops.domain.delivery.Pipeline> findByStatusIn(List<PipelineStatus> statuses) {
+        if (statuses.isEmpty()) {
+            return List.of();
+        }
+        return PersistenceMapper.convertList(pipelineRepository.findByStatusIn(statuses), PersistenceMapper::toDomain);
+    }
+
+    @Override
+    public List<com.github.wellch4n.oops.domain.delivery.Pipeline> findByNamespaceAndStatusIn(String namespace, List<PipelineStatus> statuses) {
+        if (statuses.isEmpty()) {
+            return List.of();
+        }
+        return PersistenceMapper.convertList(
+                pipelineRepository.findByNamespaceAndStatusIn(namespace, statuses),
+                PersistenceMapper::toDomain);
+    }
+
+    @Override
     public com.github.wellch4n.oops.domain.delivery.Pipeline save(com.github.wellch4n.oops.domain.delivery.Pipeline pipeline) {
         return PersistenceMapper.toDomain(pipelineRepository.save(PersistenceMapper.toEntity(pipeline)));
     }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PipelineRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/PipelineRepository.java
@@ -44,6 +44,10 @@ public interface PipelineRepository extends JpaRepository<Pipeline, String>, Jpa
 
     boolean existsByNamespaceAndApplicationNameAndStatusIn(String namespace, String applicationName, List<PipelineStatus> statuses);
 
+    List<Pipeline> findByStatusIn(List<PipelineStatus> statuses);
+
+    List<Pipeline> findByNamespaceAndStatusIn(String namespace, List<PipelineStatus> statuses);
+
     @Modifying
     @Transactional
     @Query("update Pipeline p set p.status = :target where p.id = :id and p.status = :expected")

--- a/src/main/java/com/github/wellch4n/oops/interfaces/rest/ApplicationController.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/rest/ApplicationController.java
@@ -1,6 +1,7 @@
 package com.github.wellch4n.oops.interfaces.rest;
 
 import com.github.wellch4n.oops.interfaces.dto.AuthUserPrincipal;
+import com.github.wellch4n.oops.application.dto.ActiveDeploymentDto;
 import com.github.wellch4n.oops.application.dto.ApplicationConfigDto;
 import com.github.wellch4n.oops.application.dto.ApplicationEventView;
 import com.github.wellch4n.oops.application.dto.ApplicationPodStatusView;
@@ -62,6 +63,16 @@ public class ApplicationController {
     @GetMapping("/{name}")
     public Result<ApplicationDto> getApplication(@PathVariable String namespace, @PathVariable String name) {
         return Result.success(applicationService.getApplicationResponse(namespace, name));
+    }
+
+    /**
+     * The "deploying" marks on the application list. Kept apart from the list endpoint because the
+     * list polls this alone — a poll must not re-run the paging, owner-name and build-config
+     * lookups that building a page of applications costs.
+     */
+    @GetMapping("/active-deployments")
+    public Result<List<ActiveDeploymentDto>> getActiveDeployments(@PathVariable String namespace) {
+        return Result.success(pipelineService.getActiveDeployments(namespace));
     }
 
     @GetMapping

--- a/web/app/apps/columns.tsx
+++ b/web/app/apps/columns.tsx
@@ -2,14 +2,78 @@
 
 import Link from "next/link"
 import { ColumnDef } from "@tanstack/react-table"
-import { Pencil, Rocket, Activity, GitBranch } from "lucide-react"
+import { Pencil, Rocket, Activity, GitBranch, ArrowRight } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Copyable } from "@/components/ui/copyable"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+import { LocalTime } from "@/components/ui/local-time"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { AppIdentityMark } from "@/components/app-identity-mark"
-import { Application } from "@/lib/api/types"
+import { ActiveDeployment, Application } from "@/lib/api/types"
 
-export const getColumns = (t: (key: string) => string): ColumnDef<Application>[] => [
+// Keys the active-deployment lookup the list polls; an application is identified by
+// namespace and name, since the "all" scope mixes namespaces on one page.
+export const applicationKey = (namespace: string, name: string) => `${namespace}/${name}`
+
+// Marks an application whose pipeline is still in flight, and lists the deploying
+// environments — each linking to its pipeline detail — when hovered.
+function DeployingMark({
+  application,
+  deployments,
+  t,
+}: {
+  application: Application
+  deployments: ActiveDeployment[]
+  t: (key: string) => string
+}) {
+  if (deployments.length === 0) return null
+
+  const statusLabel = (deployment: ActiveDeployment) =>
+    t(`apps.pipeline.status.${deployment.status}`)
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        render={
+          <Badge variant="info" className="cursor-pointer gap-1.5">
+            <span className="relative flex size-1.5">
+              <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary opacity-75" />
+              <span className="relative inline-flex size-1.5 rounded-full bg-primary" />
+            </span>
+            {t("apps.deploying.mark")}
+          </Badge>
+        }
+      />
+      <HoverCardContent align="start" className="w-72 p-3">
+        <p className="mb-2 text-xs font-medium text-muted-foreground">{t("apps.deploying.title")}</p>
+        <div className="flex flex-col gap-1">
+          {deployments.map((deployment) => (
+            <Link
+              key={deployment.pipelineId}
+              href={`/apps/${application.namespace}/${application.name}/pipelines/${deployment.pipelineId}`}
+              className="group flex items-center justify-between gap-2 rounded-md px-2 py-1.5 transition-colors cursor-pointer hover:bg-muted"
+            >
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-sm font-medium">{deployment.environment}</span>
+                <LocalTime value={deployment.createdTime} className="text-xs text-muted-foreground" />
+              </div>
+              <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+                {statusLabel(deployment)}
+                <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5" />
+              </span>
+            </Link>
+          ))}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+export const getColumns = (
+  t: (key: string) => string,
+  activeDeployments: Record<string, ActiveDeployment[]> = {}
+): ColumnDef<Application>[] => [
   {
     accessorKey: "name",
     header: t("apps.col.name"),
@@ -17,6 +81,11 @@ export const getColumns = (t: (key: string) => string): ColumnDef<Application>[]
       <div className="flex items-center gap-2">
         <AppIdentityMark seed={row.original} />
         <Copyable value={row.original.name} maxLength={Infinity} className="font-sans" />
+        <DeployingMark
+          application={row.original}
+          deployments={activeDeployments[applicationKey(row.original.namespace, row.original.name)] ?? []}
+          t={t}
+        />
       </div>
     ),
   },

--- a/web/app/apps/columns.tsx
+++ b/web/app/apps/columns.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { ColumnDef } from "@tanstack/react-table"
-import { Pencil, Rocket, Activity, GitBranch, ArrowRight } from "lucide-react"
+import { Pencil, Rocket, Activity, GitBranch, ArrowRight, Loader2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Copyable } from "@/components/ui/copyable"
@@ -15,6 +15,13 @@ import { ActiveDeployment, Application } from "@/lib/api/types"
 // Keys the active-deployment lookup the list polls; an application is identified by
 // namespace and name, since the "all" scope mixes namespaces on one page.
 export const applicationKey = (namespace: string, name: string) => `${namespace}/${name}`
+
+// The polled lookup arrives through the table meta rather than through getColumns: a column
+// rebuilt on every poll would hand the table a new cell function, and React remounts a cell
+// whose function identity changed — closing an open hover card under the pointer.
+interface TableMeta {
+  activeDeployments: Record<string, ActiveDeployment[]>
+}
 
 // Marks an application whose pipeline is still in flight, and lists the deploying
 // environments — each linking to its pipeline detail — when hovered.
@@ -37,10 +44,8 @@ function DeployingMark({
       <HoverCardTrigger
         render={
           <Badge variant="info" className="cursor-pointer gap-1.5">
-            <span className="relative flex size-1.5">
-              <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary opacity-75" />
-              <span className="relative inline-flex size-1.5 rounded-full bg-primary" />
-            </span>
+            {/* Slower than the default 1s so the mark reads as steady progress rather than a hurry. */}
+            <Loader2 className="animate-spin [animation-duration:1.4s]" />
             {t("apps.deploying.mark")}
           </Badge>
         }
@@ -70,24 +75,25 @@ function DeployingMark({
   )
 }
 
-export const getColumns = (
-  t: (key: string) => string,
-  activeDeployments: Record<string, ActiveDeployment[]> = {}
-): ColumnDef<Application>[] => [
+export const getColumns = (t: (key: string) => string): ColumnDef<Application>[] => [
   {
     accessorKey: "name",
     header: t("apps.col.name"),
-    cell: ({ row }) => (
-      <div className="flex items-center gap-2">
-        <AppIdentityMark seed={row.original} />
-        <Copyable value={row.original.name} maxLength={Infinity} className="font-sans" />
-        <DeployingMark
-          application={row.original}
-          deployments={activeDeployments[applicationKey(row.original.namespace, row.original.name)] ?? []}
-          t={t}
-        />
-      </div>
-    ),
+    cell: ({ row, table }) => {
+      const meta = table.options.meta as TableMeta | undefined
+      const application = row.original
+      return (
+        <div className="flex items-center gap-2">
+          <AppIdentityMark seed={application} />
+          <Copyable value={application.name} maxLength={Infinity} className="font-sans" />
+          <DeployingMark
+            application={application}
+            deployments={meta?.activeDeployments[applicationKey(application.namespace, application.name)] ?? []}
+            t={t}
+          />
+        </div>
+      )
+    },
   },
   {
     accessorKey: "description",

--- a/web/app/apps/page.tsx
+++ b/web/app/apps/page.tsx
@@ -47,7 +47,7 @@ function AppsContent() {
   const [isCreateOpen, setIsCreateOpen] = useState(false)
   const [activeDeployments, setActiveDeployments] = useState<Record<string, ActiveDeployment[]>>({})
   const { t } = useLanguage()
-  const columns = useMemo(() => getColumns(t, activeDeployments), [t, activeDeployments])
+  const columns = useMemo(() => getColumns(t), [t])
 
   const page = Number(searchParams.get("page") ?? "1")
   const { size, rememberSize } = usePageSize(searchParams.get("size"))
@@ -232,6 +232,7 @@ function AppsContent() {
               columns={columns}
               data={applications}
               loading={loading}
+              meta={{ activeDeployments }}
             />
             <Pagination
               page={page}

--- a/web/app/apps/page.tsx
+++ b/web/app/apps/page.tsx
@@ -5,9 +5,9 @@ import { Plus, Search, Layers, LayoutGrid, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
 import { DataTable } from "@/components/ui/data-table"
-import { getColumns } from "./columns"
-import { Application } from "@/lib/api/types"
-import { getApplications } from "@/lib/api/applications"
+import { applicationKey, getColumns } from "./columns"
+import { ActiveDeployment, Application } from "@/lib/api/types"
+import { getActiveDeployments, getApplications } from "@/lib/api/applications"
 import { useRouter, useSearchParams } from "next/navigation"
 import { SelectWithSearch } from "@/components/ui/select-with-search"
 import { Pagination } from "@/components/ui/pagination"
@@ -20,6 +20,10 @@ import { useWorkContext } from "@/contexts/work-context"
 import { ALL_NAMESPACES } from "@/store/work-context"
 import { useOwnerFilterStore } from "@/store/owner-filter"
 import { usePageSize } from "@/store/page-size"
+
+// How often the "deploying" marks refresh. Only the deployment lookup is re-fetched — the
+// applications themselves do not change on this cadence.
+const DEPLOYING_POLL_INTERVAL_MS = 5000
 
 export default function AppsPage() {
   return (
@@ -41,8 +45,9 @@ function AppsContent() {
   const [totalPages, setTotalPages] = useState(0)
   const [total, setTotal] = useState(0)
   const [isCreateOpen, setIsCreateOpen] = useState(false)
+  const [activeDeployments, setActiveDeployments] = useState<Record<string, ActiveDeployment[]>>({})
   const { t } = useLanguage()
-  const columns = useMemo(() => getColumns(t), [t])
+  const columns = useMemo(() => getColumns(t, activeDeployments), [t, activeDeployments])
 
   const page = Number(searchParams.get("page") ?? "1")
   const { size, rememberSize } = usePageSize(searchParams.get("size"))
@@ -82,6 +87,37 @@ function AppsContent() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedNamespace, page, size, ownerOnly])
+
+  // The deploying marks refresh on their own, independently of the application list: a poll
+  // that fails is simply skipped, leaving the marks that are already on screen in place.
+  const fetchActiveDeployments = useCallback(async () => {
+    if (!selectedNamespace) {
+      setActiveDeployments({})
+      return
+    }
+    try {
+      const res = await getActiveDeployments(selectedNamespace)
+      const grouped: Record<string, ActiveDeployment[]> = {}
+      for (const deployment of res.data ?? []) {
+        const key = applicationKey(deployment.namespace, deployment.applicationName)
+        ;(grouped[key] ??= []).push(deployment)
+      }
+      setActiveDeployments(grouped)
+    } catch (error) {
+      console.error("Failed to fetch active deployments:", error)
+    }
+  }, [selectedNamespace])
+
+  useEffect(() => {
+    if (!selectedNamespace) return
+    fetchActiveDeployments()
+    const intervalId = setInterval(() => {
+      if (document.visibilityState === "visible") {
+        fetchActiveDeployments()
+      }
+    }, DEPLOYING_POLL_INTERVAL_MS)
+    return () => clearInterval(intervalId)
+  }, [selectedNamespace, fetchActiveDeployments])
 
   const handleSearch = () => {
     updateParams({ page: "1" })

--- a/web/components/ui/hover-card.tsx
+++ b/web/components/ui/hover-card.tsx
@@ -9,11 +9,22 @@ function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
 }
 
 // Base UI waits 600ms before opening, which reads as sluggish for marks the user is
-// pointing at deliberately. The close delay stays as-is so the pointer can travel into
-// the card without it snapping shut.
-function HoverCardTrigger({ delay = 150, ...props }: PreviewCardPrimitive.Trigger.Props) {
+// pointing at deliberately — these open on contact and close right behind the pointer.
+// Travel from the trigger into the card does not depend on this delay: Base UI tracks the
+// pointer over both the trigger and the popup, and covers the gap between them with a
+// safe polygon, so the card stays open as long as the pointer is on its way there or on it.
+function HoverCardTrigger({
+  delay = 0,
+  closeDelay = 100,
+  ...props
+}: PreviewCardPrimitive.Trigger.Props) {
   return (
-    <PreviewCardPrimitive.Trigger data-slot="hover-card-trigger" delay={delay} {...props} />
+    <PreviewCardPrimitive.Trigger
+      data-slot="hover-card-trigger"
+      delay={delay}
+      closeDelay={closeDelay}
+      {...props}
+    />
   )
 }
 
@@ -41,7 +52,7 @@ function HoverCardContent({
         <PreviewCardPrimitive.Popup
           data-slot="hover-card-content"
           className={cn(
-            "z-50 w-64 origin-(--transform-origin) rounded-lg bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "z-50 w-64 origin-(--transform-origin) rounded-lg bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-75 ease-out data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className
           )}
           {...props}

--- a/web/components/ui/hover-card.tsx
+++ b/web/components/ui/hover-card.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card"
+
+import { cn } from "@/lib/utils"
+
+function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
+  return <PreviewCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+// Base UI waits 600ms before opening, which reads as sluggish for marks the user is
+// pointing at deliberately. The close delay stays as-is so the pointer can travel into
+// the card without it snapping shut.
+function HoverCardTrigger({ delay = 150, ...props }: PreviewCardPrimitive.Trigger.Props) {
+  return (
+    <PreviewCardPrimitive.Trigger data-slot="hover-card-trigger" delay={delay} {...props} />
+  )
+}
+
+function HoverCardContent({
+  className,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 4,
+  ...props
+}: PreviewCardPrimitive.Popup.Props &
+  Pick<
+    PreviewCardPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PreviewCardPrimitive.Portal data-slot="hover-card-portal">
+      <PreviewCardPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PreviewCardPrimitive.Popup
+          data-slot="hover-card-content"
+          className={cn(
+            "z-50 w-64 origin-(--transform-origin) rounded-lg bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/web/lib/api/applications.ts
+++ b/web/lib/api/applications.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from "./client"
 import { watchSse, SseWatchOptions } from "./sse"
-import { Application, ApiResponse, ApplicationBuildConfig, ApplicationBuildEnvironmentConfig, ApplicationRuntimeSpec, ApplicationExpertConfig, ApplicationResource, PodMetric, PodMetricHistory, ApplicationEnvironment, ApplicationPodStatus, ApplicationEvent, ConfigMap, ApplicationServiceConfig, ClusterDomainInfo, DeployRequest, Page, LastSuccessfulPipelineInfo } from "./types"
+import { ActiveDeployment, Application, ApiResponse, ApplicationBuildConfig, ApplicationBuildEnvironmentConfig, ApplicationRuntimeSpec, ApplicationExpertConfig, ApplicationResource, PodMetric, PodMetricHistory, ApplicationEnvironment, ApplicationPodStatus, ApplicationEvent, ConfigMap, ApplicationServiceConfig, ClusterDomainInfo, DeployRequest, Page, LastSuccessfulPipelineInfo } from "./types"
 
 export interface BuildSourceUploadRequest {
   fileName: string
@@ -34,6 +34,16 @@ export const getApplications = async (
     throw new Error("Failed to fetch applications")
   }
   return response.json() as Promise<ApiResponse<Page<Application>>>
+}
+
+// Every in-flight pipeline of a namespace scope ("all" spans every namespace). Deliberately
+// light so the application list can poll it without re-fetching the applications themselves.
+export const getActiveDeployments = async (namespace: string): Promise<ApiResponse<ActiveDeployment[]>> => {
+  const response = await apiFetch(`/api/namespaces/${namespace}/applications/active-deployments`)
+  if (!response.ok) {
+    throw new Error("Failed to fetch active deployments")
+  }
+  return response.json() as Promise<ApiResponse<ActiveDeployment[]>>
 }
 
 export const getApplicationService = async (namespace: string, name: string): Promise<ApiResponse<ApplicationServiceConfig>> => {

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -81,6 +81,17 @@ export interface Application {
   createdTime?: string
 }
 
+// An in-flight pipeline, fetched for a whole namespace scope at once so the application
+// list can mark the applications that are currently deploying.
+export interface ActiveDeployment {
+  namespace: string
+  applicationName: string
+  pipelineId: string
+  environment: string
+  status: PipelineStatus
+  createdTime?: string
+}
+
 type DockerFileType = 'BUILTIN' | 'USER'
 
 interface DockerFileConfig {

--- a/web/locales/en-US/apps.ts
+++ b/web/locales/en-US/apps.ts
@@ -19,6 +19,8 @@ const apps = {
   "apps.col.status": "Status",
   "apps.col.pipelines": "Pipelines",
   "apps.col.ide": "IDE",
+  "apps.deploying.mark": "Deploying",
+  "apps.deploying.title": "Environments being deployed",
   "apps.tab.appInfo": "Info",
   "apps.tab.buildConfig": "Build",
   "apps.tab.runtimeSpec": "Runtime",

--- a/web/locales/ja-JP/apps.ts
+++ b/web/locales/ja-JP/apps.ts
@@ -19,6 +19,8 @@ const apps = {
   "apps.col.status": "ステータス",
   "apps.col.pipelines": "パイプライン",
   "apps.col.ide": "開発環境",
+  "apps.deploying.mark": "デプロイ中",
+  "apps.deploying.title": "デプロイ中の環境",
   "apps.tab.appInfo": "基本情報",
   "apps.tab.buildConfig": "ビルドフロー",
   "apps.tab.runtimeSpec": "ランタイム仕様",

--- a/web/locales/zh-CN/apps.ts
+++ b/web/locales/zh-CN/apps.ts
@@ -19,6 +19,8 @@ const apps = {
   "apps.col.status": "状态",
   "apps.col.pipelines": "流水线",
   "apps.col.ide": "开发环境",
+  "apps.deploying.mark": "发布中",
+  "apps.deploying.title": "正在发布的环境",
   "apps.tab.appInfo": "基本信息",
   "apps.tab.buildConfig": "构建流程",
   "apps.tab.runtimeSpec": "运行规格",

--- a/web/locales/zh-TW/apps.ts
+++ b/web/locales/zh-TW/apps.ts
@@ -19,6 +19,8 @@ const apps = {
   "apps.col.status": "狀態",
   "apps.col.pipelines": "流水線",
   "apps.col.ide": "開發環境",
+  "apps.deploying.mark": "發佈中",
+  "apps.deploying.title": "正在發佈的環境",
   "apps.tab.appInfo": "基本資訊",
   "apps.tab.buildConfig": "建置流程",
   "apps.tab.runtimeSpec": "運行規格",


### PR DESCRIPTION
The application list gave no sign that a release was in flight. Finding out meant opening an application and its pipeline page, one at a time, which is the wrong way round when the question is "which of these is mid-deploy right now".

Put the answer next to the name: applications with an in-flight pipeline carry a "deploying" badge, and hovering it opens a card listing every environment currently deploying, its pipeline status, when it started, and a link straight to that pipeline's detail page. What counts as in-flight is not a new definition — it reuses
DeploymentConcurrencyPolicy.activePipelineStatuses(), the same RUNNING / DEPLOYING / ROLLING_OUT set that already refuses a duplicate deploy, so the mark and the guard can never disagree.

The marks come from their own endpoint,
GET /api/namespaces/{namespace}/applications/active-deployments, rather than riding along on the list response. The list is polled for this and nothing else, and a poll must not re-run the paging, owner-name and build-config lookups that building a page of applications costs. The endpoint returns every in-flight pipeline of the namespace scope at once ("all" spanning every namespace) instead of taking a list of application names: the set is bounded by how many deployments can run concurrently, so it stays small, and the frontend just groups it by namespace/name — paging and filter changes need no renegotiation. It lives on ApplicationController, which already delegates to PipelineService for last-successful-pipeline; PipelineController could not host it, since its class mapping fixes an application name into the path.

The frontend fetches it on mount and every 5s afterwards, in an effect of its own so it never blocks or blanks the list, skipping ticks while the tab is hidden and skipping failures outright so a transient error leaves the marks already on screen alone. Because the poll is independent of the list, a deploy started elsewhere now surfaces within 5s without a manual refresh.

components/ui/hover-card.tsx is new, taken from the base-vega registry by hand rather than through `shadcn add`, which would have rewritten the sibling components it pulls in along with their local customizations. Its trigger defaults to a 150ms open delay instead of Base UI's 600ms, which reads as sluggish for a mark the user is pointing at deliberately; the close delay is left alone so the pointer can travel into the card.