### PR TITLE
feat(identity): disable an OOPS account when Feishu reports the resignation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ Key properties to configure:
 - `oops.pipeline.image.*`: Clone, Buildah, and ZIP (curl) images for builds, registry mirrors, and ZIP unzip excludes
 - `oops.ingress.cert-resolver`: Traefik certificate resolver name
 - `oops.object-storage.*`: S3-compatible object storage for ZIP source uploads and asset hosting (`enabled`, `endpoint`, `region`, `bucket`, `access-key`, `secret-key`, `path-style-access`, `key-prefix`, `asset-key-prefix`, `asset-base-url`, URL expiration, max file size)
-- `oops.feishu.*`: Feishu (Lark) OAuth configuration (optional)
+- `oops.feishu.*`: Feishu (Lark) OAuth configuration (optional); the same credentials also drive the inbound event long connection, which additionally needs `sync-user-deactivation`
 - `oops.ide.*`: code-server IDE configuration (optional)
 - `oops.sandbox.*`: Sandbox runtime image allowlist and execution defaults
 - `oops.pod-filesystem.*`: Pod file browser limits, especially max download size
@@ -238,6 +238,21 @@ Owners can grant other users access to their applications via collaborators (`Ap
 
 ### External Accounts
 `ExternalAccount` entity stores linked OAuth accounts (`email`, `provider`, `providerUserId`). Used by the notification system to route pipeline status messages to the user's linked provider (e.g., Feishu).
+
+### External Event Subscriptions (inbound)
+
+Providers can also push events *into* OOPS. The path is split so a provider knows nothing about OOPS's domain and a business handler knows nothing about the provider:
+
+`FeishuEventClient` (infrastructure adapter, receives and translates) → publishes a **provider-neutral Spring event** → a listener in `application/event/` acts on it.
+
+**Transport is a long connection, not a webhook.** `FeishuEventClient` dials out with the SDK's `com.lark.oapi.ws.Client`, feeding an `EventDispatcher` that routes by event type. OOPS is self-hosted and frequently has no address Feishu's servers can reach, so having the backend dial out is the mode that works everywhere; it also removes the webhook attack surface entirely — no public endpoint, no verification token, no encrypt key, because the connection authenticates with the app credentials themselves. **Nothing beyond `oops.feishu.enabled` / `app-id` / `app-secret` needs configuring**, and in the Feishu console the subscription method must be 长连接, not 开发者服务器. The trade-off is that events only arrive while the process is up; acceptable because the only subscription is idempotent and nothing else depends on it.
+
+- **Off unless both `oops.feishu.enabled` and `oops.feishu.sync-user-deactivation` are true** — `@ConditionalOnProperty` with two names requires both. Opt-in for the same reason resource alerts are: it takes people's access away on a signal from outside OOPS, so it must not switch itself on at upgrade. The gate sits on the bean rather than inside the handler because resignations are the only subscription — with the switch off there is nothing to listen for and no socket worth opening. (`ExternalUserDeactivatedListener` still exists either way; with no client it simply never hears anything.)
+- It connects on `ApplicationReadyEvent` from a virtual thread, so an unreachable Feishu cannot hold up startup. **Reconnection is left entirely to the SDK**: `autoReconnect` already defaults to true and `Client.start()` routes ordinary failures into it, so the only thing it hands back is the kind of error (bad credentials) no retry fixes. There is no de-duplication either — delivery is at least once, but disabling an already-disabled account is a no-op.
+- **Subscribed events.** `contact.user.deleted_v3` (resignation) → `ExternalUserDeactivatedEvent` → `ExternalUserDeactivatedListener` disables the OOPS account (`enabled=false`), which login, `JwtAuthFilter` and `OpenApiAuthFilter` all already enforce, so an issued JWT and an OpenAPI access token both stop working on the next request. It resolves the person by `ExternalAccount.providerUserId` first and falls back to email; someone with no OOPS account is an info log, not an error. Disabling rather than deleting keeps owned applications with a resolvable owner and lets an admin reverse a mistake. `UserService.deactivateUser()` refuses to disable the **last enabled admin** (`UserRepository.countEnabledByRole`) — an external directory has no idea it is holding the only key to the installation.
+- The listener is **synchronous**, unlike the notification listeners: it is a single-row update running on the SDK's own connection thread, so an `@Async` hop would buy nothing. Nothing in this path touches an OOPS request, scheduler or pipeline thread. Note that `Client.handleDataFrame` catches whatever the handler throws **and acknowledges the event anyway**, so a failure is lost rather than redelivered — hence the listener logs the account it could not disable. Every event is logged twice at INFO, once on receipt and once for the outcome (disabled / no linked account / left as is): resignations are rare enough for the volume not to matter, and the SDK logs nothing at INFO, so without those lines an event that matched no account would leave no trace of having arrived.
+
+Adding a provider means one new client adapter; adding a business reaction means one new listener. Neither touches the other. `FeishuEventClientTests` drives payloads straight through `EventDispatcher.doWithoutValidation()`, so the event handling is covered without a socket.
 
 ### Domain Management
 `Domain` entities store managed domains with `host`, `https`, `certMode` (`AUTO` or `UPLOADED`), and optional PEM cert/key. Domains are admin-managed at `/api/domains` (ADMIN-only writes) and listed at `/networks/domains`. Domain lookup uses longest-suffix matching (supports wildcard by stripping `*.`).

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -94,6 +94,11 @@ oops:
     app-id: cli_xxx
     app-secret: xxx
     redirect-uri: http://localhost:3000/auth/feishu/callback
+    # Disable an OOPS account when Feishu reports the person as having left the organisation.
+    # Off by default — it takes access away on a signal from outside OOPS, so it waits to be asked for.
+    # Requires the Feishu console's subscription method to be 长连接 (not 开发者服务器), the
+    # contact.user.deleted_v3 event subscribed, and one of the contact:contact*readonly permissions.
+    sync-user-deactivation: false
   ide:
     enabled: false
     https: false

--- a/docker/application.yml.example
+++ b/docker/application.yml.example
@@ -99,6 +99,11 @@ oops:
     app-id: cli_xxx
     app-secret: xxx
     redirect-uri: http://localhost:3000/auth/feishu/callback
+    # Disable an OOPS account when Feishu reports the person as having left the organisation.
+    # Off by default — it takes access away on a signal from outside OOPS, so it waits to be asked for.
+    # Requires the Feishu console's subscription method to be 长连接 (not 开发者服务器), the
+    # contact.user.deleted_v3 event subscribed, and one of the contact:contact*readonly permissions.
+    sync-user-deactivation: false
   ide:
     enabled: false
     https: false

--- a/src/main/java/com/github/wellch4n/oops/application/event/ExternalUserDeactivatedEvent.java
+++ b/src/main/java/com/github/wellch4n/oops/application/event/ExternalUserDeactivatedEvent.java
@@ -1,0 +1,22 @@
+package com.github.wellch4n.oops.application.event;
+
+import com.github.wellch4n.oops.domain.shared.ExternalAccountProvider;
+import java.time.LocalDateTime;
+
+/**
+ * An external identity provider reports that one of its users is gone — a Feishu resignation, for instance.
+ *
+ * <p>Deliberately says nothing about what OOPS should do about it. The provider adapter publishes the fact; a
+ * listener decides the consequence.
+ *
+ * @param providerUserId the id in the provider's own namespace, matching {@code ExternalAccount.providerUserId}
+ * @param email best-effort fallback for accounts linked before the id was recorded, may be {@code null}
+ */
+public record ExternalUserDeactivatedEvent(
+        ExternalAccountProvider provider,
+        String providerUserId,
+        String email,
+        String name,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/github/wellch4n/oops/application/event/ExternalUserDeactivatedListener.java
+++ b/src/main/java/com/github/wellch4n/oops/application/event/ExternalUserDeactivatedListener.java
@@ -1,0 +1,79 @@
+package com.github.wellch4n.oops.application.event;
+
+import com.github.wellch4n.oops.application.port.repository.ExternalAccountRepository;
+import com.github.wellch4n.oops.application.service.UserService;
+import com.github.wellch4n.oops.domain.identity.ExternalAccount;
+import com.github.wellch4n.oops.domain.identity.User;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Disables the OOPS account of someone who left the organisation.
+ *
+ * <p>Disabling rather than deleting: {@code enabled=false} is already enforced at login, in {@code JwtAuthFilter} and
+ * in {@code OpenApiAuthFilter}, so an issued JWT and an OpenAPI access token both stop working on the next request,
+ * while the applications the person owned keep a resolvable owner and an admin can reverse a mistake.
+ *
+ * <p>Runs synchronously, unlike the notification listeners: it is a single-row update on the SDK's own connection
+ * thread, which has nothing else to do, so an {@code @Async} hop would buy nothing. Note that the SDK catches
+ * whatever this throws and acknowledges the event anyway — a failure here is lost rather than redelivered, which is
+ * why the catch below logs the person it was about instead of letting the SDK log a bare stack trace.
+ */
+@Slf4j
+@Component
+public class ExternalUserDeactivatedListener {
+
+    private final ExternalAccountRepository externalAccountRepository;
+    private final UserService userService;
+
+    public ExternalUserDeactivatedListener(ExternalAccountRepository externalAccountRepository,
+                                           UserService userService) {
+        this.externalAccountRepository = externalAccountRepository;
+        this.userService = userService;
+    }
+
+    @EventListener
+    public void onExternalUserDeactivated(ExternalUserDeactivatedEvent event) {
+        Optional<String> userId = resolveUserId(event);
+        if (userId.isEmpty()) {
+            // Not an error: plenty of people in the directory never signed in to OOPS.
+            log.info("{} user {} left the organisation but has no linked OOPS account",
+                    event.provider(), event.providerUserId());
+            return;
+        }
+
+        try {
+            if (userService.deactivateUser(userId.get())) {
+                log.info("Disabled OOPS user {} after {} reported the account as removed",
+                        userId.get(), event.provider());
+            } else {
+                // Says nothing about which of the two reasons it was — the last-admin guard logs its own warning,
+                // so anything reaching here silently is simply an account that was already disabled.
+                log.info("OOPS user {} was left as is after {} reported the account as removed",
+                        userId.get(), event.provider());
+            }
+        } catch (Exception exception) {
+            // Nothing will retry this, so the log is the only trace: name the account an admin has to disable by hand.
+            log.error("Failed to disable OOPS user {} after {} reported {} as removed",
+                    userId.get(), event.provider(), event.providerUserId(), exception);
+        }
+    }
+
+    /**
+     * Prefers the linked account, falling back to the address Feishu reports — accounts linked by an older login flow
+     * may not carry a provider id, and an email match is still the same person.
+     */
+    private Optional<String> resolveUserId(ExternalUserDeactivatedEvent event) {
+        Optional<ExternalAccount> account = externalAccountRepository
+                .findByProviderAndProviderUserId(event.provider(), event.providerUserId());
+        if (account.isPresent()) {
+            return Optional.ofNullable(account.get().getUserId());
+        }
+        if (event.email() == null || event.email().isBlank()) {
+            return Optional.empty();
+        }
+        return userService.findByEmail(event.email()).map(User::getId);
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/application/port/repository/UserRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/application/port/repository/UserRepository.java
@@ -28,4 +28,6 @@ public interface UserRepository {
     void deleteById(String id);
 
     boolean existsByRole(UserRole role);
+
+    long countEnabledByRole(UserRole role);
 }

--- a/src/main/java/com/github/wellch4n/oops/application/service/UserService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/UserService.java
@@ -13,9 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class UserService {
 
@@ -126,6 +128,28 @@ public class UserService {
 
     public boolean hasAdmin() {
         return userRepository.existsByRole(UserRole.ADMIN);
+    }
+
+    /**
+     * Disables an account without deleting it, for callers acting on an external signal such as a resignation.
+     *
+     * <p>Refuses to disable the last enabled admin: an external directory has no idea it is holding the only key to
+     * this installation, and locking every admin out is far worse than leaving one account to be turned off by hand.
+     *
+     * @return whether this call is what changed the account, so the caller can stay quiet about repeat deliveries
+     */
+    public boolean deactivateUser(String id) {
+        User user = userRepository.findById(id).orElse(null);
+        if (user == null || Boolean.FALSE.equals(user.getEnabled())) {
+            return false;
+        }
+        if (user.getRole() == UserRole.ADMIN && userRepository.countEnabledByRole(UserRole.ADMIN) <= 1) {
+            log.warn("Refusing to disable user {} — it is the last enabled admin", id);
+            return false;
+        }
+        user.setEnabled(false);
+        userRepository.save(user);
+        return true;
     }
 
     public String resetMyAccessToken(String userId) {

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/config/FeishuProperties.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/config/FeishuProperties.java
@@ -13,4 +13,11 @@ public class FeishuProperties {
     private String appSecret;
     private String redirectUri;
     private String callbackFrontUrl;
+    /**
+     * Whether a resignation in Feishu should disable the matching OOPS account.
+     *
+     * <p>Off by default: it takes people's access away on a signal from outside OOPS, so like resource alerts it
+     * waits to be asked for rather than starting on its own after an upgrade.
+     */
+    private boolean syncUserDeactivation = false;
 }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/external/feishu/FeishuEventClient.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/external/feishu/FeishuEventClient.java
@@ -1,0 +1,120 @@
+package com.github.wellch4n.oops.infrastructure.external.feishu;
+
+import com.github.wellch4n.oops.application.event.ExternalUserDeactivatedEvent;
+import com.github.wellch4n.oops.domain.shared.ExternalAccountProvider;
+import com.github.wellch4n.oops.infrastructure.config.FeishuProperties;
+import com.lark.oapi.event.EventDispatcher;
+import com.lark.oapi.service.contact.ContactService;
+import com.lark.oapi.service.contact.v3.model.P2UserDeletedV3;
+import com.lark.oapi.service.contact.v3.model.UserEvent;
+import com.lark.oapi.ws.Client;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Receives Feishu event subscriptions over the SDK's long connection.
+ *
+ * <p>Long connection rather than a webhook because OOPS is self-hosted and often has no address Feishu's servers can
+ * reach; this way the backend dials out instead. It also removes the whole webhook attack surface — no public
+ * endpoint, no verification token, no encrypt key, since the connection authenticates with the app credentials
+ * themselves. The trade-off is that events only arrive while the process is up.
+ *
+ * <p>Deliberately does not touch OOPS state. It turns an event into a provider-neutral Spring event, so that what a
+ * resignation means stays in {@code application/event} and Feishu stays in this package.
+ *
+ * <p>Gated on {@code oops.feishu.sync-user-deactivation} as well as {@code enabled}, and gated at the bean rather
+ * than at the handler: resignations are the only thing subscribed, so with the switch off there is nothing to listen
+ * for and no connection worth opening.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "oops.feishu", name = {"enabled", "sync-user-deactivation"}, havingValue = "true")
+public class FeishuEventClient {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final EventDispatcher eventDispatcher;
+    private final Client client;
+
+    public FeishuEventClient(FeishuProperties feishuConfig, ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+        // Empty token and key: those belong to the webhook mode, where the request arrives unauthenticated and has to
+        // prove itself. A long connection is already authenticated by the app credentials below.
+        this.eventDispatcher = EventDispatcher.newBuilder("", "")
+                .onP2UserDeletedV3(new ContactService.P2UserDeletedV3Handler() {
+                    @Override
+                    public void handle(P2UserDeletedV3 event) {
+                        onUserDeleted(event);
+                    }
+                })
+                .build();
+        this.client = new Client.Builder(feishuConfig.getAppId(), feishuConfig.getAppSecret())
+                .eventHandler(eventDispatcher)
+                .build();
+    }
+
+    /**
+     * Dials out once the rest of the application is up, on a virtual thread so a slow or unreachable Feishu cannot
+     * hold up startup. Reconnection is the SDK's job — it retries on its own by default, and the only failure it
+     * hands back is the kind no retry fixes.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void connect() {
+        Thread.ofVirtual().name("feishu-event-client").start(() -> {
+            try {
+                client.start();
+                log.info("Feishu event long connection established, syncing user deactivation");
+            } catch (Throwable throwable) {
+                log.error("Feishu event long connection failed to start, resignation events will not arrive: {}",
+                        throwable.getMessage(), throwable);
+            }
+        });
+    }
+
+    /**
+     * Feishu says an employee left the organisation. Publish the fact and let a listener decide the consequence.
+     *
+     * <p>No de-duplication: delivery is at least once, and disabling an account that is already disabled is a no-op.
+     *
+     * <p>Every event received is logged. Resignations are rare enough that the volume is irrelevant, and without
+     * this line an event that matches no OOPS account, or one that arrives while the person is already disabled,
+     * would leave no trace of having arrived at all.
+     */
+    private void onUserDeleted(P2UserDeletedV3 event) {
+        UserEvent deletedUser = event.getEvent() == null ? null : event.getEvent().getObject();
+        if (deletedUser == null || isBlank(deletedUser.getUserId())) {
+            log.warn("Feishu user deletion event carries no user id, ignoring");
+            return;
+        }
+        log.info("Feishu reported user {} ({}) as removed from the organisation",
+                deletedUser.getUserId(), deletedUser.getName());
+
+        eventPublisher.publishEvent(new ExternalUserDeactivatedEvent(
+                ExternalAccountProvider.FEISHU,
+                deletedUser.getUserId(),
+                resolveEmail(deletedUser),
+                deletedUser.getName(),
+                LocalDateTime.now()));
+    }
+
+    /** Mirrors {@code FeishuAuthStrategy}, so the fallback lookup by email matches the address accounts were linked with. */
+    private String resolveEmail(UserEvent deletedUser) {
+        if (!isBlank(deletedUser.getEnterpriseEmail())) {
+            return deletedUser.getEnterpriseEmail();
+        }
+        return isBlank(deletedUser.getEmail()) ? null : deletedUser.getEmail();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    /** Lets a test drive a raw event payload through the same dispatcher the connection feeds. */
+    EventDispatcher eventDispatcher() {
+        return eventDispatcher;
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/UserPersistenceAdapter.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/UserPersistenceAdapter.java
@@ -82,4 +82,9 @@ public class UserPersistenceAdapter implements com.github.wellch4n.oops.applicat
     public boolean existsByRole(UserRole role) {
         return userRepository.existsByRole(role);
     }
+
+    @Override
+    public long countEnabledByRole(UserRole role) {
+        return userRepository.countEnabledByRole(role);
+    }
 }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/UserRepository.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/persistence/jpa/UserRepository.java
@@ -14,6 +14,10 @@ public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByAccessToken(String accessToken);
     boolean existsByRole(UserRole role);
 
+    /** Rows predating the {@code enabled} column carry NULL, which everywhere else reads as enabled. */
+    @Query("SELECT COUNT(u) FROM User u WHERE u.role = :role AND (u.enabled IS NULL OR u.enabled = TRUE)")
+    long countEnabledByRole(@Param("role") UserRole role);
+
     @Query("SELECT u FROM User u WHERE LOWER(u.username) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(COALESCE(u.email, '')) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "ORDER BY u.createdTime DESC")

--- a/src/test/java/com/github/wellch4n/oops/application/event/ExternalUserDeactivatedListenerTests.java
+++ b/src/test/java/com/github/wellch4n/oops/application/event/ExternalUserDeactivatedListenerTests.java
@@ -1,0 +1,139 @@
+package com.github.wellch4n.oops.application.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.wellch4n.oops.application.port.repository.ExternalAccountRepository;
+import com.github.wellch4n.oops.application.port.repository.UserRepository;
+import com.github.wellch4n.oops.application.service.UserService;
+import com.github.wellch4n.oops.domain.identity.ExternalAccount;
+import com.github.wellch4n.oops.domain.identity.User;
+import com.github.wellch4n.oops.domain.shared.ExternalAccountProvider;
+import com.github.wellch4n.oops.domain.shared.UserRole;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * A resignation arriving from an external directory must land on exactly one account, or on none — never on the
+ * wrong one, and never on the last way into the installation.
+ */
+class ExternalUserDeactivatedListenerTests {
+
+    private ExternalAccountRepository externalAccountRepository;
+    private UserRepository userRepository;
+    private ExternalUserDeactivatedListener listener;
+
+    @BeforeEach
+    void setUp() {
+        externalAccountRepository = mock(ExternalAccountRepository.class);
+        userRepository = mock(UserRepository.class);
+        listener = new ExternalUserDeactivatedListener(
+                externalAccountRepository,
+                new UserService(userRepository, mock(PasswordEncoder.class)));
+        when(userRepository.countEnabledByRole(UserRole.ADMIN)).thenReturn(3L);
+    }
+
+    @Test
+    void disablesTheUserBehindTheLinkedAccount() {
+        linkAccount("e33ggbyz", "user-1");
+        givenUser("user-1", UserRole.USER, true);
+
+        listener.onExternalUserDeactivated(event("e33ggbyz", "zhangsan@example.com"));
+
+        assertThat(savedUser().getEnabled()).isFalse();
+    }
+
+    /** Accounts linked before the provider id was recorded are still the same person. */
+    @Test
+    void fallsBackToTheEmailWhenNoAccountIsLinked() {
+        when(externalAccountRepository.findByProviderAndProviderUserId(any(), any())).thenReturn(Optional.empty());
+        User user = givenUser("user-2", UserRole.USER, true);
+        when(userRepository.findByEmail("zhangsan@example.com")).thenReturn(Optional.of(user));
+
+        listener.onExternalUserDeactivated(event("e33ggbyz", "zhangsan@example.com"));
+
+        assertThat(savedUser().getEnabled()).isFalse();
+    }
+
+    /** Most of a directory never signs in to OOPS; those resignations must be a no-op, not a failure. */
+    @Test
+    void ignoresSomeoneWhoNeverUsedOops() {
+        when(externalAccountRepository.findByProviderAndProviderUserId(any(), any())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+
+        listener.onExternalUserDeactivated(event("e33ggbyz", "zhangsan@example.com"));
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void keepsTheLastEnabledAdmin() {
+        linkAccount("e33ggbyz", "admin-1");
+        givenUser("admin-1", UserRole.ADMIN, true);
+        when(userRepository.countEnabledByRole(UserRole.ADMIN)).thenReturn(1L);
+
+        listener.onExternalUserDeactivated(event("e33ggbyz", "zhangsan@example.com"));
+
+        verify(userRepository, never()).save(any());
+    }
+
+    /** One of several admins leaving is an ordinary resignation. */
+    @Test
+    void disablesAnAdminWhileOthersRemain() {
+        linkAccount("e33ggbyz", "admin-1");
+        givenUser("admin-1", UserRole.ADMIN, true);
+
+        listener.onExternalUserDeactivated(event("e33ggbyz", "zhangsan@example.com"));
+
+        assertThat(savedUser().getEnabled()).isFalse();
+    }
+
+    @Test
+    void doesNotRewriteAnAlreadyDisabledUser() {
+        linkAccount("e33ggbyz", "user-1");
+        givenUser("user-1", UserRole.USER, false);
+
+        listener.onExternalUserDeactivated(event("e33ggbyz", "zhangsan@example.com"));
+
+        verify(userRepository, never()).save(any());
+    }
+
+    private ExternalUserDeactivatedEvent event(String providerUserId, String email) {
+        return new ExternalUserDeactivatedEvent(
+                ExternalAccountProvider.FEISHU, providerUserId, email, "张三", LocalDateTime.now());
+    }
+
+    private void linkAccount(String providerUserId, String userId) {
+        ExternalAccount account = new ExternalAccount();
+        account.setProvider(ExternalAccountProvider.FEISHU);
+        account.setProviderUserId(providerUserId);
+        account.setUserId(userId);
+        when(externalAccountRepository.findByProviderAndProviderUserId(ExternalAccountProvider.FEISHU, providerUserId))
+                .thenReturn(Optional.of(account));
+    }
+
+    private User givenUser(String id, UserRole role, boolean enabled) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername("zhangsan");
+        user.setEmail("zhangsan@example.com");
+        user.setRole(role);
+        user.setEnabled(enabled);
+        when(userRepository.findById(id)).thenReturn(Optional.of(user));
+        return user;
+    }
+
+    private User savedUser() {
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/external/feishu/FeishuEventClientTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/external/feishu/FeishuEventClientTests.java
@@ -1,0 +1,83 @@
+package com.github.wellch4n.oops.infrastructure.external.feishu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.github.wellch4n.oops.application.event.ExternalUserDeactivatedEvent;
+import com.github.wellch4n.oops.domain.shared.ExternalAccountProvider;
+import com.github.wellch4n.oops.infrastructure.config.FeishuProperties;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * The client's job is to turn a Feishu event into a provider-neutral one and nothing more.
+ *
+ * <p>Payloads are pushed straight through the dispatcher the long connection feeds, so these run without a socket.
+ */
+class FeishuEventClientTests {
+
+    private List<Object> published;
+    private FeishuEventClient client;
+
+    @BeforeEach
+    void setUp() {
+        published = new ArrayList<>();
+        FeishuProperties properties = new FeishuProperties();
+        properties.setEnabled(true);
+        properties.setAppId("cli_test");
+        properties.setAppSecret("secret");
+        ApplicationEventPublisher publisher = published::add;
+        client = new FeishuEventClient(properties, publisher);
+    }
+
+    @Test
+    void publishesADeactivationWhenSomeoneLeaves() throws Throwable {
+        deliver("""
+                {"schema":"2.0",
+                 "header":{"event_id":"evt-1","event_type":"contact.user.deleted_v3","create_time":"1608725989000",
+                           "app_id":"cli_test","tenant_key":"tenant"},
+                 "event":{"object":{"open_id":"ou_x","user_id":"e33ggbyz","name":"张三",
+                                    "email":"zhangsan@example.com"}}}
+                """);
+
+        assertThat(published).hasSize(1);
+        ExternalUserDeactivatedEvent event = (ExternalUserDeactivatedEvent) published.getFirst();
+        assertThat(event.provider()).isEqualTo(ExternalAccountProvider.FEISHU);
+        assertThat(event.providerUserId()).isEqualTo("e33ggbyz");
+        assertThat(event.email()).isEqualTo("zhangsan@example.com");
+    }
+
+    /** The enterprise address is what {@code FeishuAuthStrategy} links accounts with, so it has to win here too. */
+    @Test
+    void prefersTheEnterpriseEmail() throws Throwable {
+        deliver("""
+                {"schema":"2.0",
+                 "header":{"event_id":"evt-4","event_type":"contact.user.deleted_v3","create_time":"1608725989000"},
+                 "event":{"object":{"user_id":"e33ggbyz","name":"张三","email":"personal@example.com",
+                                    "enterprise_email":"zhangsan@corp.example.com"}}}
+                """);
+
+        ExternalUserDeactivatedEvent event = (ExternalUserDeactivatedEvent) published.getFirst();
+        assertThat(event.email()).isEqualTo("zhangsan@corp.example.com");
+    }
+
+    /** A payload with nothing to act on must be swallowed, not thrown back at the connection. */
+    @Test
+    void toleratesAnEventWithoutAUserId() {
+        assertThatCode(() -> deliver("""
+                {"schema":"2.0",
+                 "header":{"event_id":"evt-3","event_type":"contact.user.deleted_v3","create_time":"1608725989000"},
+                 "event":{"object":{"open_id":"ou_x"}}}
+                """)).doesNotThrowAnyException();
+
+        assertThat(published).isEmpty();
+    }
+
+    private void deliver(String body) throws Throwable {
+        client.eventDispatcher().doWithoutValidation(body.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/external/feishu/FeishuEventOptInTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/external/feishu/FeishuEventOptInTests.java
@@ -1,0 +1,44 @@
+package com.github.wellch4n.oops.infrastructure.external.feishu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.wellch4n.oops.infrastructure.config.FeishuProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Syncing resignations is opt-in, and the mechanism is the bean condition rather than a flag read per event. These
+ * assertions are what stop an upgrade from quietly starting to take people's access away: an installation that never
+ * asked for it must end up with no client at all, and therefore no connection.
+ */
+class FeishuEventOptInTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(FeishuProperties.class, FeishuEventClient.class)
+            .withPropertyValues("oops.feishu.app-id=cli_test", "oops.feishu.app-secret=secret");
+
+    @Test
+    void clientIsAbsentWhenNothingIsConfigured() {
+        runner.run(context -> assertThat(context).doesNotHaveBean(FeishuEventClient.class));
+    }
+
+    /** Feishu login on its own must not drag resignation syncing in with it. */
+    @Test
+    void clientIsAbsentWhenOnlyFeishuIsEnabled() {
+        runner.withPropertyValues("oops.feishu.enabled=true")
+                .run(context -> assertThat(context).doesNotHaveBean(FeishuEventClient.class));
+    }
+
+    /** Nor the other way round: without Feishu configured there are no credentials to dial out with. */
+    @Test
+    void clientIsAbsentWhenFeishuItselfIsDisabled() {
+        runner.withPropertyValues("oops.feishu.sync-user-deactivation=true")
+                .run(context -> assertThat(context).doesNotHaveBean(FeishuEventClient.class));
+    }
+
+    @Test
+    void clientIsLoadedOnceBothAreOn() {
+        runner.withPropertyValues("oops.feishu.enabled=true", "oops.feishu.sync-user-deactivation=true")
+                .run(context -> assertThat(context).hasSingleBean(FeishuEventClient.class));
+    }
+}


### PR DESCRIPTION
Someone leaving the company kept their OOPS access until an admin remembered to revoke it by hand. Feishu already knows the moment it happens, so subscribe to contact.user.deleted_v3 and disable the matching account: enabled=false is enforced at login, in JwtAuthFilter and in OpenApiAuthFilter, so an issued JWT and an OpenAPI access token both stop working on the next request. Disabling rather than deleting keeps the applications the person owned with a resolvable owner, and lets an admin reverse a mistake.

Transport is the SDK's long connection rather than a webhook. OOPS is self-hosted and frequently has no address Feishu's servers can reach, so having the backend dial out is the mode that works everywhere; it also removes the webhook attack surface entirely, since the connection authenticates with the app credentials and there is no public endpoint, verification token or encrypt key to configure. In the Feishu console the subscription method must therefore be 长连接, not 开发者服务器. The trade-off is that events only arrive while the process is up, which is acceptable when the only subscription is idempotent and nothing else depends on it.

The path is split so a provider knows nothing about OOPS's domain and a business handler knows nothing about the provider: FeishuEventClient receives and translates, publishes a provider-neutral ExternalUserDeactivatedEvent, and ExternalUserDeactivatedListener decides what a resignation means. Adding a provider is one new client; adding a reaction is one new listener. The listener resolves the person by ExternalAccount.providerUserId and falls back to email, since accounts linked by an older flow may carry no provider id; someone with no OOPS account is an info log, not an error.

Reconnection is left to the SDK, which already defaults autoReconnect to true and routes ordinary start() failures into it, so the only thing it hands back is the kind of error no retry fixes. There is no de-duplication either: delivery is at least once, but disabling an already-disabled account does not even reach a save. Note that Client.handleDataFrame catches whatever the handler throws and acknowledges the event anyway, so a failure is lost rather than redelivered — hence the listener logs the account it could not disable, which is the only trace anyone will get.

For the same reason every event accounts for itself in exactly two INFO lines, one on receipt and one for the outcome, and the connection coming up is logged as well. The SDK logs nothing at INFO, so otherwise there would be no way to tell whether the subscription was live, and the two cases most likely to be asked about — an event matching no OOPS account, and one for a person already disabled — would pass in complete silence. Resignations are rare enough that the volume is irrelevant.

Off unless both oops.feishu.enabled and oops.feishu.sync-user-deactivation are set. Opt-in for the same reason resource alerts are: this takes people's access away on a signal from outside OOPS, so it must not switch itself on at upgrade. The gate sits on the bean rather than inside the handler, so with the switch off there is no connection and no thread at all.

UserService.deactivateUser refuses to disable the last enabled admin, counted through the new UserRepository.countEnabledByRole. An external directory has no idea it is holding the only key to the installation, and locking every admin out is worse than leaving one account to be turned off by hand. The count treats a NULL enabled as enabled, matching the !Boolean.FALSE.equals reading used everywhere else, so rows predating the column are not miscounted. The guard covers this path only — an admin disabling another admin from the user management screen is deliberate and still allowed.