### PR TITLE
feat(env): split the environment editor into tabs with per-tab saves

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/service/EnvironmentService.java
+++ b/src/main/java/com/github/wellch4n/oops/application/service/EnvironmentService.java
@@ -6,7 +6,6 @@ import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.shared.exception.BizException;
 import com.github.wellch4n.oops.shared.util.ResourceNameChecker;
 import java.util.List;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -43,16 +42,25 @@ public class EnvironmentService {
         return environmentRepository.findById(id).orElse(null);
     }
 
-    public Boolean updateEnvironment(String id, Environment environment) {
-        Optional<Environment> environmentOptional = environmentRepository.findById(id);
-        if (environmentOptional.isEmpty()) {
-            throw new BizException("Environment with id " + id + " does not exist.");
-        }
+    public Boolean updateClusterConfig(String id, Environment environment) {
+        Environment existingEnvironment = environmentRepository.findById(id)
+                .orElseThrow(() -> new BizException("Environment with id " + id + " does not exist."));
 
-        Environment existingEnvironment = environmentOptional.get();
         existingEnvironment.setKubernetesApiServer(environment.getKubernetesApiServer());
-        existingEnvironment.setBuildStorageClass(environment.getBuildStorageClass());
         existingEnvironment.setWorkNamespace(environment.getWorkNamespace());
+        existingEnvironment.setBuildStorageClass(environment.getBuildStorageClass());
+
+        // The work namespace or cluster may have changed — re-sync stored credentials into it.
+        syncDockerHubSecret(existingEnvironment);
+        syncGitCredentialSecret(existingEnvironment);
+        environmentRepository.saveAndFlush(existingEnvironment);
+        return true;
+    }
+
+    public Boolean updateCredentialConfig(String id, Environment environment) {
+        Environment existingEnvironment = environmentRepository.findById(id)
+                .orElseThrow(() -> new BizException("Environment with id " + id + " does not exist."));
+
         existingEnvironment.setImageRepository(environment.getImageRepository());
         existingEnvironment.setGitCredential(environment.getGitCredential());
 

--- a/src/main/java/com/github/wellch4n/oops/interfaces/rest/EnvironmentController.java
+++ b/src/main/java/com/github/wellch4n/oops/interfaces/rest/EnvironmentController.java
@@ -37,11 +37,18 @@ public class EnvironmentController {
         return Result.success(environment == null ? null : EnvironmentDto.from(environment));
     }
 
-    @PutMapping("{id}")
+    @PutMapping("{id}/cluster")
     @PreAuthorize("hasRole('ADMIN')")
-    public Result<Boolean> updateEnvironment(@PathVariable String id,
-                                             @RequestBody Environment environment) {
-        return Result.success(environmentService.updateEnvironment(id, environment));
+    public Result<Boolean> updateClusterConfig(@PathVariable String id,
+                                               @RequestBody Environment environment) {
+        return Result.success(environmentService.updateClusterConfig(id, environment));
+    }
+
+    @PutMapping("{id}/credentials")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<Boolean> updateCredentialConfig(@PathVariable String id,
+                                                  @RequestBody Environment environment) {
+        return Result.success(environmentService.updateCredentialConfig(id, environment));
     }
 
     @PostMapping

--- a/web/app/settings/environments/[id]/page.tsx
+++ b/web/app/settings/environments/[id]/page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { useState, useEffect, type CSSProperties } from "react"
-import { useParams, useRouter } from "next/navigation"
+import { Suspense, useState, useEffect, type CSSProperties } from "react"
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation"
 import { Eye, EyeOff, Check, Loader2, Info, Server, Package, AlertTriangle, KeyRound } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
 import { EnvironmentFormValues, getEnvironmentSchema } from "../columns"
-import { fetchEnvironment, updateEnvironment, validateKubernetes, validateImageRepository, createNamespace, deleteEnvironment } from "@/lib/api/environments"
+import { fetchEnvironment, updateEnvironmentCluster, updateEnvironmentCredentials, validateKubernetes, validateImageRepository, createNamespace, deleteEnvironment } from "@/lib/api/environments"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import {
@@ -22,6 +22,7 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { useLanguage } from "@/contexts/language-context"
 import { ContentPage } from "@/components/content-page"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import {
   AlertDialog,
@@ -34,9 +35,27 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 
+type EnvironmentTab = "basic" | "credentials" | "danger-zone"
+const VALID_TABS = new Set<EnvironmentTab>(["basic", "credentials", "danger-zone"])
+const DEFAULT_TAB: EnvironmentTab = "basic"
+
 export default function EnvironmentEditPage() {
+  return (
+    <Suspense fallback={null}>
+      <EnvironmentEditPageContent />
+    </Suspense>
+  )
+}
+
+function EnvironmentEditPageContent() {
   const params = useParams()
   const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const rawTab = searchParams.get("tab")
+  const currentTab = rawTab && VALID_TABS.has(rawTab as EnvironmentTab)
+    ? rawTab as EnvironmentTab
+    : DEFAULT_TAB
   const id = params.id as string
   const { t } = useLanguage()
   const [isLoading, setIsLoading] = useState(true)
@@ -57,6 +76,8 @@ export default function EnvironmentEditPage() {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [deleteConfirmInput, setDeleteConfirmInput] = useState("")
   const [isDeleting, setIsDeleting] = useState(false)
+  const [isSavingCluster, setIsSavingCluster] = useState(false)
+  const [isSavingCredentials, setIsSavingCredentials] = useState(false)
 
   const form = useForm<EnvironmentFormValues>({
     resolver: zodResolver(getEnvironmentSchema(t)),
@@ -219,18 +240,50 @@ export default function EnvironmentEditPage() {
     }
   }
 
-  const onSubmit = async (data: EnvironmentFormValues) => {
+  const handleTabChange = (value: string | number | null) => {
+    if (!value || !VALID_TABS.has(value as EnvironmentTab)) return
+    const nextParams = new URLSearchParams(searchParams.toString())
+    nextParams.set("tab", value as string)
+    router.push(`${pathname}?${nextParams.toString()}`)
+  }
+
+  const handleSaveCluster = async () => {
+    const valid = await form.trigger(["kubernetesApiServer", "workNamespace", "buildStorageClass"])
+    if (!valid) return
+    setIsSavingCluster(true)
     try {
-      const res = await updateEnvironment(id, data)
+      const { kubernetesApiServer, workNamespace, buildStorageClass } = form.getValues()
+      const res = await updateEnvironmentCluster(id, { kubernetesApiServer, workNamespace, buildStorageClass })
       if (res.success) {
         toast.success(t("env.updateSuccess"))
-        router.push("/settings/environments")
       } else {
-        toast.error(t("env.updateError"))
+        toast.error(res.message || t("env.updateError"))
       }
     } catch (e) {
       console.error(e)
       toast.error(t("env.updateError"))
+    } finally {
+      setIsSavingCluster(false)
+    }
+  }
+
+  const handleSaveCredentials = async () => {
+    const valid = await form.trigger(["imageRepository", "gitCredential"])
+    if (!valid) return
+    setIsSavingCredentials(true)
+    try {
+      const { imageRepository, gitCredential } = form.getValues()
+      const res = await updateEnvironmentCredentials(id, { imageRepository, gitCredential })
+      if (res.success) {
+        toast.success(t("env.updateSuccess"))
+      } else {
+        toast.error(res.message || t("env.updateError"))
+      }
+    } catch (e) {
+      console.error(e)
+      toast.error(t("env.updateError"))
+    } finally {
+      setIsSavingCredentials(false)
     }
   }
 
@@ -269,7 +322,15 @@ export default function EnvironmentEditPage() {
       <div className="flex gap-6">
         <div className="flex-1 min-w-0">
               <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmit)} className="flex w-full flex-col gap-4">
+                <form onSubmit={(event) => event.preventDefault()} className="w-full">
+                <Tabs value={currentTab} onValueChange={handleTabChange} className="w-full">
+                  <TabsList>
+                    <TabsTrigger value="basic" className="px-6 cursor-pointer">{t("env.tab.basic")}</TabsTrigger>
+                    <TabsTrigger value="credentials" className="px-6 cursor-pointer">{t("env.tab.credentials")}</TabsTrigger>
+                    <TabsTrigger value="danger-zone" className="px-6 cursor-pointer data-active:bg-destructive data-active:text-white dark:data-active:border-destructive">{t("env.dangerZone")}</TabsTrigger>
+                  </TabsList>
+
+                  <TabsContent value="basic" keepMounted className="flex flex-col gap-4">
                   {/* Basic Info Block */}
                   <div className="border rounded-lg overflow-hidden">
                     <div className="flex items-center gap-2 px-4 py-3 bg-muted/50 border-b">
@@ -399,6 +460,15 @@ export default function EnvironmentEditPage() {
                     </div>
                   </div>
 
+                  <div className="flex">
+                    <Button type="button" onClick={handleSaveCluster} disabled={!isK8sValidated || isSavingCluster}>
+                      {isSavingCluster && <Loader2 className="size-4 animate-spin" />}
+                      {t("env.save")}
+                    </Button>
+                  </div>
+                  </TabsContent>
+
+                  <TabsContent value="credentials" keepMounted className="flex flex-col gap-4">
                   {/* Image Repo Config Block */}
                   <div className="border rounded-lg overflow-hidden">
                     <div className="flex items-center justify-between px-4 py-3 bg-muted/50 border-b">
@@ -584,9 +654,14 @@ export default function EnvironmentEditPage() {
                   </div>
 
                   <div className="flex">
-                    <Button type="submit" disabled={!isK8sValidated || !isRepoValidated}>{t("env.save")}</Button>
+                    <Button type="button" onClick={handleSaveCredentials} disabled={!isRepoValidated || isSavingCredentials}>
+                      {isSavingCredentials && <Loader2 className="size-4 animate-spin" />}
+                      {t("env.save")}
+                    </Button>
                   </div>
+                  </TabsContent>
 
+                  <TabsContent value="danger-zone">
                   {/* Danger Zone Block */}
                   <div className="border border-destructive/30 rounded-lg overflow-hidden">
                     <div className="flex items-center gap-2 px-4 py-3 bg-destructive/10 border-b border-destructive/30">
@@ -615,6 +690,8 @@ export default function EnvironmentEditPage() {
                       </Button>
                     </div>
                   </div>
+                  </TabsContent>
+                </Tabs>
                 </form>
               </Form>
         </div>

--- a/web/lib/api/environments.ts
+++ b/web/lib/api/environments.ts
@@ -70,19 +70,33 @@ export async function validateImageRepository(data: { url?: string; username?: s
   return response.json() as Promise<ApiResponse<boolean>>
 }
 
-export async function updateEnvironment(id: string, data: EnvironmentFormValues): Promise<ApiResponse<boolean>> {
-  const response = await apiFetch(`/api/environments/${id}`, {
+export async function updateEnvironmentCluster(
+  id: string,
+  data: Pick<EnvironmentFormValues, "kubernetesApiServer" | "workNamespace" | "buildStorageClass">
+): Promise<ApiResponse<boolean>> {
+  const response = await apiFetch(`/api/environments/${id}/cluster`, {
     method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   })
-
   if (!response.ok) {
-    throw new Error("Failed to update environment")
+    throw new Error("Failed to update environment cluster config")
   }
+  return response.json() as Promise<ApiResponse<boolean>>
+}
 
+export async function updateEnvironmentCredentials(
+  id: string,
+  data: Pick<EnvironmentFormValues, "imageRepository" | "gitCredential">
+): Promise<ApiResponse<boolean>> {
+  const response = await apiFetch(`/api/environments/${id}/credentials`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  })
+  if (!response.ok) {
+    throw new Error("Failed to update environment credentials")
+  }
   return response.json() as Promise<ApiResponse<boolean>>
 }
 

--- a/web/locales/en-US/env.ts
+++ b/web/locales/en-US/env.ts
@@ -16,6 +16,8 @@ const env = {
   "env.col.name": "Name",
   "env.col.workNamespace": "Work Namespace",
   "env.col.imageRepo": "Image Repository",
+  "env.tab.basic": "Cluster",
+  "env.tab.credentials": "Registry",
   "env.basicInfo": "Basic Info",
   "env.k8sConfig": "Kubernetes Config",
   "env.validated": "Validated",

--- a/web/locales/ja-JP/env.ts
+++ b/web/locales/ja-JP/env.ts
@@ -16,6 +16,8 @@ const env = {
   "env.col.name": "名前",
   "env.col.workNamespace": "作業用名前空間",
   "env.col.imageRepo": "イメージリポジトリ",
+  "env.tab.basic": "クラスター情報",
+  "env.tab.credentials": "リポジトリ情報",
   "env.basicInfo": "基本情報",
   "env.k8sConfig": "Kubernetes 設定",
   "env.validated": "検証済み",

--- a/web/locales/zh-CN/env.ts
+++ b/web/locales/zh-CN/env.ts
@@ -16,6 +16,8 @@ const env = {
   "env.col.name": "名称",
   "env.col.workNamespace": "工作命名空间",
   "env.col.imageRepo": "镜像仓库",
+  "env.tab.basic": "集群信息",
+  "env.tab.credentials": "仓库信息",
   "env.basicInfo": "基本信息",
   "env.k8sConfig": "Kubernetes 配置",
   "env.validated": "验证通过",

--- a/web/locales/zh-TW/env.ts
+++ b/web/locales/zh-TW/env.ts
@@ -16,6 +16,8 @@ const env = {
   "env.col.name": "名稱",
   "env.col.workNamespace": "工作命名空間",
   "env.col.imageRepo": "鏡像倉庫",
+  "env.tab.basic": "叢集訊息",
+  "env.tab.credentials": "倉庫訊息",
   "env.basicInfo": "基本訊息",
   "env.k8sConfig": "Kubernetes 配置",
   "env.validated": "驗證透過",


### PR DESCRIPTION
Restructure the environment edit page from a single flat form into three tabs matching the application editor: cluster info (basic + Kubernetes config), registry info (image repository + git credential), and danger zone. Tab state syncs to a ?tab= query parameter and form values survive tab switches via kept-mounted panels.

Saving is now split on the backend as well: PUT /{id}/cluster updates the API server, work namespace and build storage class (re-syncing the stored credential secrets into the possibly-changed namespace), while PUT /{id}/credentials updates the image repository and git credential. Each tab's save button only requires its own validation to pass, so a change on one tab can no longer silently block saving on the other. The old whole-entity PUT /{id} endpoint had no remaining callers and is removed.