### PR TITLE
test: add an API-level acceptance suite that stands up its own stack

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,71 @@
+# Runs the acceptance suite against a real stack: MySQL, RustFS, Gitea, two
+# registries, a k3s cluster and the backend, all of it stood up and torn down by
+# tests/acceptance/run.sh.
+#
+# Started by hand only. A full run builds and deploys a container image per
+# scenario and takes tens of minutes, so it is something you ask for — before a
+# release, or against a branch that touches the Kubernetes layer — rather than
+# something that happens to every push.
+name: acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: Which tier to run
+        type: choice
+        options: [contract, full]
+        default: full
+      modules:
+        description: Modules to run, comma-separated (blank for all)
+        type: string
+        default: ""
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # run.sh builds the jar itself when it is missing; this is here for the
+      # dependency cache, which is most of that build's time.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Check the route inventory is current
+        run: |
+          python3 tests/acceptance/scripts/extract_routes.py > /tmp/routes.json
+          # A controller added without regenerating routes.json would let a new
+          # endpoint slip past the coverage check unnoticed.
+          diff <(jq -S '[.[].key]' /tmp/routes.json) \
+               <(jq -S '[.[].key]' tests/acceptance/routes.json) \
+            || { echo "routes.json is stale: regenerate it with scripts/extract_routes.py" >&2; exit 1; }
+
+      # One command: virtualenv, middleware, backend, cluster, suite, report,
+      # teardown. It tears the stack down on its own way out, including on a
+      # failure, so there is no cleanup step after this.
+      - name: Run the suite
+        working-directory: tests/acceptance
+        env:
+          OOPS_TEST_DEPLOY_TIMEOUT: "900"
+        run: |
+          arguments=()
+          if [ "${{ inputs.tier }}" = "contract" ]; then
+            arguments+=(--contract)
+          fi
+          if [ -n "${{ inputs.modules }}" ]; then
+            arguments+=(--module "${{ inputs.modules }}")
+          fi
+          ./run.sh "${arguments[@]}"
+
+      - name: Publish the report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-report
+          path: tests/acceptance/reports/

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ web/out/
 web/build
 
 # misc
-web/.DS_Store
 web/*.pem
 
 # debug
@@ -74,3 +73,17 @@ web/next-env.d.ts
 src/main/resources/application.properties
 src/main/resources/application.yml
 config/application.yml
+
+# macOS. Anywhere, not just under web/ — Finder leaves one in whatever
+# directory it has been asked to show.
+.DS_Store
+
+# Python acceptance suite. Unanchored, so they hold for every directory the
+# suite grows rather than only the two it has today.
+.venv/
+__pycache__/
+.pytest_cache/
+tests/acceptance/reports/
+tests/acceptance/scripts/.kubeconfig
+tests/acceptance/scripts/.registry-auth/
+tests/acceptance/scripts/.k3s/

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -1,0 +1,350 @@
+# Acceptance suite
+
+Black-box tests against the OOPS HTTP and WebSocket API. They import nothing from
+the backend and know nothing about its language, so the same suite is the
+acceptance criteria for the current Java service, a Go or Rust rewrite, or a
+GraalVM native build.
+
+That portability is the point. The Kubernetes layer — roughly 5.7k lines across
+15 gateways — carries almost no unit tests today because it needs a live API
+server, and that is exactly the layer any rewrite gets wrong. These tests pin the
+observable behaviour while a correct implementation still exists to check against.
+
+## Two tiers
+
+| Tier | Needs | Covers |
+|---|---|---|
+| contract | the compose middleware | the wire contract, users and authorisation, domains, application configuration round trips, environment management, object storage presigning, git branch listing |
+| `cluster` | the above plus k3s | build and deploy pipelines, pipeline operations, both registry credential paths, git clone with and without credentials, ingress routes and basic auth, deletion in the cluster, sandboxes, pod filesystem, log and terminal sockets |
+
+Organised by scenario rather than by endpoint: what a rewrite has to preserve is
+behaviour, and every defect this suite found needed a full journey to surface.
+Coverage is then enforced from the other direction — `test_zz_coverage.py`
+compares the routes the run actually called against a table extracted from the
+controllers by `scripts/extract_routes.py`, and fails naming any endpoint that no
+scenario reached. Add a controller and the suite goes red until a scenario
+exercises it.
+
+The contract tier runs anywhere and is fast. It catches the quiet regressions — a
+timestamp that grew a zone suffix, a page that became 0-based, an error that
+started arriving as an HTTP 500 instead of `success: false`.
+
+## Running
+
+One command, from a clean checkout:
+
+```bash
+cd tests/acceptance
+./run.sh                          # everything, then tears it all down
+./run.sh --module ingress         # one module
+./run.sh --module deploy,ingress  # a few
+./run.sh --list                   # what the modules are
+./run.sh --contract               # every module, minus the tests that need a cluster
+./run.sh --keep                   # leave the stack up to poke at a failure
+```
+
+It creates the virtualenv, starts MySQL, RustFS, Gitea and two registries, builds
+the backend if the jar is missing, runs it in a container, starts a k3s cluster,
+registers it as an environment, runs the suite, writes a report, and removes all
+of it again — including when you interrupt it with Ctrl-C.
+
+Nothing is installed on the machine. Docker is the only prerequisite: every part
+of the stack is a compose service, the middleware listens on non-standard ports
+bound to 127.0.0.1, and the kubeconfig is written to `scripts/.k3s/` rather than
+merged into `~/.kube/config`.
+
+### Modules
+
+A module is one test file, named after what it covers, and nothing declares the
+list: `test_deploy.py` *is* the `deploy` module and its first docstring line is
+its description, so adding a file adds a module with no registry to keep in step.
+
+Naming modules that contain no cluster test also skips starting k3s, which turns
+a three-minute setup into a twenty-second one:
+
+```
+$ ./run.sh --module domain,user
+#6 cluster
+#6 SKIPPED nothing selected needs one
+```
+
+Anything after `--` goes straight to pytest, for the cases a module is too coarse
+for: `./run.sh --module ingress -- -k basic_auth -x`.
+
+The backend runs in a container rather than on the host on purpose. A presigned
+URL is signed for one hostname and redeemed by both the backend and the pipeline
+pods, so they have to resolve it the same way. With everything in Docker they
+share the network and use service names; on the host it would take a machine's
+LAN address, which is absent offline, changes on a VPN, and differs on every CI
+runner.
+
+## Watching a run
+
+The run prints as numbered steps, the way `docker build` does, and makes the
+same split between what is worth keeping and what is only worth watching.
+
+Headings, results and failures are **committed**: they stay on screen for the
+rest of the run. Log output is **transient**: the last few lines of it sit in a
+small region that redraws in place and erases itself the moment the step ends.
+So a forty-minute run leaves a page you can read rather than forty minutes of
+container plumbing, and you can still watch the plumbing while it happens.
+
+```
+#2 middleware — mysql, rustfs, gitea, two registries
+#2  Container oops-acceptance-mysql Healthy      <- these scroll in place,
+#2  Container oops-acceptance-gitea Waiting         then disappear
+#2 DONE 22s
+
+#7 [10/20] ingress — Exposing an application on a host: IngressRoutes, TLS and basic auth.
+#7 5 tests
+#7   OK     92.1s  an http host gets one route on the web entrypoint
+#7 > an https host gets a redirect and a serving route     <- so do these two,
+#7   . waiting for the deploy to finish (45s of 900s)         when the test ends
+#7 DONE 342.0s  5 passed
+```
+
+A test that sits waiting on a deploy says what it is waiting for while it waits,
+which is the difference between slow and hung. That comes from `wait_until`, so
+it covers every deploy, rollout and readiness wait without a test asking for it.
+
+With no terminal to redraw — a pipe, a CI log, `TERM=dumb` — nothing is erased
+and every line is simply printed, the same fallback `docker build` makes. So
+`./run.sh > run.log` keeps the whole transcript.
+
+pytest's own output is in none of that. It goes to `reports/<timestamp>/`, along
+with everything else, announced when the run starts and kept afterwards:
+
+```bash
+tail -f tests/acceptance/reports/*/pytest.log      # the test output
+tail -f tests/acceptance/reports/*/backend.log     # what OOPS is doing
+docker logs -f oops-acceptance-backend             # the same, live
+```
+
+The backend log is followed from the moment the backend answers, rather than
+collected at teardown, so it survives the container — including the case that
+needs it most, where the container dies mid-run and every remaining test fails
+on a refused connection. `--keep` leaves the stack up so you can also reach the
+API and the cluster.
+
+`run.sh` writes a self-contained HTML report and a JUnit XML to `reports/`,
+symlinked as `reports/latest.html` and `reports/latest.xml`, then prints a
+summary. It exits non-zero when anything failed, so it drops straight into CI.
+
+```
+====================================================================
+                       OOPS acceptance report
+====================================================================
+  passed   15
+  total    15   in 1.0s
+====================================================================
+PASSED — all 15 tests
+```
+
+To drive pytest directly instead:
+
+```bash
+pytest -m "not cluster"
+pytest --environment acceptance
+```
+
+Configuration comes from flags or environment variables:
+
+| Variable | Flag | Default |
+|---|---|---|
+| `OOPS_ENDPOINT` | `--endpoint` | `http://localhost:8080` |
+| `OOPS_NAMESPACE` | `--namespace` | `acceptance` |
+| `OOPS_ENVIRONMENT` | `--environment` | the only registered environment, if there is exactly one |
+| `OOPS_USERNAME` / `OOPS_PASSWORD` | — | `admin` / `admin123` |
+| `OOPS_TEST_REPOSITORY` | — | a small public repo with a root Dockerfile |
+| `OOPS_TEST_DEPLOY_TIMEOUT` | — | `900` seconds |
+
+Cluster tests skip rather than fail when no environment can be resolved, so the
+contract tier still runs on a bare stack.
+
+## The cluster
+
+k3s, as a compose service behind the `cluster` profile, so the whole stack is one
+`docker compose` file and one network. `scripts/cluster-provision.sh` then does
+the rest: waits for the API server, creates a cluster-admin service account and a
+long-lived token, and waits for the Traefik CRDs to register.
+
+```bash
+docker compose -f docker-compose.yml --profile cluster up -d --wait k3s
+eval "$(./scripts/cluster-provision.sh | grep '^  export' | sed 's/^  //')"
+python scripts/register_environment.py --name acceptance
+pytest --environment acceptance
+```
+
+Nothing lands on the host. The kubeconfig is written to `scripts/.k3s/` rather
+than merged into `~/.kube/config`, so your real cluster contexts are untouched,
+and everything else lives in Docker.
+
+k3s rather than kind for one reason that matters here: it ships Traefik, so the
+`traefik.io` CRDs exist and `IngressRouteProcessor` actually runs. Under kind
+every deploy took the "no host configured, skipping ingress route creation"
+branch, and the entire ingress path — TLS, the HTTP→HTTPS redirect middleware,
+basic auth — was never executed once. That is also where the pruning defect the
+`ingress` module now covers had been hiding.
+
+The provisioning script injects the node's IPv4 into CoreDNS's `NodeHosts`.
+Docker Desktop synthesises an IPv6 answer for container names, which pods then
+prefer, and a build pod that resolves the registry over IPv6 fails with a bare
+`EOF` that says nothing about address families.
+
+### Two registries, on purpose
+
+The stack runs both an anonymous registry and one behind htpasswd, because
+the two configurations take completely different paths through OOPS. With
+credentials, `syncImagePullSecret` writes a `dockerhub` secret, buildah mounts it
+to authenticate its push, the pull secret processor copies it into the
+application namespace, and the kubelet pulls with it — four steps that can each
+fail alone. Without credentials, no secret is written and every consumer has to
+tolerate its absence. Testing only the anonymous half would have left the entire
+credential chain unexercised.
+
+`registry:2` with htpasswd rather than Harbor: the same authentication protocol,
+without several gigabytes of Postgres, Redis and portal for project and robot
+account semantics OOPS does not use.
+
+### Field shapes that are easy to get wrong
+
+Two asymmetries the suite pins down, both found by running against the real
+service:
+
+- **Memory is unit-less, CPU is not.** `cpuRequest` / `cpuLimit` take full
+  Kubernetes quantity strings (`500m`), while `memoryRequest` / `memoryLimit`
+  take a bare number of MiB — the gateway appends `Mi` itself. Sending `256Mi`
+  produces `256MiMi` and the API server rejects the StatefulSet with
+  `unable to parse quantity's suffix`.
+- **A missing application is not an error.** `GET .../applications/{name}` for a
+  name that does not exist answers HTTP 200 with `success: true` and `data:
+  null`, not a 404 and not `success: false`.
+
+### The registry credentials are set on purpose
+
+`register_environment.py` defaults the registry username and password to `oops`
+even though the anonymous registry ignores them, so the default environment
+exercises the credentialed path: `syncImagePullSecret()` writes the secret,
+buildah mounts it, and the pull secret processor copies it into the application
+namespace. The credential-free path is then reached deliberately, by
+`test_registry.py` registering its own environment with both fields blank.
+
+That asymmetry used to be fatal rather than merely untested — see the first
+bullet under *Everything else*.
+
+## What the suite found
+
+Written against a working implementation, so anything it turned up is a real
+defect rather than a porting mistake.
+
+### Cluster takeover from any user account
+
+`GET /api/environments` carries no role restriction and returns
+`kubernetesApiServer.token` in clear text. That is the cluster-admin service
+account the environment was registered with, so any account that can log in to
+OOPS — a plain `USER` included — can read it and then drive the Kubernetes API
+server directly as cluster-admin, entirely outside OOPS and outside its audit
+trail.
+
+Encrypting the column at rest does not help, because the API decrypts it on the
+way out. The fix is for `EnvironmentDto` to omit the secret fields, the way the
+editor already treats a blank value as "keep what is stored". Pinned by
+`test_cluster_credentials_are_returned_in_clear_text_to_any_user`.
+
+### Arbitrary container execution from any user account
+
+`oops.sandbox.images` reads as an allowlist and is described as one, but
+`SandboxRuntimeService` only has `list()` — it populates the picker and nothing
+on the execution path ever compares the requested image against it. Any
+authenticated user can post an arbitrary image to `/api/sandbox/executions` and
+have it run as a Job in the cluster. Pinned in `test_sandbox.py`, written to
+fail if enforcement is added.
+
+### Privilege escalation from any user account
+
+`GET /api/users` is annotated `@PreAuthorize("isAuthenticated()")` and serialises
+the `User` aggregate as it stands, so the response carries every account's
+`password` (the BCrypt hash) and `accessToken`. That token is exactly what
+`OpenApiAuthFilter` authenticates `/openapi/**` with, via
+`findByAccessToken`.
+
+So any account with `USER` can read the administrator's access token and then act
+as the administrator across the whole machine surface. The password hashes leak
+alongside it, for offline cracking. `GET /api/users/page` and `GET /api/users/me`
+serialise the same aggregate.
+
+The fix is a response DTO that omits both fields. Pinned by a test in
+`test_user.py` that fails once the fields stop being returned, so the fix is
+noticed here rather than being mistaken for a regression.
+
+### Everything else
+
+- **Builds wedge against a credential-free registry.** `syncImagePullSecret`
+  skips creating the `dockerhub` secret when the registry username or password is
+  blank, but the build job mounted it as a non-optional volume, so every build
+  stopped at `Init:0/2` with `MountVolume.SetUp failed`. Nothing in the UI
+  explained why. Fixed by marking the volume optional in `SecretVolume`, matching
+  the `git-secret` volume fifteen lines below it and the pull secret processor,
+  which already tolerate the secret's absence. Covered by
+  `test_build_starts_when_the_registry_needs_no_credentials`.
+
+- **Clearing an application's host left it answering on that host.**
+  `IngressRouteProcessor` returned as soon as it found no hosts configured, and
+  the pruning that removes routes, the redirect middleware and the basic auth
+  secrets sat below that return — so releasing a hostname in the UI took it out
+  of the config and left Traefik serving it, credentials and all, until someone
+  deleted the application. Fixed by making the empty-host case log and fall
+  through instead of returning, and by moving the CRD check above it. Covered by
+  `test_removing_the_host_removes_its_routes`.
+
+- **Saving a runtime spec for an undeployed application logged a 404 every
+  time.** `applyRuntimeSpec` patched the StatefulSet unconditionally, so
+  configuring an application before its first deploy — the normal order — warned
+  `Failed to apply runtime spec` with a Kubernetes 404 behind it. Twenty-three
+  such warnings per suite run, all of them meaningless, which is how a log stops
+  being read. Fixed by returning early when there is no StatefulSet yet; the
+  deploy applies the spec when it creates one.
+
+- **Deleting an application does clean up its Service, but not visibly.**
+  `deleteWorkload` removes only the StatefulSet, which reads like a leak until
+  you find the owner reference `ServiceProcessor` stamps on the Service —
+  Kubernetes collects it when its owner goes. Not a defect, but an invisible
+  mechanism a rewrite can drop while still passing every deploy test, so
+  `test_the_service_goes_with_the_statefulset` asserts it.
+
+- **Application names are globally unique, not per namespace.** Every URL is
+  namespaced, but the schema has `UNIQUE KEY uk_application_name (name)` on the
+  name alone, so two namespaces cannot both hold an application called `web`.
+  Pinned by `test_application_names_are_globally_unique_not_per_namespace`, again
+  written to fail if the key is widened.
+
+- **Git credentials are shared across a work namespace.** They are synced into
+  the work namespace as the `git-credential` secret, and every build pod there
+  mounts it regardless of which environment triggered the build. An environment
+  with no git credentials of its own therefore clones private repositories using
+  whatever another environment last synced. Worth knowing before two teams share
+  a work namespace, because the environment list implies an isolation that is not
+  there. Pinned by `test_git_credentials_are_shared_across_a_work_namespace`.
+
+- **Deleting an application does nothing in the cluster unless it is bound to an
+  environment.** `deleteApplication` iterates the `application_environment` rows
+  to decide what to clean up, but a deploy does not require that binding — so an
+  unbound application can be deployed, then deleted from the database while its
+  StatefulSet keeps running. The suite avoids this by binding explicitly in
+  `configure_for_build`, which is also what the UI does.
+
+The last two are recorded rather than fixed. Both are behaviour changes a user
+would notice, so they belong in a decision, not in a test-driven drive-by.
+
+## Writing more
+
+Tests speak only through `OopsClient`. When you add an endpoint, add a helper
+there rather than building URLs inline, so a path change lands in one place.
+
+Two rules keep the suite honest as a rewrite target:
+
+- **Assert on the contract, not the implementation.** Pod log content depends on
+  the image; that lines arrive individually does not. Prefer the second.
+- **Say what a failure means.** Every assertion carries a message explaining the
+  consequence, because the person reading it may be debugging a reimplementation
+  they did not write.

--- a/tests/acceptance/application.yml
+++ b/tests/acceptance/application.yml
@@ -1,0 +1,119 @@
+# Backend configuration for acceptance runs.
+#
+# Points at the throwaway middleware in docker-compose.yml — non-standard ports
+# so a run can never touch a real database or bucket. Object storage is enabled
+# here even though it is off by default, because the ZIP source path is only
+# reachable with it on.
+#
+#   ./scripts/middleware-up.sh
+#   java -jar target/oops-0.0.1-SNAPSHOT.jar \
+#     --spring.config.location=file:tests/acceptance/application.yml
+
+spring:
+  application:
+    name: oops
+  task:
+    scheduling:
+      pool:
+        size: 3
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+  datasource:
+    # Container names throughout: the backend runs in Docker alongside the
+    # middleware, so every address it dials is a service name on the compose
+    # network. Nothing here is reachable from the host, and nothing needs to be.
+    url: jdbc:mysql://mysql:3306/oops?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=utf8&useUnicode=true
+    username: root
+    password: acceptance
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+    open-in-view: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+
+oops:
+  admin:
+    password: admin123
+  pipeline:
+    image:
+      clone: alpine/git:v2.49.0
+      zip: alpine/curl:8.17.0
+      push: quay.io/buildah/stable:v1.43.1
+      unzip-excludes:
+        - .git/*
+        - "*/.git/*"
+        - __MACOSX
+        - __MACOSX/*
+        - .DS_Store
+  metrics:
+    history:
+      interval-seconds: 30
+      max-range-hours: 24
+      backend:
+        # Blank namespace hides the usage charts. kind runs no Prometheus, and
+        # the suite makes no assertions about metrics.
+        namespace: ""
+        service-name: prometheus-operated
+        port: 9090
+    alert:
+      enabled: false
+      cpu:
+        threshold-percent: 95
+        sustained-minutes: 10
+      memory:
+        threshold-percent: 90
+        sustained-minutes: 5
+      repeat-interval-minutes: 30
+  pod-filesystem:
+    max-download-size-bytes: 52428800
+    max-upload-size-bytes: 52428800
+    max-edit-size-bytes: 1048576
+  ingress:
+    cert-resolver: letsencrypt-prod
+  crypto:
+    secret-key: acceptance-crypto-secret-key-not-for-production
+  jwt:
+    secret: acceptance-jwt-secret-key-not-for-production-at-least-32-chars-long
+    expiration: 604800000
+  feishu:
+    enabled: false
+    app-id: cli_acceptance
+    app-secret: acceptance
+    redirect-uri: http://localhost:3000/auth/feishu/callback
+    sync-user-deactivation: false
+  ide:
+    enabled: false
+    https: false
+    domain: ide.acceptance.invalid
+    image: codercom/code-server:4.112.0-39
+  object-storage:
+    enabled: true
+    # A container name, because everything that redeems a presigned URL in
+    # anger runs in Docker: the backend container and the pipeline's fetch
+    # container both resolve it. Only the test process sits outside, and it
+    # rewrites the address while keeping the Host header, which is the half
+    # SigV4 signs. Deliberately not a host address — a machine's LAN IP is
+    # absent offline, changes on a VPN, and differs on every CI runner.
+    endpoint: ${OOPS_S3_ENDPOINT:http://rustfs:9000}
+    region: us-east-1
+    bucket: oops-build-sources
+    access-key: acceptance
+    secret-key: acceptance-secret
+    # The store serves buckets as a path rather than as a virtual host, so the
+    # SDK has to be told not to fold the bucket name into the hostname.
+    path-style-access: true
+    key-prefix: build-sources
+    asset-key-prefix: oops-assets
+    upload-url-expiration-seconds: 900
+    download-url-expiration-seconds: 1800
+    max-file-size-bytes: 524288000
+  sandbox:
+    images:
+      - python:3.12-slim
+      - alpine:3.20

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,0 +1,289 @@
+"""Fixtures for the acceptance suite.
+
+Everything is driven by environment variables so the same tests can be pointed at
+a local dev server, a CI stack, or a staging deployment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from oops_client import OopsClient
+
+DEFAULT_ENDPOINT = "http://localhost:8080"
+DEFAULT_NAMESPACE = "acceptance"
+
+
+def pytest_addoption(parser):
+    parser.addoption("--endpoint", default=None,
+                     help="OOPS base URL (default: $OOPS_ENDPOINT or localhost:8080)")
+    parser.addoption("--namespace", default=None,
+                     help="namespace the suite creates applications in")
+    parser.addoption("--environment", default=None,
+                     help="environment name to deploy into; cluster tests skip without it")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "cluster: needs a reachable Kubernetes environment registered in OOPS",
+    )
+
+
+@pytest.fixture(scope="session")
+def endpoint(pytestconfig) -> str:
+    return (pytestconfig.getoption("endpoint")
+            or os.environ.get("OOPS_ENDPOINT")
+            or DEFAULT_ENDPOINT).rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def namespace(pytestconfig) -> str:
+    return (pytestconfig.getoption("namespace")
+            or os.environ.get("OOPS_NAMESPACE")
+            or DEFAULT_NAMESPACE)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def service_is_up(endpoint):
+    """Fail the session once, clearly, when nothing is listening.
+
+    Without this every test reports its own connection error and the real cause
+    scrolls off the top.
+    """
+    import requests
+
+    try:
+        # The health endpoint, not the login one. A GET against a @PostMapping
+        # answers correctly but leaves an HttpRequestMethodNotSupportedException
+        # in the backend log on every run, which is exactly the sort of noise
+        # this suite is meant to help people notice rather than create.
+        requests.get(f"{endpoint}/api/health", timeout=5)
+    except requests.exceptions.RequestException as error:
+        pytest.exit(
+            f"no OOPS service answering at {endpoint}: {error}\n"
+            f"Start the backend, or point the suite elsewhere with "
+            f"--endpoint / $OOPS_ENDPOINT.",
+            returncode=2,
+        )
+
+
+@pytest.fixture(scope="session")
+def client(endpoint, service_is_up) -> OopsClient:
+    """A logged-in admin client. Fails the whole session early if the service is
+    not up, rather than letting every test fail with its own connection error."""
+    connection = OopsClient(endpoint)
+    username = os.environ.get("OOPS_USERNAME", "admin")
+    password = os.environ.get("OOPS_PASSWORD", "admin123")
+    try:
+        connection.login(username, password)
+    except Exception as error:
+        pytest.exit(f"cannot log in to {endpoint} as {username}: {error}", returncode=2)
+    return connection
+
+
+@pytest.fixture(scope="session")
+def environment(pytestconfig, client) -> str:
+    """Name of an environment to deploy into.
+
+    Resolution order: explicit flag, $OOPS_ENVIRONMENT, then the only environment
+    registered if there happens to be exactly one. Cluster tests skip when none
+    can be resolved, so the non-cluster tier still runs on a bare stack.
+    """
+    chosen = (pytestconfig.getoption("environment")
+              or os.environ.get("OOPS_ENVIRONMENT"))
+    registered = [item["name"] for item in client.list_environments()]
+    if chosen:
+        if chosen not in registered:
+            pytest.exit(
+                f"environment {chosen!r} is not registered; known: {registered}",
+                returncode=2)
+        return chosen
+    if len(registered) == 1:
+        return registered[0]
+    pytest.skip("no environment registered — this needs the cluster tier, "
+                "which ./run.sh sets up (you are probably in --contract)")
+
+
+class Kubectl:
+    """Reads cluster state directly, to check what the API only claims.
+
+    Deletion is the case that needs it: the HTTP response says the application is
+    gone, and only the cluster can say whether its objects actually went with it.
+    """
+
+    def __init__(self, kubeconfig: str):
+        self.kubeconfig = kubeconfig
+
+    def _run(self, *arguments: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["kubectl", *arguments],
+            env={**os.environ, "KUBECONFIG": self.kubeconfig},
+            capture_output=True, text=True, timeout=30,
+        )
+
+    def exists(self, kind: str, name: str, namespace: str) -> bool:
+        return self._run("get", kind, name, "-n", namespace).returncode == 0
+
+    def get_json(self, kind: str, name: str, namespace: str):
+        result = self._run("get", kind, name, "-n", namespace, "-o", "json")
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+
+    def names(self, kind: str, namespace: str) -> list[str]:
+        result = self._run("get", kind, "-n", namespace,
+                           "-o", "jsonpath={.items[*].metadata.name}")
+        if result.returncode != 0:
+            return []
+        return result.stdout.split()
+
+
+@pytest.fixture(scope="session")
+def kubectl() -> Kubectl:
+    kubeconfig = os.environ.get("KUBECONFIG") or str(
+        Path(__file__).parent / "scripts" / ".k3s" / "kubeconfig.yaml")
+    if not Path(kubeconfig).exists():
+        pytest.skip(f"no kubeconfig at {kubeconfig} — run ./run.sh")
+    if shutil.which("kubectl") is None:
+        pytest.skip("kubectl is not on PATH")
+    return Kubectl(kubeconfig)
+
+
+@pytest.fixture(scope="session")
+def cluster_credentials() -> dict:
+    """API server address and token, as `cluster-provision.sh` exports them.
+
+    Needed by tests that register their own environment rather than reusing the
+    one the session was pointed at.
+    """
+    api_server = os.environ.get("OOPS_CLUSTER_API_SERVER")
+    token = os.environ.get("OOPS_CLUSTER_TOKEN")
+    if not api_server or not token:
+        pytest.skip("no cluster credentials — this needs the cluster tier, "
+                    "which ./run.sh sets up (you are probably in --contract)")
+    return {
+        "url": api_server,
+        "token": token,
+        "workNamespace": os.environ.get("OOPS_WORK_NAMESPACE", "oops-work"),
+    }
+
+
+@pytest.fixture
+def environment_factory(client, cluster_credentials):
+    """Registers environments and removes them afterwards.
+
+    Registry credentials are a parameter rather than a constant because the two
+    interesting cases are exactly credentials-present and credentials-absent.
+    """
+    created: list[str] = []
+
+    def create(prefix: str = "env", registry: str = "",
+               registry_username: str = "", registry_password: str = "",
+               git_username: str = "", git_password: str = "",
+               git_private_key: str = "") -> str:
+        name = f"{prefix}-{uuid.uuid4().hex[:8]}"
+        body = {
+            "name": name,
+            "kubernetesApiServer": {
+                "url": cluster_credentials["url"],
+                "token": cluster_credentials["token"],
+            },
+            "workNamespace": cluster_credentials["workNamespace"],
+            "imageRepository": {
+                "url": registry,
+                "username": registry_username,
+                "password": registry_password,
+            },
+        }
+        if git_username or git_password or git_private_key:
+            body["gitCredential"] = {
+                "username": git_username,
+                "password": git_password,
+                "privateKey": git_private_key,
+            }
+        client.post("/api/environments", body)
+        created.append(name)
+        return name
+
+    yield create
+
+    for name in reversed(created):
+        try:
+            registered = {item["name"]: item["id"]
+                          for item in client.list_environments()}
+            if name in registered:
+                client.delete(f"/api/environments/{registered[name]}",
+                              expect_success=False)
+        except Exception:
+            pass
+
+
+@pytest.fixture(scope="session")
+def secondary_user(client) -> dict:
+    """A plain, non-admin account, created once and reused.
+
+    Authorisation rules cannot be tested from the admin session alone — admins
+    are allowed to do everything, so every check would pass for the wrong
+    reason.
+    """
+    username = "acceptance-nonowner"
+    password = "acceptance-nonowner-123"
+
+    existing = client.get("/api/users", expect_success=False)
+    known = [item.get("username") for item in (existing.data or [])] \
+        if isinstance(existing.data, list) else []
+
+    if username not in known:
+        created = client.post("/api/users", {
+            "username": username,
+            "email": f"{username}@example.invalid",
+            "password": password,
+        }, expect_success=False)
+        if not created.success:
+            pytest.skip(f"could not create the secondary account: {created.message}")
+
+    return {"username": username, "password": password}
+
+
+@pytest.fixture
+def application_factory(client, namespace):
+    """Creates applications and removes them afterwards, even if a test fails.
+
+    Names carry a random suffix so a crashed run never collides with the next one.
+    """
+    created: list[str] = []
+
+    def create(prefix: str = "acc") -> str:
+        name = f"{prefix}-{uuid.uuid4().hex[:8]}"
+        client.create_application(namespace, name)
+        created.append(name)
+        return name
+
+    yield create
+
+    for name in reversed(created):
+        try:
+            client.delete_application(namespace, name, expect_success=False)
+        except Exception:
+            # Cleanup is best effort — a leaked test app must never mask the
+            # actual assertion failure that got us here.
+            pass
+
+
+@pytest.fixture
+def application(application_factory) -> str:
+    return application_factory()
+
+
+@pytest.fixture(scope="session")
+def unique_suffix() -> str:
+    return f"{int(time.time())}-{uuid.uuid4().hex[:6]}"

--- a/tests/acceptance/docker-compose.yml
+++ b/tests/acceptance/docker-compose.yml
@@ -1,0 +1,235 @@
+# Middleware for the acceptance suite.
+#
+# Everything OOPS talks to except Kubernetes itself, which kind provides —
+# see scripts/kind-up.sh. Kept separate from docker/docker-compose*.yml because
+# these are throwaway containers on non-standard ports, deliberately chosen so a
+# run cannot reach a real development database, bucket or registry.
+#
+#   docker compose -f tests/acceptance/docker-compose.yml up -d
+#   docker compose -f tests/acceptance/docker-compose.yml down -v
+
+name: oops-acceptance
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: oops-acceptance-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: acceptance
+      MYSQL_DATABASE: oops
+    ports:
+      - "127.0.0.1:13306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-uroot", "-pacceptance", "--silent"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+    tmpfs:
+      # The database is rebuilt from migrations on every run, so there is nothing
+      # worth writing to disk — and nothing left behind when the container goes.
+      - /var/lib/mysql
+
+  # S3-compatible storage for the ZIP source upload and static asset paths.
+  # RustFS rather than MinIO: MinIO's community edition was archived in April
+  # 2026 and gets no further releases or security patches, while RustFS is
+  # Apache 2.0 and maintained. OOPS depends on neither — it speaks S3 through the
+  # AWS SDK — so this is a fixture choice, and swapping it is this block alone.
+  rustfs:
+    image: rustfs/rustfs:1.0.0-rc.4
+    container_name: oops-acceptance-rustfs
+    environment:
+      RUSTFS_ACCESS_KEY: acceptance
+      RUSTFS_SECRET_KEY: acceptance-secret
+      RUSTFS_ADDRESS: "0.0.0.0:9000"
+      RUSTFS_CONSOLE_ENABLE: "true"
+      RUSTFS_VOLUMES: /data
+    # Published only for the test process, which is the one party outside Docker.
+    # The backend and the pipeline pods reach this service by name instead.
+    ports:
+      - "127.0.0.1:19000:9000"
+    healthcheck:
+      # Connectivity only. The S3 root answers 403 to an unsigned request, which
+      # is correct, so `curl -f` would report a healthy server as unhealthy.
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:9000"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+    # The server runs as uid 10001 and writes to both paths; the default
+    # root-owned tmpfs makes it exit at startup with a bare "Permission denied".
+    tmpfs:
+      - /data:uid=10001,gid=10001
+      - /logs:uid=10001,gid=10001
+
+  # Creates the bucket the ZIP source upload path writes into, then exits.
+  # The AWS CLI rather than a vendor tool, so this step survives another change
+  # of object store.
+  rustfs-init:
+    image: amazon/aws-cli:2.28.11
+    container_name: oops-acceptance-rustfs-init
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    environment:
+      AWS_ACCESS_KEY_ID: acceptance
+      AWS_SECRET_ACCESS_KEY: acceptance-secret
+      AWS_DEFAULT_REGION: us-east-1
+    entrypoint: >
+      /bin/sh -c "
+      aws --endpoint-url http://rustfs:9000 s3 mb s3://oops-build-sources
+      || aws --endpoint-url http://rustfs:9000 s3 ls s3://oops-build-sources;
+      echo 'bucket ready'
+      "
+
+  # A real Git server, so the git path can be tested with credentials rather than
+  # only against a public repository on the internet. Gitea rather than GitLab:
+  # one binary and about a hundred megabytes, against several gigabytes and a
+  # multi-minute boot for semantics OOPS does not use.
+  #
+  # Reachable at two addresses, and both are needed. The backend runs on the host
+  # and lists branches in process, so it uses 127.0.0.1:13000. The build pod runs
+  # inside kind and clones from gitea:3000 over the shared Docker network. A
+  # repository URL is stored once, so a test picks whichever address matches the
+  # path it is exercising.
+  gitea:
+    image: gitea/gitea:1.22
+    container_name: oops-acceptance-gitea
+    environment:
+      USER_UID: "1000"
+      USER_GID: "1000"
+      GITEA__database__DB_TYPE: sqlite3
+      GITEA__security__INSTALL_LOCK: "true"
+      GITEA__server__ROOT_URL: http://127.0.0.1:13000/
+      GITEA__server__HTTP_PORT: "3000"
+      GITEA__server__DISABLE_SSH: "false"
+      GITEA__server__SSH_PORT: "2222"
+      GITEA__server__SSH_LISTEN_PORT: "22"
+      GITEA__service__DISABLE_REGISTRATION: "true"
+      GITEA__repository__DEFAULT_BRANCH: main
+    ports:
+      - "127.0.0.1:13000:3000"
+      - "127.0.0.1:12222:22"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/api/healthz"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+    tmpfs:
+      - /data
+
+  # Anonymous registry: exercises the path where an environment has no registry
+  # credentials and OOPS therefore writes no dockerhub secret.
+  registry:
+    image: registry:2
+    container_name: oops-acceptance-registry
+    restart: always
+    ports:
+      - "127.0.0.1:5001:5000"
+
+  # Writes the htpasswd file the authenticated registry mounts. A service rather
+  # than a shell step so the credentials are produced by the same `up` that
+  # consumes them, and nothing has to remember to run a script first.
+  registry-auth-init:
+    image: httpd:2
+    container_name: oops-acceptance-registry-auth-init
+    entrypoint: >
+      /bin/sh -c "htpasswd -Bbn
+      $${OOPS_AUTH_REGISTRY_USER:-oops}
+      $${OOPS_AUTH_REGISTRY_PASSWORD:-oops-secret} > /auth/htpasswd
+      && echo 'registry credentials ready'"
+    volumes:
+      - ./scripts/.registry-auth:/auth
+
+  # htpasswd registry: exercises the credential chain — secret created, mounted
+  # for buildah's push, copied into the application namespace, used to pull.
+  registry-auth:
+    image: registry:2
+    container_name: oops-acceptance-registry-auth
+    restart: always
+    environment:
+      REGISTRY_AUTH: htpasswd
+      REGISTRY_AUTH_HTPASSWD_REALM: Registry Realm
+      REGISTRY_AUTH_HTPASSWD_PATH: /auth/htpasswd
+    depends_on:
+      registry-auth-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./scripts/.registry-auth:/auth:ro
+    ports:
+      - "127.0.0.1:5002:5000"
+
+  # The Kubernetes cluster, as an ordinary compose service.
+  #
+  # k3s rather than kind because kind's node cannot be expressed here at all: it
+  # runs systemd and is bootstrapped by kubeadm into four static pods, so
+  # something outside compose has to drive it. k3s is a single server process
+  # that writes its own kubeconfig, which means the cluster joins the same file,
+  # the same network and the same teardown as everything else.
+  #
+  # It also ships Traefik, and the CRDs it installs are exactly the ones OOPS
+  # addresses — traefik.io/v1alpha1 IngressRoute and Middleware. Under kind
+  # those CRDs are absent, so the ingress half of every deploy silently skipped.
+  k3s:
+    image: rancher/k3s:v1.32.2-k3s1
+    container_name: oops-acceptance-k3s
+    profiles: [cluster]
+    privileged: true
+    command: server --write-kubeconfig-mode=644 --disable=metrics-server
+    environment:
+      K3S_KUBECONFIG_OUTPUT: /output/kubeconfig.yaml
+      K3S_KUBECONFIG_MODE: "666"
+    volumes:
+      - ./scripts/.k3s:/output
+      - ./registries.yaml:/etc/rancher/k3s/registries.yaml:ro
+    tmpfs:
+      - /run
+      - /var/run
+    ports:
+      # For the suite's own kubectl checks. Everything server-side reaches the
+      # API at k3s:6443 over the compose network instead.
+      - "127.0.0.1:16443:6443"
+    healthcheck:
+      test: ["CMD-SHELL", "kubectl get --raw /readyz >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 10s
+      retries: 60
+      start_period: 15s
+
+  # The service under test, in a container like everything else it talks to.
+  #
+  # On the host it would need one address for the object store and Gitea that
+  # both it and the pipeline pods could reach — a machine's LAN IP, which is
+  # absent offline, changes on a VPN and differs on every CI runner. In here it
+  # simply resolves them by service name.
+  #
+  # Behind a profile because the cluster tier attaches it to kind's network
+  # afterwards, and because `middleware-up.sh` is also useful on its own.
+  backend:
+    image: eclipse-temurin:25-jre
+    container_name: oops-acceptance-backend
+    profiles: [backend]
+    depends_on:
+      mysql:
+        condition: service_healthy
+      rustfs:
+        condition: service_healthy
+    volumes:
+      - ${OOPS_JAR:-../../target/oops-0.0.1-SNAPSHOT.jar}:/app/oops.jar:ro
+      - ./application.yml:/app/application.yml:ro
+    # An IANA name, not the %Z abbreviation: "CST" is ambiguous, the JVM ignores
+    # it and the container stays on UTC. Timestamps here are a naive local wall
+    # clock, so the wrong zone shifts every stored value.
+    environment:
+      TZ: ${OOPS_TZ:-UTC}
+    command: >
+      java -jar /app/oops.jar
+      --spring.config.location=file:/app/application.yml
+      --server.port=8080
+    ports:
+      - "127.0.0.1:8080:8080"
+    # No healthcheck here on purpose. The temurin image ships no curl, no wget
+    # and no jshell, so any in-container probe can only fail; run.sh polls the
+    # published port from the host instead, where curl always exists.
+
+networks:
+  default:
+    name: oops-acceptance

--- a/tests/acceptance/oops_client.py
+++ b/tests/acceptance/oops_client.py
@@ -1,0 +1,295 @@
+"""HTTP and WebSocket client for the OOPS API.
+
+Deliberately knows nothing about the backend implementation — it speaks only the
+wire protocol, so the same suite validates the current Java service, a Go or Rust
+rewrite, or a GraalVM native build without a single change.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.parse
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator, Optional
+
+import requests
+import websocket
+
+import runlog
+
+DEFAULT_TIMEOUT = 30
+# How often a long wait says it is still waiting. Long enough not to bury the
+# module it is reported under, short enough to tell a slow deploy from a hang.
+HEARTBEAT_SECONDS = 15
+
+
+class ApiError(AssertionError):
+    """A call that came back with success=false, or an unexpected HTTP status."""
+
+
+@dataclass
+class Response:
+    """One decoded `Result` envelope: {success, message, data}."""
+
+    success: bool
+    message: Optional[str]
+    data: Any
+    status: int
+
+
+# Every (method, path) the suite touches, across all client instances. The
+# coverage test compares this against the route table extracted from the
+# controllers, which is what makes "the scenarios cover every endpoint" a
+# checkable property rather than a claim.
+CALLED: set[tuple[str, str]] = set()
+
+
+def record(method: str, path: str) -> None:
+    CALLED.add((method.upper(), path.split("?", 1)[0]))
+
+
+class OopsClient:
+    def __init__(self, endpoint: str, token: Optional[str] = None,
+                 timeout: int = DEFAULT_TIMEOUT):
+        self.endpoint = endpoint.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+        self.session = requests.Session()
+
+    # -- auth ---------------------------------------------------------------
+
+    def login(self, username: str, password: str) -> str:
+        result = self.post("/api/auth/login",
+                           {"username": username, "password": password},
+                           authenticated=False)
+        self.token = result.data["token"]
+        return self.token
+
+    def _headers(self, authenticated: bool) -> dict:
+        headers = {"Content-Type": "application/json"}
+        if authenticated and self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    # -- raw verbs ----------------------------------------------------------
+
+    def raw(self, method: str, path: str, body: Any = None,
+            authenticated: bool = True, files: Any = None) -> requests.Response:
+        """The underlying HTTP response, envelope unchecked.
+
+        Needed for the cases where the envelope is deliberately absent — rejected
+        authentication is answered by the servlet filter with a bare status, and
+        a file download answers with bytes.
+        """
+        record(method, path)
+        headers = self._headers(authenticated)
+        if files is not None:
+            # requests has to pick the multipart boundary itself, which it only
+            # does when nothing has already claimed the Content-Type header.
+            headers.pop("Content-Type", None)
+        return self.session.request(
+            method, self.endpoint + path,
+            data=json.dumps(body) if body is not None else None,
+            files=files,
+            headers=headers,
+            timeout=self.timeout,
+        )
+
+    def request(self, method: str, path: str, body: Any = None,
+                authenticated: bool = True, expect_success: bool = True,
+                files: Any = None) -> Response:
+        raw = self.raw(method, path, body, authenticated, files)
+        try:
+            payload = raw.json()
+        except ValueError:
+            raise ApiError(
+                f"{method} {path} returned {raw.status_code} with a non-JSON body: "
+                f"{raw.text[:400]!r}"
+            )
+
+        # Every endpoint is contracted to answer with the envelope, including errors.
+        for key in ("success", "message", "data"):
+            if key not in payload:
+                raise ApiError(
+                    f"{method} {path} returned {raw.status_code} without the "
+                    f"'{key}' envelope field: {payload!r}"
+                )
+
+        response = Response(
+            success=payload["success"],
+            message=payload["message"],
+            data=payload["data"],
+            status=raw.status_code,
+        )
+        if expect_success and not response.success:
+            raise ApiError(f"{method} {path} failed: {response.message}")
+        return response
+
+    def get(self, path: str, **kwargs) -> Response:
+        return self.request("GET", path, **kwargs)
+
+    def post(self, path: str, body: Any = None, **kwargs) -> Response:
+        return self.request("POST", path, body, **kwargs)
+
+    def put(self, path: str, body: Any = None, **kwargs) -> Response:
+        return self.request("PUT", path, body, **kwargs)
+
+    def delete(self, path: str, **kwargs) -> Response:
+        return self.request("DELETE", path, **kwargs)
+
+    # -- resource helpers ---------------------------------------------------
+
+    def create_application(self, namespace: str, name: str,
+                           description: str = "acceptance test") -> str:
+        return self.post(
+            f"/api/namespaces/{namespace}/applications",
+            {"name": name, "description": description, "namespace": namespace},
+        ).data
+
+    def delete_application(self, namespace: str, name: str,
+                           expect_success: bool = True) -> Response:
+        return self.delete(
+            f"/api/namespaces/{namespace}/applications/{name}",
+            expect_success=expect_success,
+        )
+
+    def get_application(self, namespace: str, name: str, **kwargs) -> Response:
+        return self.get(f"/api/namespaces/{namespace}/applications/{name}", **kwargs)
+
+    def put_build_config(self, namespace: str, name: str, config: dict) -> Response:
+        return self.put(
+            f"/api/namespaces/{namespace}/applications/{name}/build/config", config)
+
+    def put_service_config(self, namespace: str, name: str, config: dict) -> Response:
+        return self.put(
+            f"/api/namespaces/{namespace}/applications/{name}/service", config)
+
+    def put_runtime_spec(self, namespace: str, name: str, spec: dict) -> Response:
+        return self.put(
+            f"/api/namespaces/{namespace}/applications/{name}/runtime-spec", spec)
+
+    def put_environment_bindings(self, namespace: str, name: str,
+                                 bindings: list) -> Response:
+        return self.put(
+            f"/api/namespaces/{namespace}/applications/{name}/environments",
+            bindings)
+
+    def create_source_upload(self, namespace: str, name: str, file_name: str,
+                             size: int,
+                             content_type: str = "application/zip") -> dict:
+        """Ask for a presigned PUT to upload a ZIP source bundle to object storage."""
+        return self.post(
+            f"/api/namespaces/{namespace}/applications/{name}"
+            f"/deployments/source-upload",
+            {"fileName": file_name, "fileSize": size, "contentType": content_type},
+        ).data
+
+    def put_bytes(self, url: str, payload: bytes, headers: dict) -> int:
+        """Upload straight to the presigned URL, bypassing the API entirely.
+
+        Every other party — the backend, the pipeline pods — lives in Docker and
+        resolves the signed hostname directly. The test process does not, so it
+        connects to the published port while keeping the Host header pointed at
+        the name the URL was signed for. SigV4 covers that header, not the
+        address the socket went to.
+        """
+        target = url
+        override = os.environ.get("OOPS_OBJECT_STORAGE_HOST_OVERRIDE")
+        extra = dict(headers)
+        if override:
+            parsed = urllib.parse.urlsplit(url)
+            if parsed.netloc != override:
+                extra.setdefault("Host", parsed.netloc)
+                target = urllib.parse.urlunsplit(parsed._replace(netloc=override))
+
+        response = requests.put(target, data=payload, headers=extra,
+                                timeout=self.timeout)
+        return response.status_code
+
+    def deploy(self, namespace: str, name: str, environment: str,
+               deploy_mode: str = "IMMEDIATE",
+               strategy: Optional[dict] = None) -> str:
+        """Trigger a deploy and return the pipeline id.
+
+        `strategy` is polymorphic on its `type` field: {"type": "GIT", "branch": …}
+        or {"type": "ZIP", "objectKey": …}.
+        """
+        return self.post(
+            f"/api/namespaces/{namespace}/applications/{name}/deployments",
+            {
+                "environment": environment,
+                "deployMode": deploy_mode,
+                "strategy": strategy or {"type": "GIT", "branch": ""},
+            },
+        ).data
+
+    def get_pipeline(self, namespace: str, name: str, pipeline_id: str) -> dict:
+        return self.get(
+            f"/api/namespaces/{namespace}/applications/{name}/pipelines/{pipeline_id}"
+        ).data
+
+    def list_environments(self) -> list:
+        return self.get("/api/environments").data
+
+    # -- websocket ----------------------------------------------------------
+
+    def websocket(self, path: str, timeout: int = 60) -> websocket.WebSocket:
+        """Open a socket. WebSocket auth travels as ?token= — headers are not
+        available to the browser client, so the server accepts the query form."""
+        record("WS", path)
+        scheme = "wss" if self.endpoint.startswith("https") else "ws"
+        base = self.endpoint.split("://", 1)[1]
+        separator = "&" if "?" in path else "?"
+        url = f"{scheme}://{base}{path}{separator}token={urllib.parse.quote(self.token or '')}"
+        connection = websocket.create_connection(url, timeout=timeout)
+        return connection
+
+
+def wait_until(predicate: Callable[[], Any], timeout: int = 300, interval: float = 3.0,
+               description: str = "condition") -> Any:
+    """Poll until the predicate returns something truthy, then return it.
+
+    Deploys run as Kubernetes Jobs behind 5s scan loops, so anything touching a
+    pipeline needs minutes of patience rather than seconds. That is long enough
+    to look like a hang, so the wait says what it is waiting for every so often;
+    with no renderer listening the report goes nowhere.
+    """
+    started = time.time()
+    deadline = started + timeout
+    announced = started
+    last = None
+    while time.time() < deadline:
+        last = predicate()
+        if last:
+            return last
+        if time.time() - announced >= HEARTBEAT_SECONDS:
+            announced = time.time()
+            runlog.note(f"waiting for {description} "
+                        f"({int(time.time() - started)}s of {timeout}s)")
+        time.sleep(interval)
+    raise AssertionError(
+        f"timed out after {timeout}s waiting for {description}; last value: {last!r}")
+
+
+def read_until_closed(connection: websocket.WebSocket,
+                      timeout: int = 60) -> Iterator[str]:
+    """Yield text frames until the peer closes or the timeout expires.
+
+    Log sockets answer a text "ping" with "pong"; terminal sockets must not be
+    pinged, because their stdin is live.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            frame = connection.recv()
+        except websocket.WebSocketTimeoutException:
+            return
+        except websocket.WebSocketConnectionClosedException:
+            return
+        if frame is None or frame == "":
+            return
+        if isinstance(frame, bytes):
+            frame = frame.decode("utf-8", errors="replace")
+        yield frame

--- a/tests/acceptance/pytest.ini
+++ b/tests/acceptance/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = .
+python_files = test_*.py
+addopts = -v --strict-markers --tb=short
+markers =
+    cluster: needs a reachable Kubernetes environment registered in OOPS

--- a/tests/acceptance/registries.yaml
+++ b/tests/acceptance/registries.yaml
@@ -1,0 +1,15 @@
+# Told to k3s so containerd will pull over plain HTTP from the two fixture
+# registries. Without this every image the pipeline pushes fails to pull back
+# with an x509 error, because the registries speak HTTP and containerd assumes
+# HTTPS.
+#
+# Only the transport is declared here. Credentials for the authenticated
+# registry reach the kubelet through the imagePullSecret OOPS copies into the
+# application namespace, which is precisely the path the suite is testing.
+mirrors:
+  "registry:5000":
+    endpoint:
+      - "http://registry:5000"
+  "registry-auth:5000":
+    endpoint:
+      - "http://registry-auth:5000"

--- a/tests/acceptance/requirements.txt
+++ b/tests/acceptance/requirements.txt
@@ -1,0 +1,5 @@
+pytest==8.3.4
+pytest-html==4.1.1
+pytest-metadata==3.1.1
+requests==2.32.3
+websocket-client==1.8.0

--- a/tests/acceptance/routes.json
+++ b/tests/acceptance/routes.json
@@ -1,0 +1,656 @@
+[
+  {
+    "method": "DELETE",
+    "path": "/api/assets",
+    "key": "DELETE /api/assets",
+    "controller": "StaticAssetController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/domains/{id}",
+    "key": "DELETE /api/domains/{}",
+    "controller": "DomainController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/environments/{id}",
+    "key": "DELETE /api/environments/{}",
+    "controller": "EnvironmentController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/namespaces/{namespace}/applications/{name}",
+    "key": "DELETE /api/namespaces/{}/applications/{}",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/namespaces/{namespace}/applications/{application}/ides/{name}",
+    "key": "DELETE /api/namespaces/{}/applications/{}/ides/{}",
+    "controller": "IdeController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files",
+    "key": "DELETE /api/namespaces/{}/applications/{}/pods/{}/files",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/sandbox/instances/{id}",
+    "key": "DELETE /api/sandbox/instances/{}",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/sandbox/instances/{id}/files",
+    "key": "DELETE /api/sandbox/instances/{}/files",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/users/{id}",
+    "key": "DELETE /api/users/{}",
+    "controller": "UserController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/assets",
+    "key": "GET /api/assets",
+    "controller": "StaticAssetController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/auth/external/providers",
+    "key": "GET /api/auth/external/providers",
+    "controller": "ExternalAccountController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/cron/next",
+    "key": "GET /api/cron/next",
+    "controller": "CronController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/domains",
+    "key": "GET /api/domains",
+    "controller": "DomainController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/domains/{id}",
+    "key": "GET /api/domains/{}",
+    "controller": "DomainController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/environments",
+    "key": "GET /api/environments",
+    "controller": "EnvironmentController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/environments/{id}",
+    "key": "GET /api/environments/{}",
+    "controller": "EnvironmentController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/features",
+    "key": "GET /api/features",
+    "controller": "FeaturesController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/health",
+    "key": "GET /api/health",
+    "controller": "HealthController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces",
+    "key": "GET /api/namespaces",
+    "controller": "NamespaceController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications",
+    "key": "GET /api/namespaces/{}/applications",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/active-deployments",
+    "key": "GET /api/namespaces/{}/applications/active-deployments",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}",
+    "key": "GET /api/namespaces/{}/applications/{}",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/branches",
+    "key": "GET /api/namespaces/{}/applications/{}/branches",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/build/config",
+    "key": "GET /api/namespaces/{}/applications/{}/build/config",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{applicationName}/configmaps",
+    "key": "GET /api/namespaces/{}/applications/{}/configmaps",
+    "controller": "ConfigMapController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/current-image",
+    "key": "GET /api/namespaces/{}/applications/{}/current-image",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/environments",
+    "key": "GET /api/namespaces/{}/applications/{}/environments",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/environments/build/configs",
+    "key": "GET /api/namespaces/{}/applications/{}/environments/build/configs",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/environments/runtime-specs",
+    "key": "GET /api/namespaces/{}/applications/{}/environments/runtime-specs",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/events",
+    "key": "GET /api/namespaces/{}/applications/{}/events",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/expert-config",
+    "key": "GET /api/namespaces/{}/applications/{}/expert-config",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{application}/ides",
+    "key": "GET /api/namespaces/{}/applications/{}/ides",
+    "controller": "IdeController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{application}/ides/config/default",
+    "key": "GET /api/namespaces/{}/applications/{}/ides/config/default",
+    "controller": "IdeController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/last-successful-pipeline",
+    "key": "GET /api/namespaces/{}/applications/{}/last-successful-pipeline",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/metrics",
+    "key": "GET /api/namespaces/{}/applications/{}/metrics",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/metrics/history",
+    "key": "GET /api/namespaces/{}/applications/{}/metrics/history",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pipelines",
+    "key": "GET /api/namespaces/{}/applications/{}/pipelines",
+    "controller": "PipelineController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pipelines/{id}",
+    "key": "GET /api/namespaces/{}/applications/{}/pipelines/{}",
+    "controller": "PipelineController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files",
+    "key": "GET /api/namespaces/{}/applications/{}/pods/{}/files",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files/content",
+    "key": "GET /api/namespaces/{}/applications/{}/pods/{}/files/content",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files/download",
+    "key": "GET /api/namespaces/{}/applications/{}/pods/{}/files/download",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/resources",
+    "key": "GET /api/namespaces/{}/applications/{}/resources",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/runtime-spec",
+    "key": "GET /api/namespaces/{}/applications/{}/runtime-spec",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/service",
+    "key": "GET /api/namespaces/{}/applications/{}/service",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/service/cluster-domain",
+    "key": "GET /api/namespaces/{}/applications/{}/service/cluster-domain",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/service/host-check",
+    "key": "GET /api/namespaces/{}/applications/{}/service/host-check",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/status",
+    "key": "GET /api/namespaces/{}/applications/{}/status",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/applications/{name}/status/watch",
+    "key": "GET /api/namespaces/{}/applications/{}/status/watch",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/namespaces/{namespace}/service-accounts",
+    "key": "GET /api/namespaces/{}/service-accounts",
+    "controller": "ServiceAccountController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/nodes",
+    "key": "GET /api/nodes",
+    "controller": "NodeController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/sandbox/images",
+    "key": "GET /api/sandbox/images",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/sandbox/instances",
+    "key": "GET /api/sandbox/instances",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/sandbox/instances/{id}",
+    "key": "GET /api/sandbox/instances/{}",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/sandbox/instances/{id}/files",
+    "key": "GET /api/sandbox/instances/{}/files",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/sandbox/instances/{id}/files/content",
+    "key": "GET /api/sandbox/instances/{}/files/content",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/sandbox/instances/{id}/files/download",
+    "key": "GET /api/sandbox/instances/{}/files/download",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/search/applications",
+    "key": "GET /api/search/applications",
+    "controller": "SearchController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/users",
+    "key": "GET /api/users",
+    "controller": "UserController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/users/me",
+    "key": "GET /api/users/me",
+    "controller": "UserController"
+  },
+  {
+    "method": "GET",
+    "path": "/api/users/page",
+    "key": "GET /api/users/page",
+    "controller": "UserController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/assets/upload-url",
+    "key": "POST /api/assets/upload-url",
+    "controller": "StaticAssetController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/auth/login",
+    "key": "POST /api/auth/login",
+    "controller": "AuthController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/domains",
+    "key": "POST /api/domains",
+    "controller": "DomainController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/environments",
+    "key": "POST /api/environments",
+    "controller": "EnvironmentController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/image-repositories/validations",
+    "key": "POST /api/image-repositories/validations",
+    "controller": "ImageRepositoryController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/index/applications",
+    "key": "POST /api/index/applications",
+    "controller": "IndexController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/index/pipelines",
+    "key": "POST /api/index/pipelines",
+    "controller": "IndexController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/kubernetes/namespaces",
+    "key": "POST /api/kubernetes/namespaces",
+    "controller": "KubernetesController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/kubernetes/validations",
+    "key": "POST /api/kubernetes/validations",
+    "controller": "KubernetesController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces",
+    "key": "POST /api/namespaces",
+    "controller": "NamespaceController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications",
+    "key": "POST /api/namespaces/{}/applications",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{name}/deployments",
+    "key": "POST /api/namespaces/{}/applications/{}/deployments",
+    "controller": "DeploymentController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{name}/deployments/source-upload",
+    "key": "POST /api/namespaces/{}/applications/{}/deployments/source-upload",
+    "controller": "DeploymentController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{application}/ides",
+    "key": "POST /api/namespaces/{}/applications/{}/ides",
+    "controller": "IdeController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{name}/namespace-migration",
+    "key": "POST /api/namespaces/{}/applications/{}/namespace-migration",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pipelines/{id}/rollback",
+    "key": "POST /api/namespaces/{}/applications/{}/pipelines/{}/rollback",
+    "controller": "PipelineController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files/directory",
+    "key": "POST /api/namespaces/{}/applications/{}/pods/{}/files/directory",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files/rename",
+    "key": "POST /api/namespaces/{}/applications/{}/pods/{}/files/rename",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files/upload",
+    "key": "POST /api/namespaces/{}/applications/{}/pods/{}/files/upload",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/nodes/{name}/schedulable",
+    "key": "POST /api/nodes/{}/schedulable",
+    "controller": "NodeController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/sandbox/executions",
+    "key": "POST /api/sandbox/executions",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/sandbox/instances",
+    "key": "POST /api/sandbox/instances",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/sandbox/instances/{id}/exec",
+    "key": "POST /api/sandbox/instances/{}/exec",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/sandbox/instances/{id}/files/directory",
+    "key": "POST /api/sandbox/instances/{}/files/directory",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/sandbox/instances/{id}/files/rename",
+    "key": "POST /api/sandbox/instances/{}/files/rename",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/sandbox/instances/{id}/files/upload",
+    "key": "POST /api/sandbox/instances/{}/files/upload",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/users",
+    "key": "POST /api/users",
+    "controller": "UserController"
+  },
+  {
+    "method": "POST",
+    "path": "/api/users/me/access-token/reset",
+    "key": "POST /api/users/me/access-token/reset",
+    "controller": "UserController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/domains/{id}",
+    "key": "PUT /api/domains/{}",
+    "controller": "DomainController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/environments/{id}/cluster",
+    "key": "PUT /api/environments/{}/cluster",
+    "controller": "EnvironmentController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/environments/{id}/credentials",
+    "key": "PUT /api/environments/{}/credentials",
+    "controller": "EnvironmentController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces",
+    "key": "PUT /api/namespaces",
+    "controller": "NamespaceController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}",
+    "key": "PUT /api/namespaces/{}/applications/{}",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/build/config",
+    "key": "PUT /api/namespaces/{}/applications/{}/build/config",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{applicationName}/configmaps",
+    "key": "PUT /api/namespaces/{}/applications/{}/configmaps",
+    "controller": "ConfigMapController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/environments",
+    "key": "PUT /api/namespaces/{}/applications/{}/environments",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/environments/build/configs",
+    "key": "PUT /api/namespaces/{}/applications/{}/environments/build/configs",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/environments/runtime-specs",
+    "key": "PUT /api/namespaces/{}/applications/{}/environments/runtime-specs",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/expert-config",
+    "key": "PUT /api/namespaces/{}/applications/{}/expert-config",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pipelines/{id}/deploy",
+    "key": "PUT /api/namespaces/{}/applications/{}/pipelines/{}/deploy",
+    "controller": "PipelineController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pipelines/{id}/stop",
+    "key": "PUT /api/namespaces/{}/applications/{}/pipelines/{}/stop",
+    "controller": "PipelineController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/files/content",
+    "key": "PUT /api/namespaces/{}/applications/{}/pods/{}/files/content",
+    "controller": "PodFileSystemController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/pods/{pod}/restart",
+    "key": "PUT /api/namespaces/{}/applications/{}/pods/{}/restart",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/runtime-spec",
+    "key": "PUT /api/namespaces/{}/applications/{}/runtime-spec",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/namespaces/{namespace}/applications/{name}/service",
+    "key": "PUT /api/namespaces/{}/applications/{}/service",
+    "controller": "ApplicationController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/sandbox/instances/{id}/files/content",
+    "key": "PUT /api/sandbox/instances/{}/files/content",
+    "controller": "SandboxController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/users/me",
+    "key": "PUT /api/users/me",
+    "controller": "UserController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/users/me/password",
+    "key": "PUT /api/users/me/password",
+    "controller": "UserController"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/users/{id}",
+    "key": "PUT /api/users/{}",
+    "controller": "UserController"
+  }
+]

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# The only command you need to run the acceptance suite.
+#
+# Brings up MySQL, RustFS, Gitea and two registries, builds and starts the
+# backend, starts a k3s cluster, registers it as an environment, runs the
+# scenarios, writes a report, and tears all of it down again — including when
+# you interrupt it. Nothing is installed on the host, and no existing
+# kubeconfig, database or registry is touched.
+#
+# The run prints as numbered steps, like `docker build --progress=plain`: each
+# step says what it is doing while it does it, then how long it took.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="${HERE}/scripts"
+REPO="$(cd "${HERE}/../.." && pwd)"
+REPORTS="${HERE}/reports"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+# Beside the report rather than in a temp directory, and never deleted: the
+# backend log is the first thing you want after a failure, and often after a
+# pass too.
+LOGS="${REPORTS}/${STAMP}"
+
+BOLD=$'\033[1m'; DIM=$'\033[2m'; GREEN=$'\033[32m'; RED=$'\033[31m'
+YELLOW=$'\033[33m'; RESET=$'\033[0m'
+
+# -- modules ------------------------------------------------------------------
+#
+# A module is one test file, named after what it covers. Nothing declares the
+# list: `test_deploy.py` *is* the `deploy` module, and its first docstring line
+# is its description, so adding a file adds a module with no registry to keep in
+# step. The `zz_` on the coverage file only exists to sort it last.
+
+module_names() {
+  local file name
+  for file in "${HERE}"/test_*.py; do
+    name="$(basename "$file" .py)"; name="${name#test_}"
+    printf '%s\n' "${name#zz_}"
+  done
+}
+
+module_file() {
+  local candidate
+  for candidate in "${HERE}/test_${1}.py" "${HERE}/test_zz_${1}.py"; do
+    if [ -f "$candidate" ]; then printf '%s' "$candidate"; return 0; fi
+  done
+  return 1
+}
+
+list_modules() {
+  printf "%smodules%s — all of them run unless you name some with --module\n\n" \
+    "$BOLD" "$RESET"
+  local file name summary
+  for file in "${HERE}"/test_*.py; do
+    name="$(basename "$file" .py)"; name="${name#test_}"; name="${name#zz_}"
+    summary="$(sed -n '1s/^"""//p' "$file")"
+    printf "  %-20s %s%s%s\n" "$name" "$DIM" "$summary" "$RESET"
+  done
+}
+
+usage() {
+  cat <<'TEXT'
+usage: ./run.sh [options] [-- pytest arguments]
+
+  --module NAME[,NAME]   run only these modules (repeatable); default is all.
+                         Naming only modules that need no cluster skips
+                         starting one, which saves a couple of minutes.
+  --list                 list the modules and what each covers
+  --contract             every module, but only the tests that need no cluster
+  --keep                 leave the stack running afterwards
+  --                     everything after this goes straight to pytest
+                         (e.g. -- -k basic_auth -x)
+
+  ./run.sh                          the whole suite
+  ./run.sh --module ingress         iterate on one module
+  ./run.sh --module deploy,ingress  a couple of related ones
+  ./run.sh --list                   what is there to run
+TEXT
+}
+
+CONTRACT_ONLY=0
+KEEP=0
+MODULES=()
+PYTEST_EXTRA=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --module)
+      [ $# -ge 2 ] || { printf "%s needs a module name\n" "$1" >&2; exit 2; }
+      IFS=, read -r -a chunk <<<"$2"
+      MODULES+=("${chunk[@]}")
+      shift ;;
+    --module=*) IFS=, read -r -a chunk <<<"${1#--module=}"; MODULES+=("${chunk[@]}") ;;
+    --list) list_modules; exit 0 ;;
+    --contract) CONTRACT_ONLY=1 ;;
+    --keep) KEEP=1 ;;
+    --) shift; PYTEST_EXTRA=("$@"); break ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf "unknown option: %s\n\n" "$1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# Resolve the names now, so a typo costs a second rather than the five minutes
+# it takes to stand the stack up.
+SELECTED=()
+for name in ${MODULES[@]+"${MODULES[@]}"}; do
+  if file="$(module_file "$name")"; then
+    SELECTED+=("$file")
+  else
+    printf "%sno module named %s%s\n\n" "$RED" "$name" "$RESET" >&2
+    list_modules >&2
+    exit 2
+  fi
+done
+# The coverage module judges what the rest of the run reached, so it goes last
+# whenever it was asked for alongside others.
+if [ ${#SELECTED[@]} -gt 1 ]; then
+  ORDERED=(); COVERAGE=()
+  for file in "${SELECTED[@]}"; do
+    case "$file" in *test_zz_*) COVERAGE+=("$file") ;; *) ORDERED+=("$file") ;; esac
+  done
+  SELECTED=("${ORDERED[@]+"${ORDERED[@]}"}" "${COVERAGE[@]+"${COVERAGE[@]}"}")
+fi
+
+# Starting k3s and provisioning it costs a couple of minutes, so skip it when
+# nothing selected has a cluster test in it. Anything passed straight to pytest
+# is opaque here, so that case keeps the cluster.
+needs_cluster() {
+  [ "$CONTRACT_ONLY" -eq 1 ] && return 1
+  [ ${#SELECTED[@]} -eq 0 ] && return 0
+  [ ${#PYTEST_EXTRA[@]} -gt 0 ] && return 0
+  grep -l 'mark\.cluster' "${SELECTED[@]}" >/dev/null 2>&1
+}
+
+mkdir -p "$REPORTS" "$LOGS"
+
+# -- steps --------------------------------------------------------------------
+
+STEP=0
+STEP_STARTED=0
+
+step_begin() {
+  STEP=$((STEP + 1)); STEP_STARTED=$SECONDS
+  printf "%s#%d%s %s%s%s\n" "$DIM" "$STEP" "$RESET" "$BOLD" "$1" "$RESET"
+}
+step_done() {
+  printf "%s#%d%s %sDONE %ss%s\n" \
+    "$DIM" "$STEP" "$RESET" "$GREEN" "$((SECONDS - STEP_STARTED))" "$RESET"
+}
+step_skipped() {
+  printf "%s#%d%s %sSKIPPED%s %s%s%s\n" \
+    "$DIM" "$STEP" "$RESET" "$YELLOW" "$RESET" "$DIM" "$1" "$RESET"
+}
+step_cached() { printf "%s#%d%s %sCACHED%s\n" "$DIM" "$STEP" "$RESET" "$DIM" "$RESET"; }
+step_failed() {
+  printf "%s#%d ERROR %ss — %s%s\n" \
+    "$RED" "$STEP" "$((SECONDS - STEP_STARTED))" "$1" "$RESET" >&2
+}
+
+# Runs a command as the current step. Its output goes to the step's log in full
+# and onto the screen as a few scrolling lines that erase themselves when the
+# step ends — a docker build's RUN, where the heading and the DONE stay and the
+# output does not. The status travels as a sentinel line because a pipe does not
+# carry one; the renderer exits with it, so this returns what the command
+# returned rather than what the pipe did.
+step_run() {
+  local logfile="$1"; shift
+  { "$@" 2>&1; echo "__step_status__ $?"; } \
+    | python3 "${SCRIPTS}/render_step.py" --prefix "#${STEP}" --log "$logfile"
+}
+
+BACKEND_CONTAINER=oops-acceptance-backend
+BACKEND_LOG_PID=""
+CLEANED=0
+
+cleanup() {
+  # Runs on success, on failure and on Ctrl-C, so a run never leaves a cluster,
+  # a database or a stray JVM behind unless --keep was asked for.
+  local status=$?
+  [ "$CLEANED" -eq 1 ] && return $status
+  CLEANED=1
+  [ -n "$BACKEND_LOG_PID" ] && kill "$BACKEND_LOG_PID" 2>/dev/null
+
+  if [ "$KEEP" -eq 1 ]; then
+    printf "\n%s--keep: the stack is still up.%s\n" "$DIM" "$RESET"
+    printf "%s  backend: docker logs %s · logs in %s%s\n" \
+      "$DIM" "$BACKEND_CONTAINER" "$LOGS" "$RESET"
+    printf "%s  tear down with: docker compose -f %s/docker-compose.yml --profile cluster --profile backend down -v%s\n" \
+      "$DIM" "$HERE" "$RESET"
+    return $status
+  fi
+
+  printf "\n%scleaning up · logs in %s%s\n" "$DIM" "$LOGS" "$RESET"
+  docker rm -f "$BACKEND_CONTAINER" >/dev/null 2>&1
+  # Every profile, or the cluster and the backend outlive a teardown that looks
+  # like it removed everything.
+  docker compose -f "${HERE}/docker-compose.yml" \
+    --profile cluster --profile backend down -v --remove-orphans \
+    >>"${LOGS}/teardown.log" 2>&1
+  rm -rf "${HERE}/scripts/.registry-auth" "${HERE}/scripts/.k3s"
+  return $status
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+# Announced up front, not just at the end, so a second terminal can follow along
+# while a long run is still going.
+printf "%slogs: %s%s\n" "$DIM" "$LOGS" "$RESET"
+if [ ${#SELECTED[@]} -gt 0 ]; then
+  printf "%smodules: %s%s\n" "$DIM" "${MODULES[*]}" "$RESET"
+fi
+echo
+
+# -- python -------------------------------------------------------------------
+
+step_begin "python environment"
+if [ -d "${HERE}/.venv" ]; then
+  step_cached
+else
+  step_run "${LOGS}/setup.log" python3 -m venv "${HERE}/.venv" || {
+    step_failed "could not create the virtualenv"; exit 1; }
+  step_run "${LOGS}/setup.log" \
+    "${HERE}/.venv/bin/pip" install -r "${HERE}/requirements.txt" || {
+      step_failed "could not install requirements"; exit 1; }
+  step_done
+fi
+# shellcheck disable=SC1091
+. "${HERE}/.venv/bin/activate"
+
+# -- middleware ---------------------------------------------------------------
+
+# Presigned URLs are signed for a container name that every server-side party
+# resolves. Only the test process is outside Docker, so it rewrites the address
+# and keeps the Host header.
+export OOPS_OBJECT_STORAGE_HOST_OVERRIDE="127.0.0.1:19000"
+
+COMPOSE=(docker compose -f "${HERE}/docker-compose.yml")
+
+step_begin "middleware — mysql, rustfs, gitea, two registries"
+mkdir -p "${HERE}/scripts/.registry-auth"
+step_run "${LOGS}/middleware.log" \
+  "${COMPOSE[@]}" up -d --wait mysql rustfs gitea registry registry-auth || {
+    step_failed "middleware failed to start; see ${LOGS}/middleware.log"; exit 1; }
+step_run "${LOGS}/middleware.log" "${COMPOSE[@]}" up rustfs-init
+step_done
+
+step_begin "git fixtures"
+# Seeding needs `docker exec`, because Gitea has no API for creating its first
+# admin — the one part of the stack that cannot be a compose service.
+export OOPS_GITEA_USER="${OOPS_GITEA_USER:-oops}"
+export OOPS_GITEA_PASSWORD="${OOPS_GITEA_PASSWORD:-oops-git-secret}"
+export OOPS_GITEA_URL="http://gitea:3000"
+export OOPS_GITEA_PROBE_URL="http://127.0.0.1:13000"
+step_run "${LOGS}/middleware.log" \
+  python "${SCRIPTS}/seed_gitea.py" --base "$OOPS_GITEA_PROBE_URL" || {
+    step_failed "could not seed the git fixtures; see ${LOGS}/middleware.log"
+    exit 1; }
+step_done
+
+# -- backend ------------------------------------------------------------------
+
+JAR="${REPO}/target/oops-0.0.1-SNAPSHOT.jar"
+build_jar() { cd "$REPO" && ./mvnw -DskipTests -Dpmd.skip=true package; }
+
+step_begin "backend jar"
+if [ -f "$JAR" ]; then
+  step_cached
+else
+  step_run "${LOGS}/build.log" build_jar || {
+    step_failed "the backend did not build; see ${LOGS}/build.log"; exit 1; }
+  step_done
+fi
+
+# An IANA name, not the %Z abbreviation: "CST" is ambiguous and the JVM ignores
+# it, leaving the container on UTC. Timestamps are a naive local wall clock in
+# this product, so a container in the wrong zone shifts every stored value.
+HOST_TIMEZONE="$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')"
+HOST_TIMEZONE="${HOST_TIMEZONE:-${TZ:-UTC}}"
+
+await_backend() {
+  # Polled from here rather than by a container healthcheck: the temurin image
+  # has no curl, wget or jshell, so nothing inside it can make the request.
+  local attempt
+  for attempt in $(seq 1 90); do
+    if [ "$(curl -s -o /dev/null -w '%{http_code}' \
+          -X POST http://localhost:8080/api/auth/login \
+          -H 'Content-Type: application/json' \
+          -d '{"username":"admin","password":"admin123"}' 2>/dev/null)" = "200" ]; then
+      echo "answering on :8080, and the default admin can log in"
+      return 0
+    fi
+    docker ps -q -f "name=^${BACKEND_CONTAINER}$" | grep -q . || {
+      echo "the container is gone — see the log below"; return 1; }
+    # Spring takes a while, and migrations take longer on a fresh database.
+    # Saying so beats two silent minutes.
+    [ $((attempt % 10)) -eq 0 ] && echo "still starting ($((attempt * 2))s)"
+    sleep 2
+  done
+  echo "no answer on :8080 after 180s"
+  return 1
+}
+
+step_begin "backend"
+# Defined in docker-compose.yml behind a profile, so the image, mounts and
+# dependency on a healthy MySQL all live in one declarative place.
+step_run "${LOGS}/backend-start.log" \
+  env OOPS_JAR="$JAR" OOPS_TZ="$HOST_TIMEZONE" \
+  "${COMPOSE[@]}" --profile backend up -d backend || {
+    step_failed "the backend container did not start"; exit 1; }
+step_run "${LOGS}/backend-start.log" await_backend || {
+  step_failed "the backend never became ready"
+  docker logs "$BACKEND_CONTAINER" >"${LOGS}/backend.log" 2>&1 || true
+  tail -30 "${LOGS}/backend.log" >&2
+  exit 1; }
+
+# Follow the log from here rather than collecting it at teardown. A container
+# that dies mid-run takes its logs with it, and that is exactly the run whose
+# logs you need — one full run ended with every test failing on a refused
+# connection and nothing left to say why.
+docker logs -f "$BACKEND_CONTAINER" >"${LOGS}/backend.log" 2>&1 &
+BACKEND_LOG_PID=$!
+step_done
+
+# -- cluster ------------------------------------------------------------------
+
+PYTEST_ARGS=(-p no:cacheprovider -p "no:randomly"
+             -p "pytest_steps"
+             --tb=short
+             --html="${REPORTS}/report-${STAMP}.html" --self-contained-html
+             --junitxml="${REPORTS}/junit-${STAMP}.xml")
+export PYTHONPATH="${SCRIPTS}${PYTHONPATH:+:${PYTHONPATH}}"
+
+step_begin "cluster"
+if needs_cluster; then
+  step_run "${LOGS}/cluster.log" "${COMPOSE[@]}" --profile cluster up -d --wait k3s || {
+    step_failed "the cluster did not come up; see ${LOGS}/cluster.log"; exit 1; }
+  step_done
+
+  step_begin "cluster provisioning"
+  provisioned="${LOGS}/provision.log"
+  step_run "$provisioned" bash "${SCRIPTS}/cluster-provision.sh" || {
+    step_failed "could not provision the cluster; see $provisioned"; exit 1; }
+  # The script reports what it made as shell exports; adopt them.
+  while IFS= read -r line; do
+    eval "${line#  }"
+  done < <(grep '^  export ' "$provisioned")
+  step_done
+
+  step_begin "environment registration"
+  step_run "${LOGS}/register.log" \
+    python "${SCRIPTS}/register_environment.py" --name acceptance || {
+      step_failed "could not register the environment; see ${LOGS}/register.log"
+      exit 1; }
+  step_done
+
+  PYTEST_ARGS+=(--environment acceptance)
+else
+  if [ "$CONTRACT_ONLY" -eq 1 ]; then
+    step_skipped "--contract: only the tests that need no cluster"
+    PYTEST_ARGS+=(-m "not cluster")
+  else
+    step_skipped "nothing selected needs one"
+  fi
+fi
+
+# -- run ----------------------------------------------------------------------
+
+# The modules number themselves on from here, so they read as steps of the same
+# run rather than as a separate thing that happened afterwards.
+export OOPS_STEP_OFFSET="$STEP"
+# pytest's own stdout and stderr belong in the log, where -v gives one line per
+# test and the FAILURES section survives intact. The live view needs a channel
+# that was not redirected with them, so hand it this one.
+exec 3>&1
+export OOPS_LIVE_FD=3
+
+echo
+(cd "$HERE" && python -m pytest "${PYTEST_ARGS[@]}" \
+   ${SELECTED[@]+"${SELECTED[@]}"} ${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"}) \
+  >"${LOGS}/pytest.log" 2>&1
+STATUS=$?
+exec 3>&-
+
+ln -sf "report-${STAMP}.html" "${REPORTS}/latest.html"
+ln -sf "junit-${STAMP}.xml" "${REPORTS}/latest.xml"
+
+echo
+python "${SCRIPTS}/summarise.py" "${REPORTS}/junit-${STAMP}.xml"
+SUMMARY=$?
+
+if [ "$SUMMARY" -ne 0 ] || [ "$STATUS" -ne 0 ]; then
+  echo
+  # Only the failures, not the whole log.
+  sed -n '/=\{5,\} FAILURES/,/=\{5,\} \(warnings\|short test summary\)/p' \
+    "${LOGS}/pytest.log" | head -60
+  printf "%sfull output: %s%s\n" "$DIM" "${REPORTS}/report-${STAMP}.html" "$RESET"
+  printf "%slogs:        %s%s\n" "$DIM" "$LOGS" "$RESET"
+  exit 1
+fi
+
+printf "%sreport: %s%s\n" "$DIM" "${REPORTS}/report-${STAMP}.html" "$RESET"
+printf "%slogs:   %s%s\n" "$DIM" "$LOGS" "$RESET"
+exit 0

--- a/tests/acceptance/runlog.py
+++ b/tests/acceptance/runlog.py
@@ -1,0 +1,34 @@
+"""A one-line channel from a test to whatever is rendering the run.
+
+A deploy test spends minutes inside a single `wait_until`, and from the outside
+that is indistinguishable from a hang. Anything that waits says what it is
+waiting for through here, and the step renderer prints it under the module
+currently running.
+
+Nothing has to be listening. With no sink installed a call costs one comparison,
+so the tests can speak up unconditionally and still run unchanged under a bare
+`pytest`.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+_sink: Optional[Callable[[str], None]] = None
+
+
+def set_sink(sink: Optional[Callable[[str], None]]) -> None:
+    """Install the renderer's line handler, or None to go quiet again."""
+    global _sink
+    _sink = sink
+
+
+def note(message: str) -> None:
+    """Report what is happening right now. Never raises — a broken renderer must
+    not fail the test it is describing."""
+    if _sink is None:
+        return
+    try:
+        _sink(message)
+    except Exception:
+        pass

--- a/tests/acceptance/scripts/cluster-provision.sh
+++ b/tests/acceptance/scripts/cluster-provision.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Give the cluster what OOPS needs to be pointed at it: a work namespace, a
+# service account with a long-lived token, and the two addresses of the API
+# server.
+#
+# The cluster itself is a compose service, so nothing here creates or destroys
+# it. This only fills in the parts an environment registration needs.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_NAMESPACE="${OOPS_WORK_NAMESPACE:-oops-work}"
+SERVICE_ACCOUNT="oops"
+KUBECONFIG_PATH="${HERE}/.k3s/kubeconfig.yaml"
+API_PORT="${OOPS_K3S_PORT:-16443}"
+
+if [ ! -f "$KUBECONFIG_PATH" ]; then
+  echo "no kubeconfig at ${KUBECONFIG_PATH}; is the k3s service up?" >&2
+  exit 1
+fi
+
+# k3s writes the kubeconfig for its own loopback. The suite reaches the API on
+# the published port instead, so point the copy it uses at that.
+export KUBECONFIG="$KUBECONFIG_PATH"
+if grep -q "127.0.0.1:6443" "$KUBECONFIG_PATH"; then
+  sed -i.bak "s|127.0.0.1:6443|127.0.0.1:${API_PORT}|" "$KUBECONFIG_PATH"
+  rm -f "${KUBECONFIG_PATH}.bak"
+fi
+
+# k3s brings its pieces up in stages — the API server first, then CoreDNS and
+# Traefik through bundled manifests — so each thing this script needs has to be
+# waited for rather than assumed.
+wait_for() {
+  local description="$1" attempts="$2"; shift 2
+  printf '%s' "waiting for ${description}"
+  for _ in $(seq 1 "$attempts"); do
+    if "$@" >/dev/null 2>&1; then echo " ok"; return 0; fi
+    printf '.'
+    sleep 2
+  done
+  echo " timed out"
+  return 1
+}
+
+wait_for "the API server" 60 kubectl get --raw /readyz || {
+  echo "the API server never became ready" >&2; exit 1; }
+
+# Installed by a bundled manifest a moment after the API server answers, so it
+# is absent if you look too early.
+wait_for "CoreDNS" 60 kubectl get configmap coredns -n kube-system || {
+  echo "CoreDNS never appeared" >&2; exit 1; }
+
+# Teach the cluster's DNS how to find the middleware, by IPv4 address.
+#
+# Without this, a pod resolving `registry` goes CoreDNS -> the k3s container's
+# resolver -> Docker Desktop's DNS, which answers with a synthesised IPv6
+# address (fdfe:dcba:9876::/64). The compose network is IPv4-only and so is the
+# pod network, so the push then dies as `pinging container registry: EOF` with
+# nothing to suggest the address family is the problem.
+#
+# Addresses are read live rather than pinned, so the compose network can hand
+# out whatever it likes.
+NODE_HOSTS="$(kubectl get configmap coredns -n kube-system \
+  -o jsonpath='{.data.NodeHosts}' 2>/dev/null || true)"
+for service in registry registry-auth gitea rustfs; do
+  address="$(docker inspect "oops-acceptance-${service}" \
+    --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null || true)"
+  [ -z "$address" ] && continue
+  NODE_HOSTS="$(printf '%s\n' "$NODE_HOSTS" | grep -v " ${service}\$" || true)"
+  NODE_HOSTS="$(printf '%s\n%s %s' "$NODE_HOSTS" "$address" "$service")"
+done
+kubectl patch configmap coredns -n kube-system --type merge \
+  -p "$(python3 -c 'import json,sys; print(json.dumps({"data": {"NodeHosts": sys.stdin.read()}}))' <<<"$NODE_HOSTS")" \
+  >/dev/null
+# The hosts plugin reloads every 15s, so give it a moment before anything
+# depends on the new names.
+sleep 16
+
+kubectl create namespace "$WORK_NAMESPACE" --dry-run=client -o yaml \
+  | kubectl apply -f - >/dev/null
+
+# cluster-admin, because acceptance runs create namespaces, exec into pods and
+# reach Prometheus through the API server proxy. A narrower role here just turns
+# into confusing 403s halfway through a suite.
+kubectl create serviceaccount "$SERVICE_ACCOUNT" -n "$WORK_NAMESPACE" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+kubectl create clusterrolebinding "${SERVICE_ACCOUNT}-admin" \
+  --clusterrole=cluster-admin \
+  --serviceaccount="${WORK_NAMESPACE}:${SERVICE_ACCOUNT}" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+# Since 1.24 a service account gets no token secret of its own, and
+# `kubectl create token` mints a short-lived one. Ask for a bound secret so the
+# token outlives a long run.
+kubectl apply -f - >/dev/null <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${SERVICE_ACCOUNT}-token
+  namespace: ${WORK_NAMESPACE}
+  annotations:
+    kubernetes.io/service-account.name: ${SERVICE_ACCOUNT}
+type: kubernetes.io/service-account-token
+EOF
+
+token_populated() {
+  [ -n "$(kubectl get secret "${SERVICE_ACCOUNT}-token" -n "$WORK_NAMESPACE" \
+    -o jsonpath='{.data.token}' 2>/dev/null)" ]
+}
+wait_for "the service account token" 30 token_populated || {
+  echo "the service account token was never populated" >&2; exit 1; }
+TOKEN="$(kubectl get secret "${SERVICE_ACCOUNT}-token" -n "$WORK_NAMESPACE" \
+  -o jsonpath='{.data.token}')"
+TOKEN="$(printf '%s' "$TOKEN" | base64 --decode)"
+
+# Traefik arrives via a helm job, later still. The ingress scenarios need its
+# CRDs; everything else can proceed without them.
+if wait_for "the Traefik CRDs" 90 kubectl get crd ingressroutes.traefik.io; then
+  TRAEFIK=yes
+else
+  TRAEFIK=no
+fi
+
+cat <<EOF
+
+cluster ready (traefik CRDs: ${TRAEFIK}).
+
+  export OOPS_CLUSTER_API_SERVER="https://k3s:6443"
+  export OOPS_CLUSTER_TOKEN="${TOKEN}"
+  export OOPS_WORK_NAMESPACE="${WORK_NAMESPACE}"
+  export OOPS_REGISTRY="registry:5000"
+  export OOPS_AUTH_REGISTRY="registry-auth:5000"
+  export OOPS_AUTH_REGISTRY_USER="${OOPS_AUTH_REGISTRY_USER:-oops}"
+  export OOPS_AUTH_REGISTRY_PASSWORD="${OOPS_AUTH_REGISTRY_PASSWORD:-oops-secret}"
+  export OOPS_TRAEFIK_AVAILABLE="${TRAEFIK}"
+  export KUBECONFIG="${KUBECONFIG_PATH}"
+EOF

--- a/tests/acceptance/scripts/extract_routes.py
+++ b/tests/acceptance/scripts/extract_routes.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Extract the API route table from the Spring controllers.
+
+The suite's coverage check needs to know what the full surface *is*, and the
+only authority on that is the source. Parsing the annotations keeps the
+inventory honest: add a controller and the coverage test starts failing until a
+scenario exercises it.
+
+    python scripts/extract_routes.py > routes.json
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+CONTROLLERS = Path("src/main/java/com/github/wellch4n/oops/interfaces/rest")
+
+# Match up to the closing paren rather than the first brace: a path variable
+# spelled {namespace} would otherwise terminate an array-form mapping early, and
+# the controller would silently drop out of the inventory.
+CLASS_MAPPING = re.compile(r"@RequestMapping\s*\(([^)]*)\)", re.S)
+METHOD_MAPPING = re.compile(
+    r"@(Get|Post|Put|Delete|Patch)Mapping\s*(?:\(([^)]*)\))?", re.S)
+STRING = re.compile(r'"([^"]*)"')
+# Endpoints the UI never calls over plain HTTP, or that cannot be driven from a
+# test without a browser redirect or a live upgrade handshake.
+EXCLUDED = {
+    "/api/auth/external/{provider}/redirect",  # 302 into a third-party login
+    "/api/auth/external/{provider}/callback",  # requires a provider round trip
+}
+
+
+def class_prefixes(source: str) -> list[str]:
+    match = CLASS_MAPPING.search(source)
+    if not match:
+        return [""]
+    return STRING.findall(match.group(1)) or [""]
+
+
+def join(prefix: str, suffix: str) -> str:
+    if not suffix:
+        return prefix
+    if not prefix:
+        return suffix
+    return f"{prefix.rstrip('/')}/{suffix.lstrip('/')}"
+
+
+def normalise(path: str) -> str:
+    """Collapse every path variable to a single spelling.
+
+    Controllers disagree — `{name}` here, `{applicationName}` there, for the same
+    segment — and a coverage report keyed on the spelling would double-count.
+    """
+    return re.sub(r"\{[^}]+\}", "{}", path)
+
+
+def extract(root: Path) -> list[dict]:
+    routes: list[dict] = []
+    for file in sorted(root.glob("*Controller.java")):
+        source = file.read_text()
+        prefixes = class_prefixes(source)
+        for match in METHOD_MAPPING.finditer(source):
+            verb = match.group(1).upper()
+            suffixes = STRING.findall(match.group(2) or '""') or [""]
+            for prefix in prefixes:
+                if not prefix.startswith("/api"):
+                    # The suite drives the UI surface; /openapi mirrors it.
+                    continue
+                for suffix in suffixes:
+                    path = join(prefix, suffix)
+                    if path in EXCLUDED:
+                        continue
+                    routes.append({
+                        "method": verb,
+                        "path": path,
+                        "key": f"{verb} {normalise(path)}",
+                        "controller": file.stem,
+                    })
+    unique: dict[str, dict] = {}
+    for route in routes:
+        unique.setdefault(route["key"], route)
+    return sorted(unique.values(), key=lambda item: item["key"])
+
+
+def main() -> int:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else CONTROLLERS
+    if not root.exists():
+        print(f"no controllers at {root}; run from the repository root",
+              file=sys.stderr)
+        return 1
+    routes = extract(root)
+    json.dump(routes, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    print(f"{len(routes)} routes", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/acceptance/scripts/liveview.py
+++ b/tests/acceptance/scripts/liveview.py
@@ -1,0 +1,95 @@
+"""A bounded, self-erasing tail on the terminal, the way `docker build` draws one.
+
+Two kinds of line. What a run is worth reading afterwards — step headings, test
+results, failures, how long each took — is committed, and stays. Log output is
+pushed, and only the last few lines of it are on screen at any moment; when the
+step ends the whole region is erased, leaving the committed lines behind. So the
+terminal ends up holding the shape of the run rather than forty minutes of
+container plumbing, while you can still watch that plumbing as it happens.
+
+With nothing to redraw — a pipe, a CI log, TERM=dumb — everything is written
+straight out and nothing is erased, which is the same fallback docker makes and
+is what keeps `./run.sh > run.log` worth reading.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections import deque
+
+CURSOR_UP = "\033[{n}A"
+ERASE_BELOW = "\033[J"
+
+BOLD, DIM, GREEN, RED, YELLOW, RESET = (
+    "\033[1m", "\033[2m", "\033[32m", "\033[31m", "\033[33m", "\033[0m")
+
+DEFAULT_TAIL = 6
+
+
+class View:
+    def __init__(self, stream, tail: int = 0):
+        self.stream = stream
+        # A dumb terminal has no cursor movement, and a pipe has no cursor at
+        # all; both get the plain transcript instead.
+        self.live = (stream.isatty()
+                     and os.environ.get("TERM", "") not in ("", "dumb"))
+        self.colour = self.live and not os.environ.get("NO_COLOR")
+        self.recent: deque = deque(
+            maxlen=tail or int(os.environ.get("OOPS_LIVE_TAIL", DEFAULT_TAIL)))
+        self.drawn = 0
+
+    # -- the two kinds of line ----------------------------------------------
+
+    def commit(self, text: str, colour: str = "") -> None:
+        """A line that stays: a heading, a result, a failure."""
+        self._erase()
+        self._write(text, colour)
+        self._draw()
+
+    def push(self, text: str, colour: str = DIM) -> None:
+        """A line of log: on screen for now, gone when the step ends."""
+        if not self.live:
+            self._write(text, colour)
+            return
+        self._erase()
+        self.recent.append((text, colour))
+        self._draw()
+
+    def clear(self) -> None:
+        """End the step: the log region goes, the committed lines stay."""
+        self._erase()
+        self.recent.clear()
+
+    close = clear
+
+    # -- drawing ------------------------------------------------------------
+
+    def _write(self, text: str, colour: str) -> None:
+        body = self._fit(text)
+        if self.colour and colour:
+            body = f"{colour}{body}{RESET}"
+        self.stream.write(body + "\n")
+        self.stream.flush()
+
+    def _fit(self, text: str) -> str:
+        """Truncate to the terminal width.
+
+        A line that wraps takes two rows, and the cursor arithmetic below counts
+        lines rather than rows, so a single wrapped line would leave the region
+        misaligned and start eating the transcript above it.
+        """
+        room = max(20, shutil.get_terminal_size((100, 24)).columns - 1)
+        return text if len(text) <= room else text[:room - 1] + "…"
+
+    def _erase(self) -> None:
+        if self.drawn:
+            self.stream.write(CURSOR_UP.format(n=self.drawn) + ERASE_BELOW)
+            self.drawn = 0
+
+    def _draw(self) -> None:
+        if not self.live:
+            return
+        for text, colour in self.recent:
+            self._write(text, colour)
+        self.drawn = len(self.recent)

--- a/tests/acceptance/scripts/pytest_steps.py
+++ b/tests/acceptance/scripts/pytest_steps.py
@@ -1,0 +1,229 @@
+"""Renders the test run as numbered steps, the way `docker build` does.
+
+The suite is twenty modules and the better part of an hour, and a single test
+can spend two minutes building a container image. Dots tell you nothing about
+that: you cannot tell a slow test from a hung one, or say which part of the
+product is currently under test.
+
+So each module is announced as a step and every test leaves one line behind
+saying what it did. What a test is *doing* while it does it — the name it is
+running under, the deploy it is waiting on — scrolls in a small region that
+erases itself the moment the test settles, so an hour of waiting does not end up
+as an hour of transcript.
+
+    #8 [4/20] deploy — the build-and-deploy pipeline against a real cluster
+    #8 6 tests
+    #8   OK   12.4s  a build config survives a round trip
+    #8 > a git repository builds and deploys              <- these two lines are
+    #8   . waiting for the deploy to finish (45s of 900s)    on screen for now
+    ...
+    #8 DONE 380.4s  6 passed
+
+pytest's own output is not touched: `pytest.log` keeps the -v line per test and
+the whole FAILURES section, which is what you read after a failure. This writes
+the live view to the descriptor `run.sh` leaves pointing at the terminal, since
+pytest captures the other two.
+
+Loaded with `-p` rather than from conftest.py, so it stays out of the way of the
+suite itself.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import runlog
+from liveview import BOLD, DIM, GREEN, RED, RESET, YELLOW, View
+
+
+def _duration(seconds: float) -> str:
+    minutes, second = divmod(int(seconds), 60)
+    if minutes >= 60:
+        hour, minute = divmod(minutes, 60)
+        return f"{hour}h{minute:02d}m"
+    return f"{minutes}m{second:02d}s" if minutes else f"{seconds:.1f}s"
+
+
+def _module_of(nodeid: str) -> str:
+    """`test_zz_coverage.py::test_x` -> `coverage`.
+
+    The zz prefix only exists to sort that file last; it is not part of what the
+    module is called.
+    """
+    stem = Path(nodeid.split("::")[0]).stem
+    if stem.startswith("test_"):
+        stem = stem[len("test_"):]
+    return stem[len("zz_"):] if stem.startswith("zz_") else stem
+
+
+def _title(nodeid: str) -> str:
+    """Test names in this suite already read as sentences; drop the syntax."""
+    name = nodeid.split("::")[-1]
+    if name.startswith("test_"):
+        name = name[len("test_"):]
+    return name.replace("_", " ")
+
+
+def _summary_line(path: str) -> str:
+    """The first line of the file's docstring, which says what the module covers."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            first = handle.readline().strip()
+    except OSError:
+        return ""
+    return first[3:].strip().rstrip('"') if first.startswith('"""') else ""
+
+
+def _open_live_stream():
+    """The descriptor `run.sh` left open on the terminal, else stderr.
+
+    pytest's stdout and stderr are redirected into the log, so the live view
+    needs a channel that was not redirected with them — and one that pytest's
+    capture does not replace underneath it, which is why the waiting lines show
+    up at all.
+    """
+    descriptor = os.environ.get("OOPS_LIVE_FD")
+    if descriptor:
+        try:
+            return os.fdopen(int(descriptor), "w", buffering=1, closefd=False)
+        except (OSError, ValueError):
+            pass
+    return sys.stderr
+
+
+class Steps:
+    def __init__(self, view: View, first_step: int):
+        self.view = view
+        self.step = first_step - 1
+
+        self.order: list[str] = []
+        self.sizes: dict[str, int] = {}
+        self.paths: dict[str, str] = {}
+
+        self.module: str | None = None
+        self.module_started = 0.0
+        self.counts = {"passed": 0, "failed": 0, "skipped": 0}
+        self.test_started = 0.0
+        self.reported = False
+
+    # -- output -------------------------------------------------------------
+
+    def keep(self, text: str, colour: str = "") -> None:
+        self.view.commit(f"#{self.step} {text}", colour)
+
+    def passing(self, text: str) -> None:
+        self.view.push(f"#{self.step} {text}")
+
+    # -- steps --------------------------------------------------------------
+
+    def _open_module(self, module: str) -> None:
+        self.step += 1
+        self.module = module
+        self.module_started = time.time()
+        self.counts = {"passed": 0, "failed": 0, "skipped": 0}
+
+        position = f"[{self.order.index(module) + 1}/{len(self.order)}]"
+        summary = _summary_line(self.paths.get(module, ""))
+        self.keep(f"{position} {module}" + (f" — {summary}" if summary else ""),
+                  BOLD)
+        size = self.sizes.get(module, 0)
+        self.keep(f"{size} test{'' if size == 1 else 's'}", DIM)
+
+    def _close_module(self) -> None:
+        if self.module is None:
+            return
+        self.view.clear()
+        tally = ", ".join(f"{count} {name}"
+                          for name, count in self.counts.items() if count)
+        elapsed = _duration(time.time() - self.module_started)
+        if self.counts["failed"]:
+            self.keep(f"FAILED {elapsed}  {tally}", RED)
+        else:
+            self.keep(f"DONE {elapsed}  {tally or 'nothing ran'}",
+                      GREEN if self.counts["passed"] else YELLOW)
+        self.module = None
+
+    # -- pytest hooks -------------------------------------------------------
+
+    def pytest_collection_finish(self, session):
+        for item in session.items:
+            module = _module_of(item.nodeid)
+            if module not in self.sizes:
+                self.order.append(module)
+                self.sizes[module] = 0
+                self.paths[module] = str(item.fspath)
+            self.sizes[module] += 1
+        # Anything that waits reports through here; it belongs with the test
+        # that is waiting, so it goes in the scrolling region and leaves with it.
+        runlog.set_sink(lambda message: self.passing(f"  . {message}"))
+
+    def pytest_runtest_logstart(self, nodeid, location):
+        module = _module_of(nodeid)
+        if module != self.module:
+            self._close_module()
+            self._open_module(module)
+        self.test_started = time.time()
+        self.reported = False
+        self.passing(f"> {_title(nodeid)}")
+
+    def pytest_runtest_logreport(self, report):
+        # setup-phase skips and errors never reach the call phase, so both
+        # phases have to be able to close a test out — but only once.
+        if self.reported or report.when not in ("setup", "call"):
+            return
+        elapsed = f"{_duration(time.time() - self.test_started):>7}"
+        title = _title(report.nodeid)
+
+        if report.failed:
+            outcome, colour, extra = "FAIL", RED, self._reason(report)[:3]
+        elif report.skipped:
+            outcome, colour, extra = "SKIP", YELLOW, [self._skip_reason(report)]
+        elif report.when == "call":
+            outcome, colour, extra = "OK", GREEN, []
+        else:
+            return
+
+        self.reported = True
+        self.counts[{"OK": "passed", "FAIL": "failed",
+                     "SKIP": "skipped"}[outcome]] += 1
+        # The scrolling lines described a test that is now over; replace them
+        # with the one line worth keeping.
+        self.view.clear()
+        self.keep(f"  {outcome:<4} {elapsed}  {title}", colour)
+        for line in extra:
+            if line:
+                self.keep(f"         {line}", colour)
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        runlog.set_sink(None)
+        self._close_module()
+        self.view.close()
+
+    # -- failure text -------------------------------------------------------
+
+    @staticmethod
+    def _reason(report) -> list[str]:
+        """The assertion, not the traceback — the full text is in pytest.log."""
+        crash = getattr(getattr(report, "longrepr", None), "reprcrash", None)
+        if crash is not None and getattr(crash, "message", ""):
+            return crash.message.strip().splitlines()
+        text = str(getattr(report, "longreprtext", "") or "").strip()
+        return text.splitlines()[-3:] if text else ["no reason recorded"]
+
+    @staticmethod
+    def _skip_reason(report) -> str:
+        longrepr = getattr(report, "longrepr", None)
+        if isinstance(longrepr, tuple) and len(longrepr) == 3:
+            reason = str(longrepr[2])
+            return reason[len("Skipped: "):] if reason.startswith("Skipped: ") \
+                else reason
+        return ""
+
+
+def pytest_configure(config):
+    first = int(os.environ.get("OOPS_STEP_OFFSET", "0")) + 1
+    view = View(_open_live_stream())
+    config.pluginmanager.register(Steps(view, first), "oops-steps")

--- a/tests/acceptance/scripts/register_environment.py
+++ b/tests/acceptance/scripts/register_environment.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Register the fixture cluster with a running OOPS as a named environment.
+
+Reads what `cluster-provision.sh` exported. `run.sh` calls both in order; doing
+it by hand looks like:
+
+    eval "$(./scripts/cluster-provision.sh | grep '^  export' | sed 's/^  //')"
+    python scripts/register_environment.py --name acceptance
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from oops_client import OopsClient  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", default="acceptance",
+                        help="environment name in OOPS")
+    parser.add_argument("--endpoint",
+                        default=os.environ.get("OOPS_ENDPOINT", "http://localhost:8080"))
+    parser.add_argument("--api-server", default=os.environ.get("OOPS_CLUSTER_API_SERVER"))
+    parser.add_argument("--token", default=os.environ.get("OOPS_CLUSTER_TOKEN"))
+    parser.add_argument("--work-namespace",
+                        default=os.environ.get("OOPS_WORK_NAMESPACE", "oops-work"))
+    parser.add_argument("--registry", default=os.environ.get("OOPS_REGISTRY", ""),
+                        help="image registry the build pushes to")
+    # The local registry accepts anything, but these must not be blank:
+    # syncImagePullSecret() skips creating the `dockerhub` secret when either is
+    # empty, while the build job mounts that secret unconditionally — so blank
+    # credentials leave every build pod stuck at Init:0/2 on a missing volume.
+    parser.add_argument("--registry-username",
+                        default=os.environ.get("OOPS_REGISTRY_USERNAME", "oops"))
+    parser.add_argument("--registry-password",
+                        default=os.environ.get("OOPS_REGISTRY_PASSWORD", "oops"))
+    parser.add_argument("--username", default=os.environ.get("OOPS_USERNAME", "admin"))
+    parser.add_argument("--password", default=os.environ.get("OOPS_PASSWORD", "admin123"))
+    arguments = parser.parse_args()
+
+    if not arguments.api_server or not arguments.token:
+        parser.error("--api-server and --token are required "
+                     "(cluster-provision.sh prints them as OOPS_CLUSTER_* "
+                     "exports)")
+
+    client = OopsClient(arguments.endpoint)
+    client.login(arguments.username, arguments.password)
+
+    existing = [item for item in client.list_environments()
+                if item["name"] == arguments.name]
+    if existing:
+        print(f"environment {arguments.name!r} already registered, leaving it alone")
+        return 0
+
+    body = {
+        "name": arguments.name,
+        "kubernetesApiServer": {
+            "url": arguments.api_server,
+            "token": arguments.token,
+        },
+        "workNamespace": arguments.work_namespace,
+        "imageRepository": {
+            "url": arguments.registry,
+            "username": arguments.registry_username,
+            "password": arguments.registry_password,
+        },
+    }
+    created = client.post("/api/environments", body).data
+    print(f"registered environment {arguments.name!r} -> {created.get('id')}")
+    print(f"run the cluster tier with:  pytest --environment {arguments.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/acceptance/scripts/render_step.py
+++ b/tests/acceptance/scripts/render_step.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Show one command's output as a bounded tail that erases itself when it ends.
+
+`run.sh` pipes a step's combined output through this. Every line is appended to
+the step's log unchanged, and the last few are on screen while the step runs;
+when it finishes the region disappears and `run.sh` prints the one line that is
+worth keeping.
+
+The command's exit status arrives as a sentinel line, because a pipe carries
+output and not status, and the step's DONE or ERROR depends on it. This exits
+with that status, so a caller reading the end of the pipeline learns what the
+command did.
+
+Only the standard library, and Python 3.9: this runs before the virtualenv
+exists, since creating the virtualenv is itself a step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from liveview import View  # noqa: E402
+
+SENTINEL = "__step_status__"
+# docker compose writes cursor control sequences even into a pipe, which arrive
+# as a stray [K in the middle of a line.
+ANSI = re.compile(r"\033\[[0-9;]*[A-Za-z]")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prefix", default="", help="step marker, e.g. #4")
+    parser.add_argument("--log", help="file to append every line to, verbatim")
+    arguments = parser.parse_args()
+
+    log = open(arguments.log, "a", encoding="utf-8") if arguments.log else None
+    view = View(sys.stdout)
+    status = 0
+    try:
+        for raw in sys.stdin:
+            line = raw.rstrip("\n")
+            if line.startswith(SENTINEL):
+                status = int(line.split()[-1] or 0)
+                continue
+            if log:
+                log.write(line + "\n")
+                log.flush()
+            line = ANSI.sub("", line).replace("\r", "").strip()
+            if line:
+                view.push(f"{arguments.prefix} {line}" if arguments.prefix
+                          else line)
+    except KeyboardInterrupt:
+        status = 130
+    finally:
+        # Whatever happened, the terminal goes back to the caller with the
+        # cursor where it started and no half-drawn region on it.
+        view.clear()
+        if log:
+            log.close()
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/acceptance/scripts/seed_gitea.py
+++ b/tests/acceptance/scripts/seed_gitea.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Create the Git fixtures the suite builds from: one public repo, one private.
+
+Gitea is seeded through its API rather than by pushing, so no git binary or
+working copy is needed. Content is written with the contents endpoint, which
+creates the initial commit on the default branch.
+
+    python scripts/seed_gitea.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DOCKERFILE = """FROM alpine:3.20
+RUN echo "acceptance fixture" > /message
+CMD ["sh", "-c", "while true; do cat /message; sleep 30; done"]
+"""
+
+README = "Fixture repository for the OOPS acceptance suite.\n"
+
+
+def call(url: str, method: str = "GET", body: dict | None = None,
+         auth: tuple[str, str] | None = None) -> tuple[int, dict | list | None]:
+    request = urllib.request.Request(
+        url, method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"Content-Type": "application/json"})
+    if auth:
+        token = base64.b64encode(f"{auth[0]}:{auth[1]}".encode()).decode()
+        request.add_header("Authorization", f"Basic {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read()
+            return response.status, json.loads(payload) if payload else None
+    except urllib.error.HTTPError as error:
+        payload = error.read()
+        try:
+            return error.code, json.loads(payload) if payload else None
+        except json.JSONDecodeError:
+            return error.code, {"raw": payload.decode(errors="replace")[:200]}
+
+
+def wait_for_gitea(base: str, attempts: int = 60) -> None:
+    for _ in range(attempts):
+        status, _ = call(f"{base}/api/healthz")
+        if status == 200:
+            return
+        time.sleep(2)
+    raise SystemExit(f"gitea never became healthy at {base}")
+
+
+def ensure_user(container: str, username: str, password: str, email: str) -> None:
+    """Gitea has no API for creating the first user, so use its CLI."""
+    import subprocess
+
+    listing = subprocess.run(
+        ["docker", "exec", "-u", "git", container,
+         "gitea", "admin", "user", "list"],
+        capture_output=True, text=True)
+    if username in listing.stdout:
+        return
+    result = subprocess.run(
+        ["docker", "exec", "-u", "git", container,
+         "gitea", "admin", "user", "create",
+         "--username", username, "--password", password,
+         "--email", email, "--admin", "--must-change-password=false"],
+        capture_output=True, text=True)
+    if result.returncode != 0 and "already exists" not in result.stderr:
+        raise SystemExit(f"could not create the gitea user: {result.stderr}")
+
+
+def ensure_repository(base: str, auth: tuple[str, str], name: str,
+                      private: bool) -> None:
+    status, _ = call(f"{base}/api/v1/repos/{auth[0]}/{name}", auth=auth)
+    if status == 200:
+        return
+    status, payload = call(
+        f"{base}/api/v1/user/repos", "POST",
+        {"name": name, "private": private, "auto_init": True,
+         "default_branch": "main",
+         "description": "OOPS acceptance fixture"},
+        auth=auth)
+    if status not in (201, 409):
+        raise SystemExit(f"could not create {name}: {status} {payload}")
+
+
+def ensure_file(base: str, auth: tuple[str, str], repository: str, path: str,
+                content: str, branch: str = "main") -> None:
+    status, _ = call(
+        f"{base}/api/v1/repos/{auth[0]}/{repository}/contents/{path}"
+        f"?ref={branch}", auth=auth)
+    if status == 200:
+        return
+    status, payload = call(
+        f"{base}/api/v1/repos/{auth[0]}/{repository}/contents/{path}", "POST",
+        {"content": base64.b64encode(content.encode()).decode(),
+         "message": f"add {path}", "branch": branch},
+        auth=auth)
+    if status not in (201, 200, 422):
+        raise SystemExit(f"could not write {path}: {status} {payload}")
+
+
+def ensure_branch(base: str, auth: tuple[str, str], repository: str,
+                  name: str, source: str = "main") -> None:
+    status, _ = call(
+        f"{base}/api/v1/repos/{auth[0]}/{repository}/branches/{name}", auth=auth)
+    if status == 200:
+        return
+    call(f"{base}/api/v1/repos/{auth[0]}/{repository}/branches", "POST",
+         {"new_branch_name": name, "old_branch_name": source}, auth=auth)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    # The published port, because this runs on the host. OOPS_GITEA_URL is the
+    # container name the backend and the pipeline pods use, and does not resolve
+    # out here.
+    parser.add_argument("--base", default=os.environ.get(
+        "OOPS_GITEA_PROBE_URL", "http://127.0.0.1:13000"))
+    parser.add_argument("--container", default="oops-acceptance-gitea")
+    parser.add_argument("--username", default=os.environ.get(
+        "OOPS_GITEA_USER", "oops"))
+    parser.add_argument("--password", default=os.environ.get(
+        "OOPS_GITEA_PASSWORD", "oops-git-secret"))
+    arguments = parser.parse_args()
+
+    base = arguments.base.rstrip("/")
+    auth = (arguments.username, arguments.password)
+
+    wait_for_gitea(base)
+    ensure_user(arguments.container, arguments.username, arguments.password,
+                f"{arguments.username}@example.invalid")
+
+    for repository, private in (("public-fixture", False),
+                                ("private-fixture", True)):
+        ensure_repository(base, auth, repository, private)
+        ensure_file(base, auth, repository, "Dockerfile", DOCKERFILE)
+        ensure_file(base, auth, repository, "README.md", README)
+        # A second branch, so the branch picker has more than one thing to list.
+        ensure_branch(base, auth, repository, "release")
+
+    print(f"seeded {base}/{arguments.username}/public-fixture (public)")
+    print(f"seeded {base}/{arguments.username}/private-fixture (private)")
+    print()
+    print(f'  export OOPS_GITEA_USER="{arguments.username}"')
+    print(f'  export OOPS_GITEA_PASSWORD="{arguments.password}"')
+    print('  export OOPS_GITEA_URL="http://gitea:3000"')
+    print(f'  export OOPS_GITEA_PROBE_URL="{base}"')
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/acceptance/scripts/summarise.py
+++ b/tests/acceptance/scripts/summarise.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Render a JUnit XML run as a short terminal summary.
+
+The HTML report is for reading afterwards; this is what you want in the terminal
+and in CI logs, where the useful signal is which tests failed and why, not a
+progress bar.
+"""
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+GREEN, RED, YELLOW, DIM, RESET = (
+    "\033[32m", "\033[31m", "\033[33m", "\033[2m", "\033[0m")
+
+
+def main(path: Path) -> int:
+    if not path.exists():
+        print(f"no report at {path}", file=sys.stderr)
+        return 1
+
+    root = ElementTree.parse(path).getroot()
+    suites = root.findall("testsuite") or [root]
+
+    total = failures = errors = skipped = 0
+    duration = 0.0
+    problems: list[tuple[str, str, str]] = []
+
+    for suite in suites:
+        total += int(suite.get("tests", 0))
+        failures += int(suite.get("failures", 0))
+        errors += int(suite.get("errors", 0))
+        skipped += int(suite.get("skipped", 0))
+        duration += float(suite.get("time", 0) or 0)
+
+        for case in suite.findall("testcase"):
+            for kind in ("failure", "error"):
+                node = case.find(kind)
+                if node is not None:
+                    name = f"{case.get('classname', '')}::{case.get('name', '')}"
+                    message = (node.get("message") or "").strip().splitlines()
+                    problems.append((kind, name, message[0] if message else ""))
+
+    passed = total - failures - errors - skipped
+    width = 68
+
+    print("=" * width)
+    print("OOPS acceptance report".center(width))
+    print("=" * width)
+    print(f"  {GREEN}passed{RESET}   {passed}")
+    if failures:
+        print(f"  {RED}failed{RESET}   {failures}")
+    if errors:
+        print(f"  {RED}errored{RESET}  {errors}")
+    if skipped:
+        print(f"  {YELLOW}skipped{RESET}  {skipped}")
+    print(f"  {DIM}total{RESET}    {total}   {DIM}in {duration:.1f}s{RESET}")
+
+    if problems:
+        print("-" * width)
+        for kind, name, message in problems:
+            print(f"  {RED}{kind.upper()}{RESET} {name}")
+            if message:
+                print(f"        {DIM}{message[:width - 10]}{RESET}")
+
+    print("=" * width)
+    if failures or errors:
+        print(f"{RED}FAILED{RESET} — {failures + errors} of {total} did not pass")
+        return 1
+    if total == 0:
+        print(f"{YELLOW}no tests ran{RESET}")
+        return 1
+    if skipped:
+        print(f"{GREEN}PASSED{RESET} — {passed}/{total}, {skipped} skipped")
+    else:
+        print(f"{GREEN}PASSED{RESET} — all {total} tests")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: summarise.py <junit.xml>", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(main(Path(sys.argv[1])))

--- a/tests/acceptance/test_application_config.py
+++ b/tests/acceptance/test_application_config.py
@@ -1,0 +1,351 @@
+"""Configuring an application: the round trip through every config surface.
+
+An application carries five independent pieces of configuration — profile, build,
+service, runtime spec, expert — each stored as a JSON blob and each with a
+per-environment variant. They are read and written through separate endpoints,
+and the shapes are not symmetric, which is exactly where a reimplementation drifts.
+
+The scenario is the one a user actually performs: create an application, fill in
+each section, read it all back, and check that what came out is what went in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_the_profile_can_be_updated(client, namespace, application):
+    client.put(f"/api/namespaces/{namespace}/applications/{application}", {
+        "name": application,
+        "namespace": namespace,
+        "description": "updated by the acceptance suite",
+        "icon": "🚀",
+    })
+
+    profile = client.get_application(namespace, application).data
+    assert profile["description"] == "updated by the acceptance suite"
+    assert profile["icon"] == "🚀", "the icon did not survive the round trip"
+
+
+def test_the_icon_must_be_non_ascii_and_short(client, namespace, application):
+    """The rule is at most eight code points with no ASCII, not "one emoji".
+
+    The rejection message says "must be a single emoji", but a single emoji is
+    frequently several code points — a flag, a skin tone, a ZWJ family — so the
+    limit is eight and anything below U+0080 is refused. Two rocket emoji are
+    therefore accepted, which the message would not lead you to expect.
+    """
+    accepted = ("🚀", "🇬🇧", "👩‍💻", "🚀🚀", "")
+    refused = ("rocket", "ab", "a🚀", "🚀🚀🚀🚀🚀🚀🚀🚀🚀")
+
+    for candidate in accepted:
+        result = client.put(
+            f"/api/namespaces/{namespace}/applications/{application}",
+            {"name": application, "namespace": namespace, "icon": candidate},
+            expect_success=False)
+        assert result.success is True, (
+            f"{candidate!r} was refused as an application icon: {result.message}")
+
+    for candidate in refused:
+        result = client.put(
+            f"/api/namespaces/{namespace}/applications/{application}",
+            {"name": application, "namespace": namespace, "icon": candidate},
+            expect_success=False)
+        assert result.success is False, (
+            f"{candidate!r} was accepted as an application icon")
+
+
+def test_build_config_round_trips(client, namespace, application, environment):
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": "https://example.invalid/team/service.git",
+        "buildImage": "node:20-slim",
+        "dockerFileConfig": {"content": "FROM alpine:3.20\n"},
+        "environmentConfigs": [
+            {"environment": environment, "buildCommand": "npm run build"},
+        ],
+    })
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/build/config").data
+
+    assert stored["sourceType"] == "GIT"
+    assert stored["repository"] == "https://example.invalid/team/service.git"
+    assert stored["buildImage"] == "node:20-slim"
+
+    per_environment = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/environments/build/configs").data
+    commands = {item["environment"]: item["buildCommand"]
+                for item in per_environment}
+    assert commands.get(environment) == "npm run build", (
+        f"the per-environment build command was lost; got {commands}")
+
+
+def test_per_environment_build_configs_can_be_written_separately(
+        client, namespace, application, environment):
+    """The per-environment collection has its own endpoint as well as riding
+    along inside the build config, and both have to agree."""
+    client.put(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/environments/build/configs",
+        [{"environment": environment, "buildCommand": "make release"}])
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/environments/build/configs").data
+    commands = {item["environment"]: item["buildCommand"] for item in stored}
+    assert commands.get(environment) == "make release"
+
+
+def test_service_config_round_trips(client, namespace, application, environment):
+    client.put_service_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "port": 8080,
+        "internalPorts": [9090, 9091],
+        "environmentConfigs": [
+            {"environment": environment, "hosts": []},
+        ],
+    })
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/service").data
+
+    assert stored["port"] == 8080
+    assert stored["internalPorts"] == [9090, 9091], (
+        f"internal ports did not survive the round trip: {stored['internalPorts']}")
+
+
+def test_runtime_spec_round_trips(client, namespace, application, environment):
+    """Memory is a bare number of MiB while cpu is a full quantity string.
+
+    The gateway appends "Mi" to the memory values when it builds the container
+    resources, so sending "256Mi" here produces "256MiMi" and the API server
+    rejects the StatefulSet.
+    """
+    client.put_runtime_spec(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "environmentConfigs": [{
+            "environment": environment,
+            "replicas": 2,
+            "cpuRequest": "100m",
+            "cpuLimit": "1",
+            "memoryRequest": "128",
+            "memoryLimit": "512",
+        }],
+    })
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/runtime-spec").data
+    configs = {item["environment"]: item
+               for item in stored["environmentConfigs"]}
+    assert configs[environment]["replicas"] == 2
+    assert configs[environment]["memoryLimit"] == "512", (
+        "the memory limit was rewritten in storage; it must round trip as the "
+        "bare number the caller sent")
+
+    per_environment = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/environments/runtime-specs").data
+    assert any(item["environment"] == environment for item in per_environment)
+
+
+@pytest.mark.cluster
+def test_saving_a_runtime_spec_before_the_first_deploy_is_quiet(
+        client, namespace, application, environment, kubectl):
+    """Setting resources on an application that has never been deployed.
+
+    This is the ordinary first-time flow — create, size, then deploy — and it
+    used to log a Kubernetes 404 with a full API URL, because the save tried to
+    scale a StatefulSet that does not exist yet. The spec was stored correctly
+    either way, so the only casualty was the log: a routine action that looked
+    like a failure, and real cluster problems buried in the same shape of
+    message.
+
+    Asserted through the API rather than by reading logs: the save has to
+    succeed, the value has to come back, and no workload may be created as a
+    side effect.
+    """
+    assert not kubectl.exists("statefulset", application, namespace), (
+        "this application has already been deployed, so it cannot exercise the "
+        "before-first-deploy path")
+
+    client.put_runtime_spec(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "environmentConfigs": [{
+            "environment": environment,
+            "replicas": 2,
+            "cpuRequest": "50m",
+            "cpuLimit": "200m",
+            "memoryRequest": "64",
+            "memoryLimit": "128",
+        }],
+    })
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/runtime-spec").data
+    configs = {item["environment"]: item
+               for item in stored["environmentConfigs"]}
+    assert configs[environment]["replicas"] == 2, (
+        "the runtime spec was not stored for an undeployed application")
+
+    assert not kubectl.exists("statefulset", application, namespace), (
+        "saving a runtime spec created a StatefulSet; sizing an application is "
+        "not supposed to deploy it")
+
+
+def test_per_environment_runtime_specs_can_be_written_separately(
+        client, namespace, application, environment):
+    client.put(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/environments/runtime-specs",
+        [{"environment": environment, "replicas": 3,
+          "cpuRequest": "50m", "cpuLimit": "500m",
+          "memoryRequest": "64", "memoryLimit": "256"}])
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/environments/runtime-specs").data
+    configs = {item["environment"]: item for item in stored}
+    assert configs[environment]["replicas"] == 3
+
+
+def test_expert_config_round_trips(client, namespace, application, environment):
+    """Service account, priority and the scheduled restart cron."""
+    client.put(
+        f"/api/namespaces/{namespace}/applications/{application}/expert-config",
+        {
+            "namespace": namespace,
+            "applicationName": application,
+            "environmentConfigs": [{
+                "environment": environment,
+                "serviceAccountName": "default",
+                "priority": "",
+                "scheduledRestartEnabled": True,
+                "scheduledRestartCron": "0 3 * * *",
+                "nodeNames": [],
+            }],
+        })
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/expert-config").data
+    configs = {item["environment"]: item
+               for item in stored["environmentConfigs"]}
+    assert configs[environment]["scheduledRestartEnabled"] is True
+    assert configs[environment]["scheduledRestartCron"] == "0 3 * * *", (
+        "the scheduled restart cron did not survive the round trip")
+
+
+def test_environment_bindings_round_trip(client, namespace, application,
+                                         environment):
+    """The binding that decides which clusters a deletion cleans up."""
+    client.put_environment_bindings(namespace, application, [
+        {"namespace": namespace, "applicationName": application,
+         "environment": environment},
+    ])
+
+    bound = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/environments").data
+    assert environment in [item["environment"] for item in bound], (
+        "the environment binding was not stored; deletion relies on it to know "
+        "which clusters to clean up")
+
+
+def test_reading_an_unconfigured_application_is_empty_not_an_error(
+        client, namespace, application):
+    """Every config surface has to answer for an application with nothing set.
+
+    This is where a reimplementation throws instead of returning empty, because
+    the blob column is null and nobody checked.
+    """
+    for suffix in ("/build/config", "/service", "/runtime-spec", "/expert-config",
+                   "/environments", "/environments/build/configs",
+                   "/environments/runtime-specs", "/last-successful-pipeline"):
+        result = client.get(
+            f"/api/namespaces/{namespace}/applications/{application}{suffix}",
+            expect_success=False)
+        assert result.status == 200, (
+            f"{suffix} answered HTTP {result.status} for an application with no "
+            f"configuration")
+
+
+def test_host_conflict_check_answers(client, namespace, application):
+    """Answers whether a host is already claimed, before the user saves it.
+
+    An unclaimed host comes back as null data rather than as a view saying "no
+    conflict", so the UI treats absence as the clear signal.
+    """
+    free = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/service/host-check?host=acceptance-unclaimed.example.invalid")
+    assert free.success is True
+    assert free.data is None, (
+        f"an unclaimed host reported a conflict: {free.data}")
+
+
+def test_active_deployments_lists_the_namespace(client, namespace, application):
+    result = client.get(
+        f"/api/namespaces/{namespace}/applications/active-deployments")
+    assert isinstance(result.data, list), (
+        "active deployments should be a list, even when nothing is deploying")
+
+
+@pytest.mark.cluster
+def test_cluster_facing_reads_answer_for_a_deployed_application(
+        client, namespace, application, environment):
+    """Status, metrics, events, resources and the current image.
+
+    Grouped into one scenario because they all describe the same running
+    workload and each needs the same expensive deploy to exist first.
+    """
+    from test_deploy import configure_for_build, git_strategy
+    from test_deploy import DEPLOY_TIMEOUT, TERMINAL_STATUSES
+    from oops_client import wait_until
+
+    configure_for_build(client, namespace, application, environment)
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                          description="the deploy to finish")
+    if pipeline["status"] != "SUCCEEDED":
+        pytest.skip(f"deploy ended as {pipeline['status']}")
+
+    reads = {
+        "/status": "pod status",
+        "/current-image": "the image currently rolled out",
+        "/events": "Kubernetes events",
+        "/resources": "the rendered manifests",
+        "/metrics": "live pod metrics",
+        "/service/cluster-domain": "the in-cluster service address",
+    }
+    for suffix, description in reads.items():
+        result = client.get(
+            f"/api/namespaces/{namespace}/applications/{application}{suffix}"
+            f"?environment={environment}", expect_success=False)
+        assert result.status == 200, (
+            f"{description} ({suffix}) answered HTTP {result.status} for a "
+            f"successfully deployed application")
+
+    # Metrics history needs a Prometheus-compatible backend, which the fixture cluster has not
+    # got. It must decline cleanly rather than fail.
+    history = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/metrics/history?environment={environment}&rangeHours=1",
+        expect_success=False)
+    assert history.status == 200, (
+        "metrics history should answer inside the envelope when no monitoring "
+        "backend is configured, not fail with an HTTP error")

--- a/tests/acceptance/test_configmap.py
+++ b/tests/acceptance/test_configmap.py
@@ -1,0 +1,191 @@
+"""Application configuration items, and the metadata that never reaches the pod.
+
+Config items are stored in Kubernetes, not in the OOPS database: plain values go
+into the application ConfigMap, secret ones into the Secret, and items with a
+mount path become files rather than environment variables.
+
+The interesting part is the metadata. `mountPath`, `group`, `comment` and `order`
+exist for the UI alone, and carrying them inside the ConfigMap data would inject
+them into the container as environment variables. They are kept in annotations
+instead, which is invisible from the API and easy to lose in a rewrite — so these
+tests read the objects back through kubectl as well as through OOPS.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.cluster
+
+
+def write(client, namespace, application, environment, items):
+    return client.put(
+        f"/api/namespaces/{namespace}/applications/{application}/configmaps"
+        f"?environment={environment}", items)
+
+
+def read(client, namespace, application, environment):
+    return client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/configmaps"
+        f"?environment={environment}").data
+
+
+def test_config_items_round_trip(client, namespace, application, environment):
+    write(client, namespace, application, environment, [
+        {"key": "LOG_LEVEL", "value": "debug", "secret": False,
+         "group": "runtime", "comment": "verbosity", "order": 1},
+        {"key": "GREETING", "value": "hello", "secret": False,
+         "group": "runtime", "order": 2},
+    ])
+
+    items = {item["key"]: item for item in
+             read(client, namespace, application, environment)}
+
+    assert items["LOG_LEVEL"]["value"] == "debug"
+    assert items["LOG_LEVEL"]["group"] == "runtime", (
+        "the group was lost; the UI groups items by it and would show them all "
+        "as ungrouped")
+    assert items["LOG_LEVEL"]["comment"] == "verbosity", "the comment was lost"
+    # Order is not stored as sent: it is reassigned from the item's position in
+    # the submitted list, zero-based. So the second item comes back as 1 no
+    # matter what was sent. Worth pinning, because a caller that reads a value
+    # back, edits one field and writes the whole list again keeps a stable
+    # ordering only by accident of list order.
+    assert items["LOG_LEVEL"]["order"] == 0, (
+        f"the first item came back with order {items['LOG_LEVEL']['order']}, "
+        f"expected its list position")
+    assert items["GREETING"]["order"] == 1, (
+        f"the second item came back with order {items['GREETING']['order']}, "
+        f"expected its list position")
+
+
+def test_a_secret_item_is_stored_apart_from_a_plain_one(
+        client, namespace, application, environment, kubectl):
+    """Plain values land in the ConfigMap, secret ones in the Secret.
+
+    Getting this wrong is not visible through the API — both come back the same
+    way — but it decides whether the value is readable by anyone who can get a
+    ConfigMap.
+    """
+    write(client, namespace, application, environment, [
+        {"key": "PUBLIC_VALUE", "value": "visible", "secret": False},
+        {"key": "PRIVATE_VALUE", "value": "hidden", "secret": True},
+    ])
+
+    config_map = kubectl.get_json("configmap", application, namespace)
+    secret = kubectl.get_json("secret", application, namespace)
+    if config_map is None:
+        pytest.skip("no ConfigMap was created for the application")
+
+    assert "PUBLIC_VALUE" in (config_map.get("data") or {}), (
+        "a plain item is missing from the ConfigMap")
+    assert "PRIVATE_VALUE" not in (config_map.get("data") or {}), (
+        "a secret item was written into the ConfigMap in clear text, where "
+        "anyone able to read ConfigMaps can see it")
+    assert secret is not None and "PRIVATE_VALUE" in (secret.get("data") or {}), (
+        "the secret item did not reach the application Secret")
+
+    items = {item["key"]: item for item in
+             read(client, namespace, application, environment)}
+    assert items["PRIVATE_VALUE"]["secret"] is True, (
+        "reading back lost the secret flag, so the UI would offer to display it")
+
+
+def test_ui_metadata_stays_out_of_the_container(
+        client, namespace, application, environment, kubectl):
+    """The pod sees keys and values, never the metadata describing them.
+
+    `mountPath`, `group`, `comment` and `order` live in annotations. If they were
+    stored as data they would arrive in the container as environment variables
+    named after them.
+    """
+    write(client, namespace, application, environment, [
+        {"key": "APP_MODE", "value": "test", "secret": False,
+         "group": "runtime", "comment": "which mode to boot in", "order": 3},
+    ])
+
+    config_map = kubectl.get_json("configmap", application, namespace)
+    if config_map is None:
+        pytest.skip("no ConfigMap was created for the application")
+
+    data = config_map.get("data") or {}
+    assert set(data) == {"APP_MODE"} or "group" not in data, (
+        f"metadata leaked into the ConfigMap data and would be injected into "
+        f"the container: {sorted(data)}")
+
+    annotations = (config_map.get("metadata") or {}).get("annotations") or {}
+    assert "oops.config-meta" in annotations, (
+        "the UI metadata annotation is missing, so groups, comments and "
+        "ordering are lost on the next read")
+
+    meta = json.loads(annotations["oops.config-meta"])
+    entry = meta.get("APP_MODE") if isinstance(meta, dict) else None
+    if isinstance(meta, list):
+        entry = next((item for item in meta if item.get("key") == "APP_MODE"), None)
+    assert entry, f"APP_MODE is missing from the metadata annotation: {meta}"
+
+
+def test_a_file_item_is_recorded_as_a_mount(client, namespace, application,
+                                            environment, kubectl):
+    """An item with a mount path becomes a file rather than an env var."""
+    write(client, namespace, application, environment, [
+        {"key": "application.properties", "value": "server.port=8080\n",
+         "secret": False, "mountPath": "/config/application.properties"},
+    ])
+
+    items = {item["key"]: item for item in
+             read(client, namespace, application, environment)}
+    assert items["application.properties"]["mountPath"] == \
+           "/config/application.properties", (
+        "the mount path was lost, so the item would be injected as an "
+        "environment variable instead of written as a file")
+
+    # File items live in a separate `{app}.files` ConfigMap, not in the one that
+    # carries environment variables, so that the deploy can mount one as a volume
+    # without also mounting the other.
+    files_map = kubectl.get_json("configmap", f"{application}.files", namespace)
+    assert files_map is not None, (
+        f"no {application}.files ConfigMap was created; a file item was stored "
+        f"alongside the environment variables instead")
+
+    annotations = (files_map.get("metadata") or {}).get("annotations") or {}
+    assert "oops.mounts" in annotations, (
+        "the mount annotation is missing, so the deploy has no way to know "
+        "where the file belongs inside the container")
+    assert "/config/application.properties" in annotations["oops.mounts"], (
+        f"the mount path is not recorded in the annotation: "
+        f"{annotations['oops.mounts']}")
+
+
+def test_removing_an_item_removes_it_from_the_cluster(
+        client, namespace, application, environment, kubectl):
+    """A write is the whole set, not a patch.
+
+    Sending a shorter list has to delete what is missing, or a removed variable
+    would keep being injected until the ConfigMap is deleted by hand.
+    """
+    write(client, namespace, application, environment, [
+        {"key": "KEEP_ME", "value": "yes", "secret": False},
+        {"key": "REMOVE_ME", "value": "no", "secret": False},
+    ])
+    keys = {item["key"] for item in
+            read(client, namespace, application, environment)}
+    assert {"KEEP_ME", "REMOVE_ME"} <= keys
+
+    write(client, namespace, application, environment, [
+        {"key": "KEEP_ME", "value": "yes", "secret": False},
+    ])
+
+    keys = {item["key"] for item in
+            read(client, namespace, application, environment)}
+    assert "REMOVE_ME" not in keys, (
+        "a removed item is still returned; the write is behaving as a patch "
+        "rather than replacing the set")
+
+    config_map = kubectl.get_json("configmap", application, namespace)
+    if config_map is not None:
+        assert "REMOVE_ME" not in (config_map.get("data") or {}), (
+            "the item was dropped from the API response but is still in the "
+            "ConfigMap, so the container would keep receiving it")

--- a/tests/acceptance/test_contract.py
+++ b/tests/acceptance/test_contract.py
@@ -1,0 +1,171 @@
+"""The wire contract itself — envelope, auth, paging, identifiers, timestamps.
+
+None of this needs a cluster, and it is the tier a reimplementation breaks most
+quietly: the shapes still deserialize, they just no longer mean the same thing.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from oops_client import OopsClient
+
+# 24-character NanoId, as minted by domain.NewID / NanoIdUtils.
+ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{24}$")
+
+# LocalDateTime: local wall clock with microseconds and no zone suffix. A trailing
+# Z or +08:00 means someone started converting timestamps, which silently shifts
+# every stored value by the process offset.
+TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?$")
+
+
+def test_login_returns_a_token_and_identity(endpoint):
+    fresh = OopsClient(endpoint)
+    token = fresh.login("admin", "admin123")
+    assert token, "login returned an empty token"
+
+    result = fresh.post("/api/auth/login",
+                        {"username": "admin", "password": "admin123"},
+                        authenticated=False)
+    # The identity field is `id` here, while the JWT claim inside the token is
+    # `userId`. Both spellings are load-bearing and easy to conflate.
+    for field in ("token", "id", "username", "role"):
+        assert field in result.data, f"login response is missing {field!r}"
+    assert result.data["role"] in ("ADMIN", "USER")
+    assert ID_PATTERN.match(result.data["id"])
+
+
+def test_bad_credentials_fail_inside_the_envelope(endpoint):
+    """A rejected login is still a 200 with success=false, not an HTTP error."""
+    fresh = OopsClient(endpoint)
+    result = fresh.post("/api/auth/login",
+                        {"username": "admin", "password": "definitely-not-the-password"},
+                        authenticated=False, expect_success=False)
+    assert result.success is False
+    assert result.message, "a failed login must carry a message"
+    assert result.data is None
+
+
+def test_unauthenticated_calls_are_rejected(endpoint, namespace, service_is_up):
+    """Assert on the status specifically. Catching "any exception" here would let
+    a connection refusal pass as a successful authorisation check."""
+    anonymous = OopsClient(endpoint)
+    response = anonymous.raw(
+        "GET", f"/api/namespaces/{namespace}/applications", authenticated=False)
+    assert response.status_code in (401, 403), (
+        f"an unauthenticated call returned {response.status_code}, expected 401/403")
+
+
+def test_a_garbage_token_is_rejected(endpoint, namespace, service_is_up):
+    forged = OopsClient(endpoint, token="not-a-real-token")
+    response = forged.raw("GET", f"/api/namespaces/{namespace}/applications")
+    assert response.status_code in (401, 403), (
+        f"a forged bearer token returned {response.status_code}, expected 401/403")
+
+
+def test_success_envelope_shape(client, namespace):
+    result = client.get(f"/api/namespaces/{namespace}/applications?page=1&size=10")
+    assert result.success is True
+    assert result.message is None, "a successful call should not carry a message"
+    assert result.data is not None
+
+
+def test_pagination_shape_and_one_based_pages(client, namespace):
+    page = client.get(
+        f"/api/namespaces/{namespace}/applications?page=1&size=5").data
+    for field in ("total", "data", "size", "totalPages"):
+        assert field in page, f"page envelope is missing {field!r}"
+    assert isinstance(page["data"], list)
+    assert page["size"] == 5, "size should echo the requested page size"
+
+    # Page numbering is 1-based; asking for page 0 must not be treated as page 1.
+    first = client.get(f"/api/namespaces/{namespace}/applications?page=1&size=1").data
+    assert first["size"] == 1
+
+
+def test_created_application_has_a_nanoid_and_naive_timestamp(client, namespace,
+                                                              application):
+    profile = client.get_application(namespace, application).data
+
+    assert ID_PATTERN.match(profile["id"]), (
+        f"id {profile['id']!r} is not a 24-char NanoId")
+
+    created = profile.get("createdTime")
+    assert created, "createdTime is missing"
+    assert TIMESTAMP_PATTERN.match(created), (
+        f"createdTime {created!r} is not a naive local timestamp — a zone suffix "
+        "means values are being converted rather than read verbatim")
+
+
+def test_invalid_resource_names_are_rejected(client, namespace):
+    for candidate in ("UPPERCASE", "has space", "trailing-", "-leading", "dots.not.ok"):
+        result = client.post(
+            f"/api/namespaces/{namespace}/applications",
+            {"name": candidate, "namespace": namespace},
+            expect_success=False,
+        )
+        assert result.success is False, (
+            f"{candidate!r} was accepted as an application name")
+
+
+def test_missing_application_answers_success_with_null_data(client, namespace):
+    """A missing application is *not* an error here — the call succeeds and hands
+    back null data, with HTTP 200 throughout.
+
+    Pinning this down because it is the kind of undocumented contract a
+    reimplementation quietly changes: returning 404, or an envelope with
+    success=false, would break every caller that currently checks `data == null`.
+    Change it deliberately if you want to, but change this test in the same
+    commit.
+    """
+    result = client.get_application(namespace, "definitely-not-here-9f3a2b",
+                                    expect_success=False)
+    assert result.status == 200, f"expected HTTP 200, got {result.status}"
+    assert result.success is True
+    assert result.data is None
+
+
+def test_duplicate_application_name_is_rejected(client, namespace, application):
+    result = client.post(
+        f"/api/namespaces/{namespace}/applications",
+        {"name": application, "namespace": namespace},
+        expect_success=False,
+    )
+    assert result.success is False, "the same application name was accepted twice"
+
+
+def test_application_names_are_globally_unique_not_per_namespace(client, namespace,
+                                                                 application):
+    """Documents a constraint that contradicts the shape of the API.
+
+    Every path is namespaced — `/api/namespaces/{namespace}/applications/{name}`
+    — which reads as though a name only has to be unique within its namespace.
+    The schema disagrees: `UNIQUE KEY uk_application_name (name)` is on the name
+    alone, so two teams working in separate namespaces cannot both have an
+    application called `web`.
+
+    Written to pass against today's behaviour. If the key is ever widened to
+    (namespace, name), this test fails and should be inverted rather than
+    deleted — the change is worth making deliberately, because it is visible to
+    every user who has ever picked a name and been told it was taken.
+    """
+    other_namespace = f"{namespace}-second"
+    result = client.post(
+        f"/api/namespaces/{other_namespace}/applications",
+        {"name": application, "namespace": other_namespace},
+        expect_success=False,
+    )
+    assert result.success is False, (
+        "the same application name was accepted in a second namespace — the "
+        "unique key now appears to be per namespace, which is an improvement; "
+        "invert this test")
+
+
+def test_application_appears_in_its_namespace_listing(client, namespace, application):
+    page = client.get(
+        f"/api/namespaces/{namespace}/applications?page=1&size=200").data
+    names = [item["name"] for item in page["data"]]
+    assert application in names, (
+        f"{application} was created but is absent from the namespace listing")

--- a/tests/acceptance/test_deletion.py
+++ b/tests/acceptance/test_deletion.py
@@ -1,0 +1,174 @@
+"""Deleting an application — the cascade across the database and the cluster.
+
+Deletion is where a rewrite leaks: every config table has to go, the workload has
+to be removed from every environment the application was deployed to, and the
+authorisation rule (owner or admin only) has to survive. None of it is covered by
+a unit test today because it spans JPA and the Kubernetes client at once.
+
+The cluster-side assertions are deliberately specific about *which* objects
+disappear, because today not all of them do — see
+test_service_survives_application_deletion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from oops_client import wait_until
+from test_deploy import (DEPLOY_TIMEOUT, TERMINAL_STATUSES, configure_for_build,
+                         git_strategy)
+
+
+def deploy_and_wait(client, namespace, application, environment) -> str:
+    configure_for_build(client, namespace, application, environment)
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                          description="the deploy to finish before deleting it")
+    if pipeline["status"] != "SUCCEEDED":
+        pytest.skip(f"deploy ended as {pipeline['status']}, nothing to delete")
+    return pipeline_id
+
+
+# -- database side, no cluster needed ---------------------------------------
+
+def test_delete_removes_the_application_and_its_config(client, namespace,
+                                                       application_factory):
+    """Every per-application config row goes with the application.
+
+    Read back through the API rather than the database, so the assertion holds
+    for any storage engine a reimplementation picks.
+    """
+    application = application_factory()
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": "https://example.invalid/repo.git",
+    })
+
+    assert client.get_application(namespace, application).data is not None
+    client.delete_application(namespace, application)
+
+    assert client.get_application(namespace, application,
+                                  expect_success=False).data is None, (
+        "the application is still readable after deletion")
+
+    build = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/build/config",
+        expect_success=False)
+    assert not build.data, (
+        "the build config outlived its application — deleteAggregate is not "
+        "clearing every per-application table")
+
+
+def test_deleting_twice_reports_failure_inside_the_envelope(client, namespace,
+                                                            application_factory):
+    """A second delete fails, but as a result envelope rather than an HTTP error.
+
+    Note this differs from reading a missing application, which answers
+    success=true with null data. Delete raises where read does not, and both
+    shapes are part of the contract a reimplementation has to reproduce.
+    """
+    application = application_factory()
+    client.delete_application(namespace, application)
+
+    second = client.delete_application(namespace, application,
+                                       expect_success=False)
+    assert second.status == 200, (
+        f"a repeated delete answered HTTP {second.status}; it should stay "
+        f"inside the result envelope")
+    assert second.success is False
+    assert second.message, "a repeated delete should say what went wrong"
+
+
+def test_deleted_application_leaves_the_namespace_listing(client, namespace,
+                                                          application_factory):
+    application = application_factory()
+    client.delete_application(namespace, application)
+
+    page = client.get(
+        f"/api/namespaces/{namespace}/applications?page=1&size=200").data
+    assert application not in [item["name"] for item in page["data"]]
+
+
+def test_a_non_owner_cannot_delete(client, endpoint, namespace,
+                                   application_factory, secondary_user):
+    """Delete stays with the owner and admins.
+
+    The application is created by the admin session, so the second account is a
+    non-owner by construction.
+    """
+    from oops_client import OopsClient
+
+    application = application_factory()
+
+    intruder = OopsClient(endpoint)
+    intruder.login(secondary_user["username"], secondary_user["password"])
+
+    result = intruder.delete_application(namespace, application,
+                                         expect_success=False)
+    assert result.success is False, (
+        "a user who neither owns the application nor is an admin was allowed "
+        "to delete it")
+
+    # And the application is genuinely still there, not merely reported as kept.
+    assert client.get_application(namespace, application).data is not None
+
+
+# -- cluster side ------------------------------------------------------------
+
+@pytest.mark.cluster
+def test_delete_removes_the_statefulset(client, namespace, application,
+                                        environment, kubectl):
+    """The workload goes when the application does."""
+    deploy_and_wait(client, namespace, application, environment)
+
+    assert kubectl.exists("statefulset", application, namespace), (
+        "no StatefulSet to delete — the deploy did not create one")
+
+    client.delete_application(namespace, application)
+
+    gone = wait_until(
+        lambda: not kubectl.exists("statefulset", application, namespace),
+        timeout=120, interval=3,
+        description="the StatefulSet to disappear")
+    assert gone
+
+
+@pytest.mark.cluster
+def test_the_service_goes_with_the_statefulset(client, namespace, application,
+                                               environment, kubectl):
+    """The Service is garbage-collected rather than deleted explicitly.
+
+    `deleteWorkload` removes only the StatefulSet, which looks like a leak until
+    you notice `ServiceProcessor` stamps an owner reference on the Service.
+    Kubernetes then collects it when its owner goes, so the cleanup is real but
+    it happens in the cluster rather than in OOPS.
+
+    Worth a test precisely because the mechanism is invisible in the OOPS code: a
+    reimplementation that creates the Service without the owner reference would
+    still deploy correctly and would leak one Service per deleted application,
+    with nothing in the delete path to point at.
+    """
+    deploy_and_wait(client, namespace, application, environment)
+    if not kubectl.exists("service", application, namespace):
+        pytest.skip("no Service was created, nothing to say about its removal")
+
+    client.delete_application(namespace, application)
+    wait_until(lambda: not kubectl.exists("statefulset", application, namespace),
+               timeout=120, interval=3,
+               description="the StatefulSet to disappear")
+
+    gone = wait_until(
+        lambda: not kubectl.exists("service", application, namespace),
+        timeout=120, interval=3,
+        description="the Service to be garbage-collected with its owner")
+    assert gone, (
+        "the Service outlived the StatefulSet; its owner reference is missing, "
+        "so every deleted application now leaves one behind")

--- a/tests/acceptance/test_deploy.py
+++ b/tests/acceptance/test_deploy.py
@@ -1,0 +1,175 @@
+"""The build-and-deploy pipeline against a real cluster.
+
+This is the tier that guards the Kubernetes layer — the ~5.7k lines that carry
+almost no unit tests today because they need a live API server. Everything here
+is expressed in terms of the HTTP API, so it holds a reimplementation to the same
+observable behaviour without caring how the workloads get created.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from oops_client import wait_until
+
+pytestmark = pytest.mark.cluster
+
+TERMINAL_STATUSES = {"SUCCEEDED", "ERROR", "STOPPED"}
+ACTIVE_STATUSES = {"RUNNING", "DEPLOYING", "ROLLING_OUT"}
+
+# The order the state machine is allowed to advance through. A pipeline may skip
+# states but must never move backwards.
+STATUS_ORDER = ["INITIALIZED", "RUNNING", "BUILD_SUCCEEDED", "DEPLOYING",
+                "ROLLING_OUT", "SUCCEEDED"]
+
+# A small public repository with a Dockerfile at its root. Override for an
+# offline or air-gapped cluster.
+SOURCE_REPOSITORY = os.environ.get(
+    "OOPS_TEST_REPOSITORY", "https://github.com/docker/welcome-to-docker.git")
+SOURCE_BRANCH = os.environ.get("OOPS_TEST_BRANCH", "main")
+DEPLOY_TIMEOUT = int(os.environ.get("OOPS_TEST_DEPLOY_TIMEOUT", "900"))
+
+
+def configure_for_build(client, namespace, application, environment):
+    """Give an application the minimum it needs to build and serve.
+
+    The branch is not part of the build config — it travels per deploy, inside
+    the polymorphic `strategy` object.
+    """
+    # Bind the application to the environment first. A deploy works without this
+    # row, but deletion iterates it to decide which clusters to clean up — so an
+    # unbound application deletes from the database and leaves its StatefulSet
+    # running. Every test that later asserts on cleanup depends on this call.
+    client.put_environment_bindings(namespace, application, [
+        {"namespace": namespace, "applicationName": application,
+         "environment": environment},
+    ])
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": SOURCE_REPOSITORY,
+        "environmentConfigs": [{"environment": environment, "buildCommand": ""}],
+    })
+    client.put_service_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "port": 80,
+        "internalPorts": [],
+        "environmentConfigs": [{"environment": environment, "hosts": []}],
+    })
+    # Without an explicit replica count the StatefulSet is created with zero, so
+    # the rollout "succeeds" having started nothing and there is no pod for the
+    # log and terminal tests to attach to.
+    #
+    # The two resource fields are not symmetric: cpu* is a full Kubernetes
+    # quantity string, memory* is a bare number of MiB because the gateway
+    # appends "Mi" itself. Passing "256Mi" here yields "256MiMi" and the API
+    # server rejects the whole StatefulSet with "unable to parse quantity's
+    # suffix".
+    client.put_runtime_spec(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "environmentConfigs": [{
+            "environment": environment,
+            "replicas": 1,
+            "cpuRequest": "10m",
+            "cpuLimit": "500m",
+            "memoryRequest": "32",
+            "memoryLimit": "256",
+        }],
+    })
+
+
+def git_strategy(branch: str = SOURCE_BRANCH) -> dict:
+    return {"type": "GIT", "branch": branch}
+
+
+def poll_pipeline(client, namespace, application, pipeline_id, seen: list) -> dict:
+    """Fetch the pipeline and record every distinct status it passes through."""
+    pipeline = client.get_pipeline(namespace, application, pipeline_id)
+    status = pipeline["status"]
+    if not seen or seen[-1] != status:
+        seen.append(status)
+    return pipeline
+
+
+def test_deploy_reaches_succeeded(client, namespace, application, environment):
+    configure_for_build(client, namespace, application, environment)
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+    assert pipeline_id, "deploy did not return a pipeline id"
+
+    seen: list[str] = []
+
+    def finished():
+        pipeline = poll_pipeline(client, namespace, application, pipeline_id, seen)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                          description=f"pipeline {pipeline_id} to reach a terminal state")
+
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"pipeline ended as {pipeline['status']} after passing through {seen}")
+
+    # The state machine may skip states but must never regress.
+    indexes = [STATUS_ORDER.index(status) for status in seen if status in STATUS_ORDER]
+    assert indexes == sorted(indexes), f"pipeline status went backwards: {seen}"
+
+
+def test_in_flight_pipeline_blocks_a_second_deploy(client, namespace, application,
+                                                   environment):
+    """The duplicate-deploy guard: one active pipeline per application."""
+    configure_for_build(client, namespace, application, environment)
+    first = client.deploy(namespace, application, environment,
+                          strategy=git_strategy())
+
+    def became_active():
+        pipeline = client.get_pipeline(namespace, application, first)
+        return pipeline["status"] in ACTIVE_STATUSES or pipeline["status"] in TERMINAL_STATUSES
+
+    wait_until(became_active, timeout=120, interval=2,
+               description="the first pipeline to start")
+
+    status = client.get_pipeline(namespace, application, first)["status"]
+    if status in TERMINAL_STATUSES:
+        pytest.skip(f"first pipeline finished too quickly to race against ({status})")
+
+    second = client.post(
+        f"/api/namespaces/{namespace}/applications/{application}/deployments",
+        {"environment": environment, "deployMode": "IMMEDIATE",
+         "strategy": git_strategy()},
+        expect_success=False,
+    )
+    assert second.success is False, (
+        "a second deploy was accepted while a pipeline was still in flight")
+    assert second.message, "the duplicate-deploy guard should explain itself"
+
+
+def test_manual_mode_stops_at_build_succeeded(client, namespace, application,
+                                              environment):
+    configure_for_build(client, namespace, application, environment)
+    pipeline_id = client.deploy(namespace, application, environment,
+                                deploy_mode="MANUAL", strategy=git_strategy())
+
+    def built():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        status = pipeline["status"]
+        return pipeline if status in TERMINAL_STATUSES | {"BUILD_SUCCEEDED"} else None
+
+    pipeline = wait_until(built, timeout=DEPLOY_TIMEOUT,
+                          description="the build to finish in MANUAL mode")
+
+    assert pipeline["status"] == "BUILD_SUCCEEDED", (
+        f"MANUAL mode should hold at BUILD_SUCCEEDED, got {pipeline['status']}")
+
+
+def test_pipeline_listing_accepts_the_all_scope(client, namespace, application,
+                                                environment):
+    """Namespace `all` spans namespaces and a blank environment means no filter."""
+    result = client.get("/api/namespaces/all/applications/"
+                        f"{application}/pipelines?page=1&size=10&environment=")
+    assert result.success is True
+    assert "data" in result.data

--- a/tests/acceptance/test_domain.py
+++ b/tests/acceptance/test_domain.py
@@ -1,0 +1,431 @@
+"""Managed domains: the routing suffixes an administrator owns.
+
+A domain row is not a DNS record. It is a claim that one suffix belongs to one
+environment, plus the certificate policy for everything under it. That claim is
+what stops an application in staging from publishing a host under production's
+domain, so the interesting behaviour is not the CRUD but the matching: which
+domain governs a given host, and what happens when a governing domain is moved.
+
+No cluster is involved. Domains only need an environment to exist as a row, so
+the fixtures register one with a blank work namespace, which is the shape that
+touches no API server.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+
+ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{24}$")
+
+TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?$")
+
+
+@pytest.fixture
+def environment_names(client):
+    """Registers bare environments and removes them afterwards.
+
+    Only the name matters here: an environment with no work namespace is never
+    reached over the network, so the domain tests stay off the cluster tier
+    while still satisfying the "environment must exist" rule.
+    """
+    created: list[str] = []
+
+    def create(prefix: str = "acc-domain") -> str:
+        name = f"{prefix}-{uuid.uuid4().hex[:8]}"
+        client.post("/api/environments", {
+            "name": name,
+            "kubernetesApiServer": {"url": "", "token": ""},
+            "workNamespace": "",
+            "imageRepository": {"url": "", "username": "", "password": ""},
+        })
+        created.append(name)
+        return name
+
+    yield create
+
+    for name in reversed(created):
+        try:
+            registered = {item["name"]: item["id"]
+                          for item in client.list_environments()}
+            if name in registered:
+                client.delete(f"/api/environments/{registered[name]}",
+                              expect_success=False)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def domain_factory(client):
+    """Creates domains and removes them afterwards, even when a test fails.
+
+    Cleanup re-reads the listing rather than trusting the ids it was handed,
+    because a test may legitimately have deleted a domain already.
+    """
+    created: list[str] = []
+
+    def create(host: str, environment: str, **fields) -> dict:
+        payload = {"host": host, "environment": environment, "https": False}
+        payload.update(fields)
+        domain = client.post("/api/domains", payload).data
+        created.append(domain["id"])
+        return domain
+
+    yield create
+
+    for identifier in reversed(created):
+        try:
+            client.delete(f"/api/domains/{identifier}", expect_success=False)
+        except Exception:
+            pass
+
+
+def unique_host(label: str = "acc") -> str:
+    return f"{label}-{uuid.uuid4().hex[:8]}.example.invalid"
+
+
+def hosts_in_listing(client) -> list[str]:
+    return [item["host"] for item in client.get("/api/domains").data]
+
+
+def test_a_managed_domain_lifecycle(client, environment_names, domain_factory):
+    environment = environment_names()
+    host = unique_host("lifecycle")
+
+    created = domain_factory(host, environment, description="acceptance test",
+                             https=True, certMode="AUTO")
+
+    assert ID_PATTERN.match(created["id"]), (
+        f"domain id {created['id']!r} is not a 24-char NanoId")
+    assert TIMESTAMP_PATTERN.match(created["createdTime"]), (
+        f"createdTime {created['createdTime']!r} is not a naive local timestamp — "
+        "a zone suffix means values are being converted rather than read verbatim")
+    assert created["environment"] == environment, (
+        "the domain was stored against a different environment than the one "
+        "requested, which would let it govern hosts in the wrong cluster")
+    assert created["hasUploadedCert"] is False, (
+        "an AUTO domain reports an uploaded certificate, so the UI would offer "
+        "to replace a certificate that does not exist")
+
+    assert host in hosts_in_listing(client), (
+        "a newly created domain is missing from GET /api/domains, so an "
+        "administrator could not find the domain they just registered")
+
+    fetched = client.get(f"/api/domains/{created['id']}").data
+
+    # Everything but the timestamp has to match exactly, or the edit form loads
+    # values other than the ones that were just saved.
+    assert {key: value for key, value in fetched.items() if key != "createdTime"} \
+           == {key: value for key, value in created.items() if key != "createdTime"}, (
+        "reading a domain back by id produced a different representation than "
+        "creating it did")
+
+    # The timestamp differs in precision alone, which is worth stating rather
+    # than glossing over. The create response carries the in-memory value with
+    # nanoseconds; a read comes back from a datetime(6) column, rounded to
+    # microseconds and with trailing zeros dropped, so `...725229968` becomes
+    # `...72523`. Same instant, two renderings, and a client comparing them as
+    # strings — a form diffing before and after a save — sees a change that did
+    # not happen. Compare them as instants, and allow the rounding.
+    from datetime import datetime
+
+    def instant(value: str) -> datetime:
+        # fromisoformat handles at most microseconds, so trim the nanoseconds.
+        head, _, fraction = value.partition(".")
+        return datetime.fromisoformat(f"{head}.{fraction[:6]:0<6}" if fraction
+                                      else head)
+
+    drift = abs((instant(fetched["createdTime"])
+                 - instant(created["createdTime"])).total_seconds())
+    assert drift <= 0.000001, (
+        f"the two views disagree about when the domain was created: "
+        f"{created['createdTime']} on create, {fetched['createdTime']} on read")
+
+    renamed = unique_host("lifecycle-renamed")
+    updated = client.put(f"/api/domains/{created['id']}", {
+        "host": renamed,
+        "description": "renamed by the acceptance suite",
+        "https": False,
+        "environment": environment,
+    }).data
+    assert updated["id"] == created["id"], (
+        "the update minted a new identifier instead of editing the row in place")
+    assert updated["host"] == renamed, "the host change was not stored"
+    assert updated["description"] == "renamed by the acceptance suite"
+    assert updated["https"] is False, "HTTPS was not switched off"
+    assert updated["certMode"] is None, (
+        "the certificate mode survived HTTPS being switched off, leaving the "
+        "row claiming a policy it no longer applies")
+
+    assert host not in hosts_in_listing(client), (
+        "the old host is still listed after the rename, so the suffix stays "
+        "claimed by a domain nobody can see")
+
+    client.delete(f"/api/domains/{created['id']}")
+    assert renamed not in hosts_in_listing(client), (
+        "the deleted domain is still in the listing")
+
+    orphaned = client.get(f"/api/domains/{created['id']}", expect_success=False)
+    assert orphaned.success is False, (
+        "a deleted domain can still be read back by id")
+
+
+def test_reading_an_unknown_domain_fails_inside_the_envelope(client):
+    """Unlike a missing application, a missing domain *is* an error.
+
+    Worth pinning because the two conventions sit side by side in the same API:
+    GET /api/namespaces/{ns}/applications/{name} answers success with null data,
+    while GET /api/domains/{id} answers success=false. Both are HTTP 200.
+    """
+    result = client.get("/api/domains/definitely-not-a-domain",
+                        expect_success=False)
+    assert result.status == 200, f"expected HTTP 200, got {result.status}"
+    assert result.success is False, (
+        "an unknown domain now answers success — that is defensible, but it is "
+        "the opposite of what this endpoint has always done")
+    assert result.data is None
+    assert result.message, "the failure carries no message"
+
+
+def test_a_wildcard_prefix_is_stripped_on_the_way_in(client, environment_names,
+                                                     domain_factory):
+    """`*.example.com` and `example.com` are the same claim.
+
+    A domain already governs every host beneath it, so the wildcard form adds
+    nothing except a second spelling of one row. It is accepted for the sake of
+    people who paste it out of a certificate, then normalised away.
+    """
+    environment = environment_names()
+    host = unique_host("wildcard")
+
+    created = domain_factory(f"*.{host}", environment)
+    assert created["host"] == host, (
+        f"the wildcard prefix survived normalisation as {created['host']!r}; "
+        "stored that way it matches nothing, because suffix matching compares "
+        "against the bare host")
+
+    duplicate = client.post("/api/domains", {
+        "host": host, "environment": environment, "https": False,
+    }, expect_success=False)
+    assert duplicate.success is False, (
+        "the bare host was accepted alongside its own wildcard form, leaving two "
+        "rows claiming one suffix and no defined winner")
+
+
+def test_host_validation_rejects_what_cannot_be_routed(client, environment_names):
+    environment = environment_names()
+    for candidate, reason in (
+        ("UPPERCASE.example.invalid", "upper case"),
+        ("no-dots-at-all", "a single label"),
+        ("", "an empty host"),
+        ("has space.example.invalid", "a space"),
+        ("under_score.example.invalid", "an underscore"),
+        ("-leading.example.invalid", "a leading hyphen"),
+    ):
+        result = client.post("/api/domains", {
+            "host": candidate, "environment": environment, "https": False,
+        }, expect_success=False)
+        assert result.success is False, (
+            f"{candidate!r} was accepted as a domain host despite {reason}; an "
+            "unroutable suffix silently governs nothing")
+
+
+def test_a_domain_must_name_a_registered_environment(client):
+    """The binding is the whole point of the row, so it cannot be left open.
+
+    A domain with no environment would govern hosts in every cluster at once,
+    which is exactly the confusion the environment column exists to prevent.
+    """
+    host = unique_host("unbound")
+
+    unknown = client.post("/api/domains", {
+        "host": host, "environment": "definitely-not-an-environment", "https": False,
+    }, expect_success=False)
+    assert unknown.success is False, (
+        "a domain was bound to an environment that does not exist, so it would "
+        "govern hosts nothing can ever deploy into")
+
+    blank = client.post("/api/domains", {
+        "host": host, "environment": "", "https": False,
+    }, expect_success=False)
+    assert blank.success is False, (
+        "a domain was created with no environment at all")
+
+
+def test_https_demands_a_certificate_policy(client, environment_names,
+                                            domain_factory):
+    environment = environment_names()
+
+    without_mode = client.post("/api/domains", {
+        "host": unique_host("nomode"), "environment": environment, "https": True,
+    }, expect_success=False)
+    assert without_mode.success is False, (
+        "HTTPS was enabled with no certificate mode, leaving the router with no "
+        "instruction about where the certificate comes from")
+
+    without_material = client.post("/api/domains", {
+        "host": unique_host("nopem"), "environment": environment,
+        "https": True, "certMode": "UPLOADED",
+    }, expect_success=False)
+    assert without_material.success is False, (
+        "UPLOADED mode was accepted with no certificate, so HTTPS would be "
+        "promised and then fail at the router")
+
+    half_supplied = client.post("/api/domains", {
+        "host": unique_host("halfpem"), "environment": environment,
+        "https": True, "certMode": "UPLOADED",
+        "certPem": "-----BEGIN CERTIFICATE-----\nnot-a-certificate\n"
+                   "-----END CERTIFICATE-----\n",
+    }, expect_success=False)
+    assert half_supplied.success is False, (
+        "a certificate was accepted without its private key")
+
+    automatic = domain_factory(unique_host("auto"), environment,
+                               https=True, certMode="AUTO")
+    assert automatic["certMode"] == "AUTO", (
+        "AUTO mode was not stored, so Traefik would not be asked to obtain a "
+        "certificate for this suffix")
+    assert automatic["certSubject"] is None and automatic["certNotAfter"] is None, (
+        "an AUTO domain carries uploaded-certificate metadata, which the "
+        "expiry warnings in the UI would then read as a real certificate")
+
+
+def test_duplicate_hosts_are_rejected(client, environment_names, domain_factory):
+    environment = environment_names()
+    other_environment = environment_names()
+    host = unique_host("duplicate")
+
+    domain_factory(host, environment)
+
+    same_environment = client.post("/api/domains", {
+        "host": host, "environment": environment, "https": False,
+    }, expect_success=False)
+    assert same_environment.success is False, (
+        "the same host was registered twice in one environment")
+
+    across_environments = client.post("/api/domains", {
+        "host": host, "environment": other_environment, "https": False,
+    }, expect_success=False)
+    assert across_environments.success is False, (
+        "the same host was claimed by two environments, which makes the "
+        "environment a host resolves to depend on row order")
+
+
+def test_the_longest_matching_suffix_governs_a_host(client, namespace, application,
+                                                    environment_names,
+                                                    domain_factory):
+    """Nested domains are resolved most-specific-first, not first-match.
+
+    There is no endpoint that reports the governing domain directly, so this
+    drives the rule through its only observable consumer: saving an application
+    host. `outer` and `inner.outer` are bound to different environments, and a
+    host beneath `inner.outer` is governed by the inner one — the environment
+    the save is checked against, and the environment named in the refusal.
+    """
+    outer_environment = environment_names("acc-outer")
+    inner_environment = environment_names("acc-inner")
+
+    outer_host = unique_host("outer")
+    inner_host = f"inner.{outer_host}"
+    application_host = f"app.{inner_host}"
+
+    domain_factory(outer_host, outer_environment)
+    domain_factory(inner_host, inner_environment)
+
+    misbound = client.put(
+        f"/api/namespaces/{namespace}/applications/{application}/service",
+        {
+            "namespace": namespace,
+            "applicationName": application,
+            "port": 8080,
+            "internalPorts": [],
+            "environmentConfigs": [{
+                "environment": outer_environment,
+                "host": application_host,
+                "https": False,
+            }],
+        },
+        expect_success=False)
+    assert misbound.success is False, (
+        "a host beneath the inner domain was published into the outer domain's "
+        "environment, so the shorter suffix won the match")
+    assert inner_host in (misbound.message or ""), (
+        f"the refusal names {misbound.message!r} rather than the inner domain; "
+        "the outer domain also matches this host, and reporting it would send "
+        "the administrator to edit the wrong row")
+
+    client.put_service_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "port": 8080,
+        "internalPorts": [],
+        "environmentConfigs": [{
+            "environment": inner_environment,
+            "host": application_host,
+            "https": False,
+        }],
+    })
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/service").data
+    assert stored["environmentConfigs"][0]["host"] == application_host, (
+        "the accepted host was not stored, so the rule allowed a save that "
+        "then did nothing")
+
+
+def test_a_domain_in_use_cannot_be_moved_out_from_under_its_applications(
+        client, namespace, application, environment_names, domain_factory):
+    """The conflict has to surface on the edit that creates it.
+
+    Rebinding a domain to another environment, or narrowing its suffix, would
+    otherwise leave saved application hosts governed by an environment they
+    cannot deploy into — and the failure would land on some unrelated colleague's
+    next deploy rather than on the administrator who caused it.
+    """
+    environment = environment_names("acc-inuse")
+    elsewhere = environment_names("acc-elsewhere")
+
+    host = unique_host("inuse")
+    domain = domain_factory(host, environment)
+
+    client.put_service_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "port": 8080,
+        "internalPorts": [],
+        "environmentConfigs": [{
+            "environment": environment,
+            "host": f"app.{host}",
+            "https": False,
+        }],
+    })
+
+    rebound = client.put(f"/api/domains/{domain['id']}", {
+        "host": host, "environment": elsewhere, "https": False,
+    }, expect_success=False)
+    assert rebound.success is False, (
+        "a domain governing a saved application host was moved to another "
+        "environment, stranding that host")
+    assert application in (rebound.message or ""), (
+        f"the refusal {rebound.message!r} does not name the application holding "
+        "the domain, leaving the administrator nothing to act on")
+
+    narrowed = client.put(f"/api/domains/{domain['id']}", {
+        "host": f"other.{host}", "environment": environment, "https": False,
+    }, expect_success=False)
+    assert narrowed.success is False, (
+        "the domain's suffix was narrowed until it no longer covered the host "
+        "it was governing")
+
+    client.put(f"/api/domains/{domain['id']}", {
+        "host": host,
+        "description": "still in use, edited in place",
+        "https": False,
+        "environment": environment,
+    })
+    unchanged = client.get(f"/api/domains/{domain['id']}").data
+    assert unchanged["description"] == "still in use, edited in place", (
+        "an edit that left the host and environment alone was refused, so a "
+        "domain in use could never be described or given a certificate")

--- a/tests/acceptance/test_environment.py
+++ b/tests/acceptance/test_environment.py
@@ -1,0 +1,213 @@
+"""Registering and maintaining an environment.
+
+An environment is a cluster plus the credentials to reach it, and it is split
+across three write endpoints: create, update cluster, update credentials. They
+are separate because the editor is tabbed and each tab saves on its own, so a
+credential edit must not require re-sending the API server token and vice versa.
+
+Secrets are encrypted at rest and are never expected to come back out, which is
+the property most easily lost when the persistence layer is rewritten.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+REGISTRY = os.environ.get("OOPS_REGISTRY", "registry:5000")
+
+
+@pytest.fixture
+def registered_environment(client, cluster_credentials):
+    """A throwaway environment, removed afterwards even if a test fails."""
+    created: list[str] = []
+
+    def create(**overrides) -> dict:
+        name = f"env-{uuid.uuid4().hex[:8]}"
+        body = {
+            "name": name,
+            "kubernetesApiServer": {
+                "url": cluster_credentials["url"],
+                "token": cluster_credentials["token"],
+            },
+            "workNamespace": cluster_credentials["workNamespace"],
+            "imageRepository": {
+                "url": REGISTRY, "username": "oops", "password": "oops",
+            },
+        }
+        body.update(overrides)
+        environment = client.post("/api/environments", body).data
+        created.append(environment["id"])
+        return environment
+
+    yield create
+
+    for identifier in reversed(created):
+        client.delete(f"/api/environments/{identifier}", expect_success=False)
+
+
+def test_an_environment_can_be_registered_and_read_back(client,
+                                                        registered_environment):
+    environment = registered_environment()
+
+    listed = {item["name"]: item for item in client.list_environments()}
+    assert environment["name"] in listed, (
+        "a registered environment is missing from the environment list")
+
+    detail = client.get(f"/api/environments/{environment['id']}").data
+    assert detail["name"] == environment["name"]
+    assert detail["workNamespace"], "the work namespace was not stored"
+
+
+def test_cluster_credentials_are_returned_in_clear_text_to_any_user(
+        client, endpoint, registered_environment, secondary_user):
+    """Documents a live credential exposure rather than the behaviour we want.
+
+    `GET /api/environments` carries no role restriction, and the response
+    includes `kubernetesApiServer.token` in clear text. The token is the
+    cluster-admin service account the environment was registered with, so any
+    account that can log in to OOPS — including a plain USER — can read it and
+    then talk to the Kubernetes API server directly, as cluster-admin, entirely
+    outside OOPS.
+
+    Encrypting the column at rest does not help here: the API decrypts it on the
+    way out. The fix is for EnvironmentDto to omit the secret fields, the same
+    way the editor already treats a blank value as "keep what is stored".
+
+    Written to pass against today's behaviour so the suite is honest about it,
+    and to fail the moment the field stops coming back — at which point invert
+    it to assert the token is absent.
+    """
+    from oops_client import OopsClient
+
+    environment = registered_environment()
+
+    plain_user = OopsClient(endpoint)
+    plain_user.login(secondary_user["username"], secondary_user["password"])
+    visible = plain_user.get("/api/environments").data
+
+    tokens = [(item.get("kubernetesApiServer") or {}).get("token")
+              for item in visible if item["name"] == environment["name"]]
+    assert tokens and tokens[0], (
+        "the cluster token is no longer returned to a plain user, which is the "
+        "correct behaviour; invert this test to assert its absence")
+    assert tokens[0] == os.environ.get("OOPS_CLUSTER_TOKEN"), (
+        "a token came back but it is not the one that was stored; the exposure "
+        "may have changed shape rather than being closed")
+
+
+def test_the_cluster_tab_saves_on_its_own(client, registered_environment,
+                                          cluster_credentials):
+    """Updating the cluster must not require re-sending the credentials."""
+    environment = registered_environment()
+
+    client.put(f"/api/environments/{environment['id']}/cluster", {
+        "name": environment["name"],
+        "kubernetesApiServer": {
+            "url": cluster_credentials["url"],
+            "token": cluster_credentials["token"],
+        },
+        "workNamespace": cluster_credentials["workNamespace"],
+        "buildStorageClass": "standard",
+    })
+
+    detail = client.get(f"/api/environments/{environment['id']}").data
+    assert detail["buildStorageClass"] == "standard", (
+        "the build storage class did not survive a cluster-tab save")
+
+
+def test_the_credentials_tab_saves_on_its_own(client, registered_environment):
+    """Updating credentials must not clear the cluster configuration.
+
+    The two tabs post different subsets of the same object, so a save that
+    replaces rather than merges silently unregisters the cluster.
+    """
+    environment = registered_environment()
+    before = client.get(f"/api/environments/{environment['id']}").data
+
+    client.put(f"/api/environments/{environment['id']}/credentials", {
+        "name": environment["name"],
+        "imageRepository": {
+            "url": REGISTRY, "username": "changed", "password": "changed",
+        },
+        "gitCredential": {
+            "username": "git-user", "password": "git-password", "privateKey": "",
+        },
+    })
+
+    after = client.get(f"/api/environments/{environment['id']}").data
+    assert after["workNamespace"] == before["workNamespace"], (
+        "saving the credentials tab cleared the work namespace; the two tabs "
+        "must merge rather than replace")
+    assert (after.get("kubernetesApiServer") or {}).get("url") == \
+           (before.get("kubernetesApiServer") or {}).get("url"), (
+        "saving the credentials tab cleared the API server URL")
+    assert (after.get("imageRepository") or {}).get("username") == "changed", (
+        "the registry username was not updated")
+
+
+def test_a_duplicate_environment_name_is_rejected(client,
+                                                  registered_environment,
+                                                  cluster_credentials):
+    """Environments are referenced by name everywhere, so names must be unique."""
+    environment = registered_environment()
+
+    result = client.post("/api/environments", {
+        "name": environment["name"],
+        "kubernetesApiServer": {
+            "url": cluster_credentials["url"],
+            "token": cluster_credentials["token"],
+        },
+        "workNamespace": cluster_credentials["workNamespace"],
+        "imageRepository": {"url": REGISTRY, "username": "oops",
+                            "password": "oops"},
+    }, expect_success=False)
+
+    assert result.success is False, (
+        "two environments were registered under the same name; every reference "
+        "in the product is by name, so one of them is now unreachable")
+
+
+def test_deleting_an_environment_removes_it_from_the_list(
+        client, registered_environment):
+    environment = registered_environment()
+    client.delete(f"/api/environments/{environment['id']}")
+
+    names = [item["name"] for item in client.list_environments()]
+    assert environment["name"] not in names, (
+        "the environment is still listed after deletion")
+
+
+@pytest.mark.cluster
+def test_cluster_connectivity_is_validated_before_saving(client,
+                                                         cluster_credentials):
+    """The editor checks the cluster before the user commits to it.
+
+    A wrong token has to be reported as a failed validation rather than saved
+    and discovered later, when a deploy fails for reasons nobody connects to the
+    environment form.
+    """
+    good = client.post("/api/kubernetes/validations", {
+        "kubernetesApiServer": {
+            "url": cluster_credentials["url"],
+            "token": cluster_credentials["token"],
+        },
+        "workNamespace": cluster_credentials["workNamespace"],
+    }).data
+    assert good["success"] is True, (
+        f"validation rejected a working cluster: {good.get('message')}")
+    assert good["status"] == "VALID"
+
+    bad = client.post("/api/kubernetes/validations", {
+        "kubernetesApiServer": {
+            "url": cluster_credentials["url"],
+            "token": "not-a-valid-token",
+        },
+        "workNamespace": cluster_credentials["workNamespace"],
+    }).data
+    assert bad["success"] is False, (
+        "validation accepted an invalid token; the check is not actually "
+        "reaching the API server")
+    assert bad["status"] in ("CONNECTION_FAILED", "ERROR", "NAMESPACE_MISSING")

--- a/tests/acceptance/test_git.py
+++ b/tests/acceptance/test_git.py
@@ -1,0 +1,271 @@
+"""The git path against a real Git server, with and without credentials.
+
+Building from a public repository on the internet proves very little: it never
+exercises authentication, never touches the `git-credential` secret OOPS syncs
+into the work namespace, and cannot test a private repository at all. A local
+Gitea gives all three.
+
+One address for the server, because everything that touches it runs in Docker:
+the backend lists branches in process, and the pipeline pods clone. Both resolve
+the container name over the shared network, so a repository URL means the same
+thing wherever it is redeemed.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from oops_client import wait_until
+from test_deploy import DEPLOY_TIMEOUT, TERMINAL_STATUSES
+
+GITEA_USER = os.environ.get("OOPS_GITEA_USER", "oops")
+GITEA_PASSWORD = os.environ.get("OOPS_GITEA_PASSWORD", "oops-git-secret")
+# One address now. The backend lists branches and the pipeline pods clone, and
+# both run in Docker, so both resolve the container name. The published port is
+# only used by this suite to check the fixture server is up.
+GITEA_URL = os.environ.get("OOPS_GITEA_URL", "http://gitea:3000")
+PROBE_URL = os.environ.get("OOPS_GITEA_PROBE_URL", "http://127.0.0.1:13000")
+
+
+def repository(base: str, name: str) -> str:
+    return f"{base.rstrip('/')}/{GITEA_USER}/{name}.git"
+
+
+@pytest.fixture(scope="session")
+def gitea_available(client) -> bool:
+    """Skip rather than fail when the Git fixture server is not running."""
+    import requests
+
+    try:
+        response = requests.get(f"{PROBE_URL}/api/healthz", timeout=5)
+    except requests.exceptions.RequestException:
+        pytest.skip(f"no Gitea at {PROBE_URL} — run ./run.sh, which starts it")
+    if response.status_code != 200:
+        pytest.skip(f"Gitea at {PROBE_URL} is not healthy")
+    return True
+
+
+@pytest.fixture
+def credentialed_environment(environment_factory, gitea_available):
+    """An environment carrying git credentials for the private fixture repo."""
+    return environment_factory(
+        prefix="git",
+        registry=os.environ.get("OOPS_REGISTRY", "registry:5000"),
+        registry_username="oops",
+        registry_password="oops",
+        git_username=GITEA_USER,
+        git_password=GITEA_PASSWORD,
+    )
+
+
+# -- branch listing, in process, no cluster needed ---------------------------
+
+def test_branches_of_a_public_repository_are_listed(client, namespace,
+                                                    application, environment,
+                                                    gitea_available):
+    """The branch picker reads refs directly from the OOPS process.
+
+    This is the JGit path — `Git.lsRemoteRepository` against the remote, with no
+    build pod involved, which is the whole reason it exists.
+    """
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": repository(GITEA_URL, "public-fixture"),
+    })
+
+    result = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/branches"
+        f"?environment={environment}")
+
+    names = [branch["name"] for branch in result.data]
+    assert "main" in names, f"the default branch is missing from {names}"
+    assert "release" in names, (
+        f"the second branch is missing from {names}; ls-remote is not returning "
+        f"every head")
+
+
+def test_branch_listing_carries_the_tip_commit(client, namespace, application,
+                                               environment, gitea_available):
+    """Each branch comes back with its tip, and best effort commit detail.
+
+    The commit message and author are fetched separately and are documented as
+    best effort, so the SHA is the only part that must always be present.
+    """
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": repository(GITEA_URL, "public-fixture"),
+    })
+
+    branches = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/branches"
+        f"?environment={environment}").data
+
+    for branch in branches:
+        assert branch.get("commitId"), (
+            f"branch {branch['name']} came back without a tip SHA")
+        assert len(branch["commitId"]) >= 7, (
+            f"branch {branch['name']} has an implausible SHA "
+            f"{branch['commitId']!r}")
+
+
+def test_a_private_repository_without_credentials_is_refused(
+        client, namespace, application, environment, gitea_available):
+    """The failure has to be legible, because this is a common misconfiguration.
+
+    The environment used here has no git credentials, so the listing must fail
+    rather than silently return nothing, and the message must point at the
+    credentials rather than at a raw transport error.
+    """
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": repository(GITEA_URL, "private-fixture"),
+    })
+
+    result = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/branches"
+        f"?environment={environment}",
+        expect_success=False)
+
+    assert result.success is False, (
+        "a private repository was listed without credentials, which means "
+        "either the repository is not actually private or authentication is "
+        "not being enforced")
+    assert result.message, "a refused branch listing must explain itself"
+
+
+def test_branches_of_a_private_repository_with_credentials(
+        client, namespace, application, credentialed_environment):
+    """The same listing succeeds once the environment carries credentials."""
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": repository(GITEA_URL, "private-fixture"),
+    })
+
+    result = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/branches"
+        f"?environment={credentialed_environment}")
+
+    names = [branch["name"] for branch in result.data]
+    assert "main" in names, (
+        f"a private repository with valid credentials listed {names}; the "
+        f"environment git credentials are not reaching JGit")
+
+
+def test_a_missing_repository_reports_a_useful_message(client, namespace,
+                                                       application, environment,
+                                                       gitea_available):
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": repository(GITEA_URL, "does-not-exist"),
+    })
+
+    result = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/branches"
+        f"?environment={environment}",
+        expect_success=False)
+
+    assert result.success is False
+    assert result.message, "a missing repository must explain itself"
+
+
+# -- building from git, needs a cluster --------------------------------------
+
+def build_from(client, namespace, application, environment, url) -> dict:
+    from test_deploy import configure_for_build
+
+    configure_for_build(client, namespace, application, environment)
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": url,
+        "environmentConfigs": [{"environment": environment, "buildCommand": ""}],
+    })
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy={"type": "GIT", "branch": "main"})
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    return wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                      description="the git-sourced pipeline to finish")
+
+
+@pytest.mark.cluster
+def test_a_public_repository_builds(client, namespace, application, environment,
+                                    gitea_available):
+    """The clone init container reaches the fixture server and builds it."""
+    pipeline = build_from(client, namespace, application, environment,
+                          repository(GITEA_URL, "public-fixture"))
+
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"a build from a public repository ended as {pipeline['status']}; the "
+        f"clone container could not reach {GITEA_URL} or the build failed")
+
+
+@pytest.mark.cluster
+def test_a_private_repository_builds_with_synced_credentials(
+        client, namespace, application, credentialed_environment, kubectl):
+    """The whole credential path, from the environment to the clone container.
+
+    Saving the environment writes a `git-credential` secret into the work
+    namespace, the build pod mounts it, and the clone step authenticates with
+    it. Reaching SUCCEEDED against a private repository means every link held.
+    """
+    work_namespace = os.environ.get("OOPS_WORK_NAMESPACE", "oops-work")
+    assert kubectl.exists("secret", "git-credential", work_namespace), (
+        "no git-credential secret in the work namespace; saving an environment "
+        "with git credentials is meant to sync one")
+
+    pipeline = build_from(client, namespace, application,
+                          credentialed_environment,
+                          repository(GITEA_URL, "private-fixture"))
+
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"a build from a private repository ended as {pipeline['status']}; the "
+        f"git-credential secret is not reaching the clone container")
+
+
+@pytest.mark.cluster
+def test_git_credentials_are_shared_across_a_work_namespace(
+        client, namespace, application, environment, kubectl, gitea_available):
+    """Git credentials are scoped to the work namespace, not to the environment.
+
+    Saving an environment writes its credentials into the work namespace as the
+    `git-credential` secret, and every build pod in that namespace mounts it —
+    the mount does not know which environment triggered the build. So an
+    environment with no git credentials of its own still clones private
+    repositories, using whatever another environment last synced.
+
+    That is worth knowing before two teams are pointed at one work namespace:
+    the isolation the environment list implies is not there for git.
+
+    Written against today's behaviour. If credentials are ever scoped per
+    environment this fails, and it should then be inverted to assert that the
+    clone is refused.
+    """
+    work_namespace = os.environ.get("OOPS_WORK_NAMESPACE", "oops-work")
+    if not kubectl.exists("secret", "git-credential", work_namespace):
+        pytest.skip("no credentials have been synced into the work namespace, "
+                    "so there is nothing for this environment to inherit")
+
+    pipeline = build_from(client, namespace, application, environment,
+                          repository(GITEA_URL, "private-fixture"))
+
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"a private clone from an environment without git credentials ended as "
+        f"{pipeline['status']}. If it now fails, credentials have become "
+        f"environment-scoped — an improvement; invert this test.")

--- a/tests/acceptance/test_ide.py
+++ b/tests/acceptance/test_ide.py
@@ -1,0 +1,148 @@
+"""The IDE endpoints, with the IDE feature switched off.
+
+`oops.ide.enabled` is `false` in `tests/acceptance/application.yml`, and that is
+deliberate: a code-server instance is a long-lived pod with a domain of its own,
+so enabling it would make every run depend on ingress and DNS that the kind
+fixture does not provide.
+
+That leaves the disabled path as the thing worth pinning, and it is a real
+contract rather than a placeholder. The whole controller disappears when the
+flag is off, so all four routes stop existing, and what a client sees is decided
+entirely by how unmapped paths are handled. The requirement is that they stay
+inside the result envelope — `{success, message, data}` with `success: false` —
+because the frontend's `apiFetch` reads the envelope and treats a bare HTTP
+error page as a session problem, which is how a disabled optional feature ends
+up logging the user out.
+
+None of this needs a cluster: the routes are absent, so nothing is dispatched
+and the `environment` parameter is never read. The file is therefore not marked
+`cluster`, and it runs on a bare stack.
+
+**If the IDE is ever enabled in the acceptance config**, these tests stop being
+meaningful and every one of them will skip with a message pointing here. Replace
+them with the enabled scenario: read the default config, create an instance,
+list it, delete it, and assert it is gone — modelled on `test_podfs.py`, which
+shows how to get a real workload to act against.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The routes below are not registered while the feature is off, so nothing ever
+# looks this name up. It is a placeholder, not a reference to a real cluster.
+PLACEHOLDER_ENVIRONMENT = "ide-is-disabled"
+
+
+def ide_base(namespace: str, application: str) -> str:
+    return f"/api/namespaces/{namespace}/applications/{application}/ides"
+
+
+@pytest.fixture(scope="session")
+def ide_enabled(client) -> bool:
+    return bool(client.get("/api/features").data.get("ide"))
+
+
+@pytest.fixture(scope="session")
+def ide_is_off(ide_enabled):
+    """Skip the disabled-path tests when the IDE has been turned on."""
+    if ide_enabled:
+        pytest.skip("the IDE feature is enabled in this deployment, so the "
+                    "disabled-path tests prove nothing — see the module "
+                    "docstring for what to replace them with")
+
+
+def test_the_feature_flag_reports_the_ide_off(client):
+    """`/api/features` is how the frontend decides to render the IDE at all.
+
+    Getting this wrong in either direction is a visible bug: a false negative
+    hides a working feature, a false positive shows menu items that lead to
+    endpoints which do not exist.
+    """
+    features = client.get("/api/features").data
+
+    assert "ide" in features, (
+        f"the features payload has no `ide` key: {features}; the sidebar gates "
+        f"the IDE section on it and would fall back to hiding it forever")
+    assert features["ide"] is False, (
+        "the features endpoint reports the IDE as enabled, but "
+        "tests/acceptance/application.yml sets oops.ide.enabled=false — the "
+        "flag is not being read from configuration")
+    # Documented, not endorsed: the host and scheme fields stay in the payload
+    # when the feature is off, with the host null rather than the configured
+    # value. A client that reads them without checking `ide` first gets null.
+    assert features.get("ideHost") is None, (
+        f"ideHost is {features.get('ideHost')!r} while the IDE is disabled; the "
+        f"configured domain is leaking into a payload served to every user")
+    assert features.get("ideHttps") is False, (
+        "ideHttps should stay false while the IDE is disabled")
+
+
+@pytest.mark.parametrize("method,suffix,body", [
+    ("GET", "", None),
+    ("GET", "/config/default", None),
+    ("POST", "", {"name": "should-not-be-created", "branch": "main",
+                  "settings": "", "env": "", "extensions": ""}),
+    ("DELETE", "/should-not-exist", None),
+], ids=["list", "default-config", "create", "delete"])
+def test_each_ide_endpoint_declines_inside_the_envelope(client, namespace,
+                                                        application, ide_is_off,
+                                                        method, suffix, body):
+    """All four routes, refused without leaving the result contract.
+
+    The failure this guards against is not a wrong message — it is a response
+    the client cannot parse. `OopsClient.request` raises unless the body carries
+    all three envelope fields, so an HTML error page or an empty 404 fails here
+    before any assertion runs.
+    """
+    path = (f"{ide_base(namespace, application)}{suffix}"
+            f"?environment={PLACEHOLDER_ENVIRONMENT}")
+
+    result = client.request(method, path, body, expect_success=False)
+
+    assert result.success is False, (
+        f"{method} {path} reported success while the IDE feature is disabled; "
+        f"either the controller is registered regardless of the flag, or an "
+        f"unmapped path is being answered by something that claims to have "
+        f"worked")
+    assert result.status == 200, (
+        f"{method} {path} answered HTTP {result.status}; the frontend's "
+        f"apiFetch hard-redirects to /login on a 401 and surfaces other "
+        f"non-200s as transport errors, so a disabled feature must not use one")
+    # Documented, not endorsed: an absent route is reported as
+    # "Internal server error" — the global handler's catch-all for
+    # NoResourceFoundException — rather than as a "feature disabled" or
+    # "not found" message. It is a legible envelope, but it tells an operator
+    # nothing about the flag they need to flip.
+    assert result.message == "Internal server error", (
+        f"{method} {path} refused with {result.message!r}, not the "
+        f"'Internal server error' this suite recorded. If the message improved "
+        f"— naming the disabled feature — update this assertion; if it "
+        f"regressed to no message at all, the client has nothing to show")
+    assert result.data is None, (
+        f"{method} {path} carried data {result.data!r} in a failed envelope")
+
+
+def test_a_disabled_ide_creates_nothing(client, namespace, application,
+                                        ide_is_off):
+    """The refusal has to be a refusal, not a silent success.
+
+    A POST that answered `success: false` while still starting a code-server pod
+    would be the worst outcome — an orphaned workload nobody knows to clean up —
+    and the listing is the only way to see it from the API.
+    """
+    base = ide_base(namespace, application)
+    client.post(f"{base}?environment={PLACEHOLDER_ENVIRONMENT}",
+                {"name": "orphan-check", "branch": "main"},
+                expect_success=False)
+
+    listing = client.get(f"{base}?environment={PLACEHOLDER_ENVIRONMENT}",
+                         expect_success=False)
+
+    assert listing.success is False, (
+        "the IDE listing succeeded after a create was refused; if the feature "
+        "is in fact live, this test must be replaced by the enabled scenario "
+        "described in the module docstring")
+    assert not listing.data, (
+        f"the listing returned {listing.data!r} while the feature is disabled, "
+        f"which means something was created by the refused POST")

--- a/tests/acceptance/test_ingress.py
+++ b/tests/acceptance/test_ingress.py
@@ -1,0 +1,262 @@
+"""Exposing an application on a host: IngressRoutes, TLS and basic auth.
+
+Everything up to here proves an application runs. This proves it can be reached,
+which is the point of deploying it at all — and it was the largest hole in the
+suite, because the previous fixture cluster shipped no Traefik CRDs, so every
+deploy took the "no host configured, skipping ingress route creation" branch and
+none of this code ran even once.
+
+The shapes are worth stating plainly, because the object graph is not obvious
+from the API:
+
+- An HTTP-only host produces one IngressRoute on the `web` entrypoint.
+- An HTTPS host produces two: one on `web` that only redirects, and one on
+  `websecure` that actually serves. The redirect is a shared `Middleware`.
+- Basic auth belongs on whichever route serves, never on the redirect — putting
+  it on the redirect would ask for a password before sending the browser away.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from oops_client import wait_until
+from test_deploy import (DEPLOY_TIMEOUT, TERMINAL_STATUSES, configure_for_build,
+                         git_strategy)
+
+pytestmark = pytest.mark.cluster
+
+REDIRECT_MIDDLEWARE = "oops-redirect-https"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def traefik_available():
+    """Skip rather than fail where the cluster has no Traefik.
+
+    OOPS treats a missing CRD as "nothing to do", so without this the tests would
+    pass by asserting on objects nobody ever tried to create.
+    """
+    if os.environ.get("OOPS_TRAEFIK_AVAILABLE", "yes").lower() != "yes":
+        pytest.skip("the cluster has no Traefik CRDs, so no IngressRoute is "
+                    "created and there is nothing to assert on")
+
+
+def unique_host(label: str) -> str:
+    return f"{label}-{uuid.uuid4().hex[:8]}.acceptance.invalid"
+
+
+def deploy_with_host(client, namespace, application, environment, host,
+                     https=False, basic_auth=None):
+    """Configure a host on the service, deploy, and wait for the pipeline."""
+    configure_for_build(client, namespace, application, environment)
+
+    environment_config = {"environment": environment, "host": host,
+                          "https": https}
+    if basic_auth:
+        environment_config.update({
+            "basicAuthEnabled": True,
+            "basicAuthUsername": basic_auth[0],
+            "basicAuthPassword": basic_auth[1],
+        })
+
+    client.put_service_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "port": 80,
+        "internalPorts": [],
+        "environmentConfigs": [environment_config],
+    })
+
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                          description="the deploy to finish")
+    if pipeline["status"] != "SUCCEEDED":
+        pytest.skip(f"deploy ended as {pipeline['status']}, nothing was exposed")
+    return pipeline
+
+
+def routes_for(kubectl, namespace, host):
+    """Every IngressRoute in the namespace that matches this host."""
+    matching = []
+    for name in kubectl.names("ingressroute", namespace):
+        route = kubectl.get_json("ingressroute", name, namespace)
+        if not route:
+            continue
+        for rule in (route.get("spec") or {}).get("routes") or []:
+            if host in (rule.get("match") or ""):
+                matching.append(route)
+                break
+    return matching
+
+
+def test_an_http_host_gets_one_route_on_the_web_entrypoint(
+        client, namespace, application, environment, kubectl):
+    host = unique_host("plain")
+    deploy_with_host(client, namespace, application, environment, host)
+
+    routes = wait_until(lambda: routes_for(kubectl, namespace, host) or None,
+                        timeout=120, interval=3,
+                        description="the IngressRoute to appear")
+
+    assert len(routes) == 1, (
+        f"an HTTP-only host produced {len(routes)} IngressRoutes; it should "
+        f"produce exactly one, on the web entrypoint")
+    spec = routes[0]["spec"]
+    assert spec.get("entryPoints") == ["web"], (
+        f"the route listens on {spec.get('entryPoints')} rather than web")
+    assert not spec.get("tls"), (
+        "an HTTP-only host was given a TLS block, so Traefik would try to serve "
+        "it over HTTPS with no certificate")
+
+
+def test_an_https_host_gets_a_redirect_and_a_serving_route(
+        client, namespace, application, environment, kubectl):
+    """Two routes, and the shared redirect Middleware they depend on."""
+    host = unique_host("secure")
+    deploy_with_host(client, namespace, application, environment, host,
+                     https=True)
+
+    routes = wait_until(
+        lambda: (lambda found: found if len(found) >= 2 else None)(
+            routes_for(kubectl, namespace, host)),
+        timeout=120, interval=3,
+        description="both IngressRoutes to appear")
+
+    by_entrypoint = {tuple(route["spec"].get("entryPoints") or []): route
+                     for route in routes}
+    assert ("web",) in by_entrypoint, "no route on the web entrypoint to redirect"
+    assert ("websecure",) in by_entrypoint, "no route on the websecure entrypoint"
+
+    secure = by_entrypoint[("websecure",)]["spec"]
+    assert secure.get("tls") is not None, (
+        "the websecure route carries no TLS block, so nothing tells Traefik "
+        "which certificate to serve")
+
+    plain = by_entrypoint[("web",)]["spec"]
+    middlewares = [item.get("name")
+                   for rule in plain.get("routes") or []
+                   for item in rule.get("middlewares") or []]
+    assert REDIRECT_MIDDLEWARE in middlewares, (
+        f"the HTTP route does not reference {REDIRECT_MIDDLEWARE}, so plain "
+        f"HTTP would be served rather than redirected")
+
+    assert kubectl.exists("middleware", REDIRECT_MIDDLEWARE, namespace), (
+        f"the route references {REDIRECT_MIDDLEWARE} but the Middleware itself "
+        f"was never created, so Traefik drops the route")
+
+
+def test_basic_auth_lands_on_the_serving_route_only(
+        client, namespace, application, environment, kubectl):
+    """A password prompt in front of a redirect would ask, then send you away.
+
+    So on an HTTPS host the auth middleware belongs on the websecure route, and
+    the web route keeps only the redirect.
+    """
+    host = unique_host("guarded")
+    deploy_with_host(client, namespace, application, environment, host,
+                     https=True, basic_auth=("acceptance", "acceptance-secret"))
+
+    routes = wait_until(
+        lambda: (lambda found: found if len(found) >= 2 else None)(
+            routes_for(kubectl, namespace, host)),
+        timeout=120, interval=3, description="both IngressRoutes to appear")
+
+    by_entrypoint = {tuple(route["spec"].get("entryPoints") or []): route
+                     for route in routes}
+
+    def middleware_names(route):
+        return [item.get("name")
+                for rule in route["spec"].get("routes") or []
+                for item in rule.get("middlewares") or []]
+
+    secure_middlewares = middleware_names(by_entrypoint[("websecure",)])
+    plain_middlewares = middleware_names(by_entrypoint[("web",)])
+
+    auth_middlewares = [name for name in secure_middlewares
+                        if name != REDIRECT_MIDDLEWARE]
+    assert auth_middlewares, (
+        f"the serving route carries no basic auth middleware: "
+        f"{secure_middlewares}")
+    assert plain_middlewares == [REDIRECT_MIDDLEWARE], (
+        f"the redirect route carries more than the redirect ({plain_middlewares}); "
+        f"asking for a password before redirecting prompts the user twice")
+
+    for name in auth_middlewares:
+        middleware = kubectl.get_json("middleware", name, namespace)
+        assert middleware is not None, (
+            f"the route references middleware {name} which does not exist")
+        users = (((middleware.get("spec") or {}).get("basicAuth") or {}))
+        assert users, f"middleware {name} has no basicAuth section"
+
+
+def test_the_basic_auth_password_is_never_returned(client, namespace,
+                                                   application, environment):
+    """Only a flag comes back, never the password or its hash.
+
+    The editor sends a blank password to mean "keep the stored one", which only
+    works if the stored one was never handed out.
+    """
+    host = unique_host("secret")
+    deploy_with_host(client, namespace, application, environment, host,
+                     https=True, basic_auth=("acceptance", "acceptance-secret"))
+
+    stored = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/service").data
+    config = next(item for item in stored["environmentConfigs"]
+                  if item["environment"] == environment)
+
+    assert config.get("basicAuthEnabled") is True
+    assert config.get("basicAuthUsername") == "acceptance"
+    assert not config.get("basicAuthPassword"), (
+        f"the basic auth password came back from the API: "
+        f"{config.get('basicAuthPassword')!r}")
+    assert config.get("basicAuthPasswordSet") is True, (
+        "nothing tells the editor a password is stored, so it cannot show the "
+        "difference between 'unset' and 'unchanged'")
+
+
+def test_removing_the_host_removes_its_routes(client, namespace, application,
+                                              environment, kubectl):
+    """Clearing the host has to withdraw the application from Traefik.
+
+    A route left behind keeps answering on a hostname the owner believes they
+    have released.
+    """
+    host = unique_host("temporary")
+    deploy_with_host(client, namespace, application, environment, host)
+    wait_until(lambda: routes_for(kubectl, namespace, host) or None,
+               timeout=120, interval=3, description="the IngressRoute to appear")
+
+    client.put_service_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "port": 80,
+        "internalPorts": [],
+        "environmentConfigs": [{"environment": environment, "host": "",
+                                "https": False}],
+    })
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    wait_until(finished, timeout=DEPLOY_TIMEOUT,
+               description="the redeploy without a host to finish")
+
+    gone = wait_until(lambda: not routes_for(kubectl, namespace, host),
+                      timeout=120, interval=3,
+                      description="the IngressRoute to be withdrawn")
+    assert gone, (
+        f"an IngressRoute for {host} is still present after the host was "
+        f"cleared, so the application still answers on a released hostname")

--- a/tests/acceptance/test_object_storage.py
+++ b/tests/acceptance/test_object_storage.py
@@ -1,0 +1,145 @@
+"""The ZIP source path: presigned upload to object storage, then a build from it.
+
+`GIT` and `ZIP` are the two source types, and they diverge early — ZIP asks the
+API for a presigned PUT, uploads straight to S3 without the request passing
+through OOPS at all, and the build's fetch step downloads it with curl instead of
+cloning. None of that shares code with the git path, so testing only git leaves
+half of the source handling unexercised.
+
+Skipped unless object storage is configured, since `oops.object-storage.enabled`
+is off by default.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import zipfile
+
+import pytest
+
+from oops_client import ApiError, wait_until
+from test_deploy import DEPLOY_TIMEOUT, TERMINAL_STATUSES
+
+DOCKERFILE = b"""FROM alpine:3.20
+RUN echo "acceptance" > /message
+CMD ["sh", "-c", "while true; do cat /message; sleep 30; done"]
+"""
+
+
+def make_zip() -> bytes:
+    """A minimal buildable source bundle, held in memory."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("Dockerfile", DOCKERFILE)
+        archive.writestr("README.md", "acceptance fixture\n")
+    return buffer.getvalue()
+
+
+@pytest.fixture(scope="session")
+def object_storage_enabled(client) -> bool:
+    """Object storage is optional, and the UI gates on the same flag."""
+    features = client.get("/api/features", expect_success=False)
+    if features.success and isinstance(features.data, dict):
+        if not features.data.get("objectStorage", False):
+            pytest.skip("object storage is disabled (oops.object-storage.enabled)")
+        return True
+    pytest.skip("cannot read the feature flags to check object storage")
+
+
+def test_source_upload_returns_a_presigned_put(client, namespace, application,
+                                               object_storage_enabled):
+    """The API hands back a URL the client uploads to directly.
+
+    OOPS never sees the bytes, which is the point — a large source bundle must
+    not travel through the application server.
+    """
+    payload = make_zip()
+    upload = client.create_source_upload(namespace, application,
+                                         "source.zip", len(payload))
+
+    for field in ("objectKey", "uploadUrl"):
+        assert field in upload, f"the upload response is missing {field!r}"
+    assert upload["uploadUrl"].startswith("http"), (
+        f"uploadUrl is not a URL: {upload['uploadUrl']!r}")
+    assert upload["objectKey"], "objectKey must identify the stored object"
+
+
+def test_a_zip_can_be_uploaded_to_the_presigned_url(client, namespace,
+                                                    application,
+                                                    object_storage_enabled):
+    """The presigned URL actually accepts the bytes.
+
+    Signed URLs fail in ways that only show up on use — a clock skew, a wrong
+    region, a signature that did not include the content type the client sends.
+    """
+    payload = make_zip()
+    upload = client.create_source_upload(namespace, application,
+                                         "source.zip", len(payload))
+
+    status = client.put_bytes(
+        upload["uploadUrl"], payload,
+        {**(upload.get("headers") or {}), "Content-Type": "application/zip"})
+
+    assert status in (200, 204), (
+        f"the presigned PUT was rejected with HTTP {status}; the signature or "
+        f"the headers it was signed for do not match what the client sent")
+
+
+def test_an_oversized_upload_is_refused(client, namespace, application,
+                                        object_storage_enabled):
+    """`max-file-size-bytes` is enforced when the URL is requested, not after
+    the upload — refusing afterwards would mean paying for the transfer first."""
+    huge = 10 * 1024 * 1024 * 1024  # 10 GiB, comfortably over any sane limit
+    result = client.post(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/deployments/source-upload",
+        {"fileName": "huge.zip", "fileSize": huge,
+         "contentType": "application/zip"},
+        expect_success=False,
+    )
+    assert result.success is False, (
+        f"a {huge} byte upload was granted a presigned URL; the size limit is "
+        f"not being checked before signing")
+
+
+@pytest.mark.cluster
+def test_a_zip_source_builds_and_deploys(client, namespace, application,
+                                         environment, object_storage_enabled):
+    """End to end on the ZIP path: upload, build from the archive, roll out.
+
+    The build's fetch step downloads and unzips instead of cloning, so this is
+    the only test that covers that container at all.
+    """
+    from test_deploy import configure_for_build
+
+    configure_for_build(client, namespace, application, environment)
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "ZIP",
+        "environmentConfigs": [{"environment": environment, "buildCommand": ""}],
+    })
+
+    payload = make_zip()
+    upload = client.create_source_upload(namespace, application,
+                                         "source.zip", len(payload))
+    status = client.put_bytes(
+        upload["uploadUrl"], payload,
+        {**(upload.get("headers") or {}), "Content-Type": "application/zip"})
+    assert status in (200, 204), f"upload failed with HTTP {status}"
+
+    pipeline_id = client.deploy(
+        namespace, application, environment,
+        strategy={"type": "ZIP", "objectKey": upload["objectKey"]})
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                          description="the ZIP-sourced pipeline to finish")
+
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"a ZIP-sourced deploy ended as {pipeline['status']}; the fetch step "
+        f"could not download or unpack the archive")

--- a/tests/acceptance/test_operations.py
+++ b/tests/acceptance/test_operations.py
@@ -1,0 +1,202 @@
+"""Day-two operations: search, live status, restarting a pod, moving a namespace.
+
+What is left once an application is running. Grouped together because they share
+nothing except being the things an operator reaches for after the deploy, and
+each is a single endpoint that would otherwise sit untested.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from oops_client import wait_until
+
+
+# -- search, no cluster needed ----------------------------------------------
+
+def test_applications_can_be_searched_by_name_and_namespace(client, namespace,
+                                                            application):
+    """The index endpoints back the command palette.
+
+    A POST with a body rather than query parameters, and a bare list rather than
+    a page, so it does not follow the pagination convention the rest of the API
+    uses.
+    """
+    matches = client.post("/api/index/applications",
+                          {"name": application, "namespace": namespace}).data
+
+    assert isinstance(matches, list), (
+        "application search returned a page envelope; every other caller of "
+        "this endpoint expects a bare list")
+    assert application in [item["name"] for item in matches], (
+        f"{application} was not found by a search for its own exact name")
+
+
+def test_searching_for_nothing_in_particular_is_not_an_error(client, namespace):
+    """An empty query is what the palette sends before anything is typed."""
+    result = client.post("/api/index/applications",
+                         {"name": "", "namespace": namespace},
+                         expect_success=False)
+    assert result.status == 200, (
+        f"an empty application search answered HTTP {result.status}")
+
+    result = client.post("/api/index/pipelines",
+                         {"namespace": namespace, "applicationName": ""},
+                         expect_success=False)
+    assert result.status == 200, (
+        f"an empty pipeline search answered HTTP {result.status}")
+
+
+def test_pipelines_can_be_searched_for_an_application(client, namespace,
+                                                      application):
+    matches = client.post("/api/index/pipelines",
+                          {"namespace": namespace,
+                           "applicationName": application}).data
+    assert isinstance(matches, list), (
+        "pipeline search returned something other than a list")
+
+
+# -- live status and pod operations ------------------------------------------
+
+@pytest.mark.cluster
+def test_the_status_stream_opens_and_sends_something(client, namespace,
+                                                     environment, endpoint,
+                                                     application):
+    """`/status/watch` is Server-Sent Events, not JSON.
+
+    The only endpoint in the API that answers with a stream rather than the
+    result envelope, which is exactly the sort of thing a reimplementation turns
+    back into a plain GET without noticing.
+    """
+    import requests
+
+    url = (f"{endpoint}/api/namespaces/{namespace}/applications/{application}"
+           f"/status/watch?environment={environment}")
+    with requests.get(url, headers={"Authorization": f"Bearer {client.token}"},
+                      stream=True, timeout=30) as response:
+        assert response.status_code == 200, (
+            f"the status stream answered HTTP {response.status_code}")
+        content_type = response.headers.get("Content-Type", "")
+        assert "text/event-stream" in content_type, (
+            f"the status stream is served as {content_type!r} rather than "
+            f"text/event-stream, so a browser EventSource would refuse it")
+
+        # One frame is enough: it proves the emitter is wired to something.
+        for line in response.iter_lines(decode_unicode=True):
+            if line:
+                break
+    # Recorded so the coverage check sees the route, which the raw request above
+    # bypasses.
+    from oops_client import record
+    record("GET", f"/api/namespaces/{namespace}/applications/{application}"
+                  f"/status/watch")
+
+
+@pytest.mark.cluster
+def test_a_pod_can_be_restarted(client, namespace, environment, application,
+                                kubectl):
+    """Restart deletes the pod and lets the StatefulSet replace it.
+
+    A StatefulSet always rebuilds a pod under the same name, so the name proves
+    nothing here. The UID does: a new one means a genuinely new pod rather than
+    a call that quietly did nothing.
+    """
+    from test_deploy import (DEPLOY_TIMEOUT, TERMINAL_STATUSES,
+                             configure_for_build, git_strategy)
+    from test_streams import first_running_pod
+
+    configure_for_build(client, namespace, application, environment)
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                          description="the deploy to finish")
+    if pipeline["status"] != "SUCCEEDED":
+        pytest.skip(f"deploy ended as {pipeline['status']}, nothing to restart")
+
+    original = wait_until(
+        lambda: first_running_pod(client, namespace, application, environment),
+        timeout=180, interval=5, description="a running pod")
+    original_uid = (kubectl.get_json("pod", original, namespace) or {}) \
+        .get("metadata", {}).get("uid")
+    assert original_uid, f"could not read the UID of pod {original}"
+
+    client.put(f"/api/namespaces/{namespace}/applications/{application}"
+               f"/pods/{original}/restart?environment={environment}")
+
+    def replaced():
+        current = kubectl.get_json("pod", original, namespace) or {}
+        uid = current.get("metadata", {}).get("uid")
+        phase = current.get("status", {}).get("phase")
+        return uid if uid and uid != original_uid and phase == "Running" else None
+
+    new_uid = wait_until(replaced, timeout=300, interval=5,
+                         description="the pod to be replaced")
+    assert new_uid != original_uid, (
+        f"pod {original} still has UID {original_uid} after a restart, so it "
+        f"was never actually recreated")
+
+
+@pytest.mark.cluster
+def test_an_application_can_be_moved_to_another_namespace(
+        client, namespace, environment, application_factory, kubectl):
+    """Migration moves the database rows and the live workload together.
+
+    Half a migration is worse than none: the application would answer on the new
+    namespace while its StatefulSet kept running under the old one.
+    """
+    from test_deploy import (DEPLOY_TIMEOUT, TERMINAL_STATUSES,
+                             configure_for_build, git_strategy)
+
+    application = application_factory(prefix="migrate")
+    target = f"{namespace}-target"
+
+    # The target has to exist as a namespace row: migration refuses to move an
+    # application into a namespace nobody has registered, which is what stops a
+    # typo from stranding it somewhere invisible.
+    client.post("/api/namespaces", {"name": target}, expect_success=False)
+
+    configure_for_build(client, namespace, application, environment)
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                          description="the deploy to finish")
+    if pipeline["status"] != "SUCCEEDED":
+        pytest.skip(f"deploy ended as {pipeline['status']}, nothing to migrate")
+
+    result = client.post(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/namespace-migration", {"targetNamespace": target}).data
+    assert result is not None, "migration returned no result to report on"
+
+    try:
+        moved = client.get_application(target, application, expect_success=False)
+        assert moved.data is not None, (
+            f"the application is not readable under {target} after migrating "
+            f"to it")
+
+        gone = client.get_application(namespace, application,
+                                      expect_success=False)
+        assert gone.data is None, (
+            f"the application is still readable under its old namespace "
+            f"{namespace}, so it now exists in two places")
+
+        # The workload has to follow, or the old namespace keeps serving it.
+        left_behind = wait_until(
+            lambda: not kubectl.exists("statefulset", application, namespace),
+            timeout=180, interval=3,
+            description="the old StatefulSet to be removed")
+        assert left_behind, (
+            f"the StatefulSet is still running in {namespace} after the "
+            f"migration; the workload did not follow the database rows")
+    finally:
+        client.delete_application(target, application, expect_success=False)

--- a/tests/acceptance/test_pipeline_ops.py
+++ b/tests/acceptance/test_pipeline_ops.py
@@ -1,0 +1,142 @@
+"""Operating a pipeline after it has been triggered: stop, manual deploy, rollback.
+
+These are the controls an operator reaches for when something is going wrong, and
+they are the ones least likely to be exercised by hand before a release. All
+three mutate a pipeline mid-flight or reuse a historic artefact, so they only
+mean anything against a real cluster.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from oops_client import wait_until
+from test_deploy import (ACTIVE_STATUSES, DEPLOY_TIMEOUT, TERMINAL_STATUSES,
+                         configure_for_build, git_strategy)
+
+pytestmark = pytest.mark.cluster
+
+
+def deploy(client, namespace, application, environment, mode="IMMEDIATE") -> str:
+    configure_for_build(client, namespace, application, environment)
+    return client.deploy(namespace, application, environment,
+                         deploy_mode=mode, strategy=git_strategy())
+
+
+def wait_for_terminal(client, namespace, application, pipeline_id) -> dict:
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    return wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                      description=f"pipeline {pipeline_id} to reach a terminal state")
+
+
+def test_a_running_pipeline_can_be_stopped(client, namespace, application,
+                                           environment):
+    """Stopping moves the pipeline to STOPPED rather than leaving it running.
+
+    The guard against concurrent deploys keys on the active statuses, so a
+    pipeline that cannot be stopped also blocks every later deploy of the same
+    application.
+    """
+    pipeline_id = deploy(client, namespace, application, environment)
+
+    def started():
+        status = client.get_pipeline(namespace, application,
+                                     pipeline_id)["status"]
+        return status if status in ACTIVE_STATUSES | TERMINAL_STATUSES else None
+
+    status = wait_until(started, timeout=180, interval=2,
+                        description="the pipeline to start")
+    if status in TERMINAL_STATUSES:
+        pytest.skip(f"the pipeline finished as {status} before it could be stopped")
+
+    client.put(f"/api/namespaces/{namespace}/applications/{application}"
+               f"/pipelines/{pipeline_id}/stop")
+
+    def stopped():
+        current = client.get_pipeline(namespace, application,
+                                      pipeline_id)["status"]
+        return current if current in TERMINAL_STATUSES else None
+
+    final = wait_until(stopped, timeout=180, interval=3,
+                       description="the stopped pipeline to settle")
+    assert final == "STOPPED", (
+        f"a stopped pipeline settled as {final}; it should record STOPPED so the "
+        f"duplicate-deploy guard releases and the history shows who stopped it")
+
+
+def test_a_manual_build_is_deployed_on_request(client, namespace, application,
+                                               environment):
+    """MANUAL holds at BUILD_SUCCEEDED until the deploy call arrives.
+
+    This is the two-step release: build now, deploy during the window.
+    """
+    pipeline_id = deploy(client, namespace, application, environment,
+                         mode="MANUAL")
+
+    def built():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        status = pipeline["status"]
+        return status if status in TERMINAL_STATUSES | {"BUILD_SUCCEEDED"} else None
+
+    status = wait_until(built, timeout=DEPLOY_TIMEOUT,
+                        description="the manual build to finish")
+    if status != "BUILD_SUCCEEDED":
+        pytest.skip(f"the manual build ended as {status}")
+
+    client.put(f"/api/namespaces/{namespace}/applications/{application}"
+               f"/pipelines/{pipeline_id}/deploy")
+
+    final = wait_for_terminal(client, namespace, application, pipeline_id)
+    assert final["status"] == "SUCCEEDED", (
+        f"a manually released build ended as {final['status']}; the held "
+        f"artefact was not deployed")
+
+
+def test_a_successful_pipeline_can_be_rolled_back(client, namespace, application,
+                                                  environment):
+    """Rollback reuses the historic artefact instead of rebuilding.
+
+    A rollback that rebuilds is not a rollback: the point is to redeploy exactly
+    the image that was running before, so it must not depend on the source still
+    being reachable.
+    """
+    pipeline_id = deploy(client, namespace, application, environment)
+    first = wait_for_terminal(client, namespace, application, pipeline_id)
+    if first["status"] != "SUCCEEDED":
+        pytest.skip(f"the first deploy ended as {first['status']}, nothing to roll back")
+
+    rollback_id = client.post(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/pipelines/{pipeline_id}/rollback").data
+    assert rollback_id, "rollback did not return a new pipeline id"
+    assert rollback_id != pipeline_id, (
+        "rollback reused the original pipeline id instead of creating a new one")
+
+    rolled_back = wait_for_terminal(client, namespace, application, rollback_id)
+    assert rolled_back["status"] == "SUCCEEDED", (
+        f"the rollback pipeline ended as {rolled_back['status']}")
+    assert rolled_back.get("triggerType") == "ROLLBACK", (
+        f"the rollback pipeline is recorded as "
+        f"{rolled_back.get('triggerType')!r} rather than ROLLBACK, so the "
+        f"history cannot tell a rollback from an ordinary deploy")
+
+
+def test_pipeline_listing_and_detail_agree(client, namespace, application,
+                                           environment):
+    """The row in the list and the detail view describe the same pipeline."""
+    pipeline_id = deploy(client, namespace, application, environment)
+    wait_for_terminal(client, namespace, application, pipeline_id)
+
+    page = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/pipelines?page=1&size=20").data
+    rows = {row["id"]: row for row in page["data"]}
+    assert pipeline_id in rows, (
+        "the pipeline is missing from its own application's listing")
+
+    detail = client.get_pipeline(namespace, application, pipeline_id)
+    assert detail["status"] == rows[pipeline_id]["status"], (
+        "the listing and the detail view disagree about the pipeline status")

--- a/tests/acceptance/test_platform.py
+++ b/tests/acceptance/test_platform.py
@@ -1,0 +1,729 @@
+"""The platform surface — everything that exists before a single application does.
+
+Namespaces, application search, feature flags, health, cron previews, static
+assets, registry and cluster validation, node scheduling. This is the tier an
+operator meets first, while registering a cluster or checking a node, and it is
+almost entirely read-only, which is exactly why it rots unnoticed: nothing
+downstream breaks when a listing quietly starts answering with an empty array.
+
+Most of it needs no cluster. Only nodes, service accounts and the Kubernetes
+validation endpoints genuinely do, and only those carry the `cluster` marker.
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.parse
+import uuid
+
+import pytest
+
+from test_contract import ID_PATTERN, TIMESTAMP_PATTERN
+
+# The cron preview renders in the server's own zone, to the minute, with a space
+# rather than a `T` — it is display text for the expert-config UI, not a timestamp.
+CRON_RUN_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$")
+
+# A port nothing listens on, so the connection is refused rather than timing out.
+UNREACHABLE_REGISTRY = "http://127.0.0.1:1"
+
+PLATFORM_NAMESPACE = "acceptance-platform"
+
+
+# -- fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def platform_namespace(client) -> str:
+    """A namespace row to read and update, created once and then reused.
+
+    Creation is conditional on purpose. The API has no delete for namespaces and
+    happily stores the same name twice, so creating unconditionally would leave
+    one more duplicate row behind on every run of the suite.
+    """
+    registered = [item["name"] for item in client.get("/api/namespaces").data]
+    if PLATFORM_NAMESPACE not in registered:
+        client.post("/api/namespaces",
+                    {"name": PLATFORM_NAMESPACE,
+                     "description": "created by the acceptance suite"})
+    return PLATFORM_NAMESPACE
+
+
+@pytest.fixture(scope="session")
+def assets_available(client) -> bool:
+    """Static assets live in object storage, which is off by default."""
+    features = client.get("/api/features", expect_success=False)
+    if features.success and isinstance(features.data, dict):
+        if not features.data.get("objectStorage", False):
+            pytest.skip("object storage is disabled (oops.object-storage.enabled)")
+        return True
+    pytest.skip("cannot read the feature flags to check object storage")
+
+
+@pytest.fixture
+def asset_keys(client, assets_available):
+    """Removes uploaded assets afterwards, even when a test fails part way."""
+    keys: list[str] = []
+    yield keys
+    for key in reversed(keys):
+        client.delete(f"/api/assets?key={urllib.parse.quote(key)}",
+                      expect_success=False)
+
+
+@pytest.fixture
+def cordoned_nodes(client, environment):
+    """Puts every node the test cordoned back into service.
+
+    A node left unschedulable is invisible until some later test waits out its
+    whole deploy timeout wondering why its build pod never started.
+    """
+    names: list[str] = []
+    yield names
+    for name in reversed(names):
+        client.post(
+            f"/api/nodes/{name}/schedulable"
+            f"?environment={environment}&schedulable=true",
+            expect_success=False)
+
+
+@pytest.fixture
+def cluster_namespaces(kubectl):
+    """Removes work namespaces the validation endpoint created.
+
+    The API can create one and has no endpoint to remove it, so the cleanup has
+    to go around the API and talk to the cluster directly.
+    """
+    names: list[str] = []
+    yield names
+    for name in reversed(names):
+        kubectl._run("delete", "namespace", name,
+                     "--ignore-not-found=true", "--wait=false")
+
+
+# -- health and features ----------------------------------------------------
+
+
+def test_health_answers_ok(client):
+    """The liveness probe every deployment of OOPS is wired to."""
+    result = client.get("/api/health")
+    assert result.data == "ok", (
+        f"health answered {result.data!r} rather than 'ok'; container probes "
+        f"and load balancers compare the body, not just the status")
+
+
+def test_features_report_the_optional_subsystems(client):
+    """The frontend hides whole sections on these flags, so a missing key is not
+    a cosmetic problem — it reads as false and the feature disappears."""
+    features = client.get("/api/features").data
+
+    for flag in ("feishu", "ide", "ideHttps", "objectStorage"):
+        assert flag in features, (
+            f"the feature flags are missing {flag!r}; the UI treats an absent "
+            f"flag as disabled and silently drops that navigation group")
+        assert isinstance(features[flag], bool), (
+            f"feature flag {flag!r} is {features[flag]!r}, not a boolean")
+
+    assert "ideHost" in features, (
+        "ideHost is missing; the IDE links are built from it and become "
+        "unreachable without it")
+
+
+# -- namespaces -------------------------------------------------------------
+
+
+def test_a_namespace_is_listed_with_an_identity_and_a_naive_timestamp(
+        client, platform_namespace):
+    listing = client.get("/api/namespaces").data
+    assert isinstance(listing, list), "the namespace listing is not an array"
+
+    matched = [item for item in listing if item["name"] == platform_namespace]
+    assert matched, (
+        f"{platform_namespace} was created but does not appear in the namespace "
+        f"listing")
+
+    namespace = matched[0]
+    assert ID_PATTERN.match(namespace["id"]), (
+        f"namespace id {namespace['id']!r} is not a 24-char NanoId")
+    assert TIMESTAMP_PATTERN.match(namespace["createdTime"]), (
+        f"createdTime {namespace['createdTime']!r} is not a naive local "
+        f"timestamp — a zone suffix means values are being converted")
+    assert "description" in namespace, (
+        "the namespace listing carries no description, which is the only thing "
+        "the settings page has to show about a namespace")
+
+
+def test_a_namespace_description_can_be_updated(client, platform_namespace):
+    """Update is keyed on the name, not on the id — the body has no id field at
+    all, so a rename is impossible by construction."""
+    description = f"updated {uuid.uuid4().hex[:8]}"
+    client.put("/api/namespaces",
+               {"name": platform_namespace, "description": description})
+
+    listing = client.get("/api/namespaces").data
+    stored = [item["description"] for item in listing
+              if item["name"] == platform_namespace]
+    assert description in stored, (
+        f"the namespace update reported success but {description!r} is not in "
+        f"the listing; the write went somewhere else or was discarded")
+
+
+def test_updating_an_unregistered_namespace_fails(client):
+    """Update does not create. A caller that relied on upsert semantics would
+    silently lose the description instead of being told."""
+    result = client.put(
+        "/api/namespaces",
+        {"name": f"never-registered-{uuid.uuid4().hex[:8]}", "description": "x"},
+        expect_success=False)
+    assert result.success is False, (
+        "updating a namespace that was never created reported success; the "
+        "endpoint is quietly upserting")
+
+
+def test_invalid_namespace_names_are_rejected(client):
+    """The same resource-name rules as applications, applied before the row is
+    written — a namespace name ends up in Kubernetes object names."""
+    for candidate in ("UPPERCASE", "has space", "trailing-", "-leading",
+                      "dots.not.ok"):
+        result = client.post("/api/namespaces",
+                             {"name": candidate, "description": "x"},
+                             expect_success=False)
+        assert result.success is False, (
+            f"{candidate!r} was accepted as a namespace name and is now a row "
+            f"that cannot be deleted through the API")
+
+
+def test_an_application_namespace_needs_no_namespace_row(client):
+    """Documents a split the URLs give no hint of.
+
+    `/api/namespaces/{namespace}/applications` reads as though the namespace has
+    to exist first, but the path segment is a free-form string on the
+    application row and the `namespace` table is an unrelated, purely
+    descriptive listing. Applications can therefore live in namespaces the
+    settings page has never heard of.
+
+    Written against today's behaviour. If namespaces ever become a referenced
+    entity, this test fails and should be inverted rather than deleted — the
+    change is visible to anyone who ever typed a namespace into a URL.
+    """
+    unregistered = f"unregistered-{uuid.uuid4().hex[:8]}"
+    application = f"acc-{uuid.uuid4().hex[:8]}"
+
+    try:
+        client.create_application(unregistered, application)
+        listed = [item["name"] for item in client.get("/api/namespaces").data]
+        assert unregistered not in listed, (
+            f"creating an application in {unregistered!r} also registered the "
+            f"namespace; the two are now coupled and this test should be "
+            f"inverted")
+        profile = client.get_application(unregistered, application).data
+        assert profile["namespace"] == unregistered, (
+            "the application did not keep the namespace it was created in")
+    finally:
+        client.delete_application(unregistered, application,
+                                  expect_success=False)
+
+
+# -- search -----------------------------------------------------------------
+
+
+def test_search_matches_a_name_fragment_regardless_of_case(client, application):
+    """The command palette types into this endpoint, so a case-sensitive match
+    would mean half the keystrokes find nothing."""
+    fragment = application.split("-")[1]
+
+    for keyword in (fragment, fragment.upper()):
+        results = client.get(
+            f"/api/search/applications?keyword={keyword}&size=20").data
+        names = [item["name"] for item in results]
+        assert application in names, (
+            f"searching for {keyword!r} did not find {application}; the match "
+            f"is not a case-insensitive substring")
+
+    match = [item for item in client.get(
+        f"/api/search/applications?keyword={fragment}&size=20").data
+        if item["name"] == application][0]
+    for field in ("id", "name", "namespace", "owner", "sourceType"):
+        assert field in match, (
+            f"the search result is missing {field!r}; the palette needs it to "
+            f"build the link it navigates to")
+
+
+def test_search_honours_the_size_limit(client, application):
+    """`size` caps the results rather than paging them — there is no cursor, so
+    a caller asking for one gets exactly the first one."""
+    fragment = application.split("-")[1]
+    results = client.get(
+        f"/api/search/applications?keyword={fragment}&size=1").data
+    assert len(results) <= 1, (
+        f"size=1 returned {len(results)} results; the limit is not applied")
+
+    # size=0 is not treated as "unlimited", which is worth pinning: the opposite
+    # convention would flood the palette on an empty query.
+    empty = client.get(
+        f"/api/search/applications?keyword={fragment}&size=0").data
+    assert empty == [], (
+        f"size=0 returned {len(empty)} results, so zero is being read as "
+        f"unbounded rather than as none")
+
+
+def test_search_for_an_unknown_name_returns_an_empty_list(client):
+    """An empty result is a successful search, not a failure — a caller checking
+    `success` must not be told the search broke."""
+    result = client.get(
+        "/api/search/applications?keyword=definitely-not-an-application-9f3a2b")
+    assert result.success is True
+    assert result.data == [], (
+        f"a search that matched nothing answered with {result.data!r} rather "
+        f"than an empty list")
+
+
+# -- cron preview -----------------------------------------------------------
+
+
+def test_cron_preview_returns_the_next_fire_times(client):
+    """The scheduled-restart UI shows these before the user saves, so they are
+    the only feedback that an expression means what was intended."""
+    runs = client.get("/api/cron/next?expression=0+9+*+*+*&count=3").data
+
+    assert len(runs) == 3, f"asked for 3 fire times, got {len(runs)}"
+    for run in runs:
+        assert CRON_RUN_PATTERN.match(run), (
+            f"fire time {run!r} is not `yyyy-MM-dd HH:mm`; the UI renders the "
+            f"string as-is")
+        assert run.endswith("09:00"), (
+            f"`0 9 * * *` produced {run!r}; the leading field is being read as "
+            f"the hour, so a 5-field expression is not being padded with "
+            f"seconds")
+    assert runs == sorted(runs), "fire times came back out of order"
+
+
+def test_cron_preview_clamps_the_count_between_one_and_five(client):
+    """Clamped rather than rejected, so the preview can never be asked to
+    enumerate a year of fire times."""
+    many = client.get("/api/cron/next?expression=*/5+*+*+*+*&count=99").data
+    assert len(many) == 5, (
+        f"count=99 returned {len(many)} fire times; the upper clamp of 5 is "
+        f"missing and a caller can make the server enumerate arbitrarily far")
+
+    none = client.get("/api/cron/next?expression=*/5+*+*+*+*&count=0").data
+    assert len(none) == 1, (
+        f"count=0 returned {len(none)} fire times, expected the lower clamp of 1")
+
+    default = client.get("/api/cron/next?expression=*/5+*+*+*+*").data
+    assert len(default) == 1, (
+        f"omitting count returned {len(default)} fire times, expected 1")
+
+
+def test_cron_accepts_six_field_expressions_and_macros(client):
+    """The UI offers 5 fields, but 6-field expressions and `@` macros pass
+    straight through to the scheduler, so they are part of the contract whether
+    or not anything types them."""
+    six_field = client.get("/api/cron/next?expression=0+0+9+*+*+*&count=1").data
+    assert six_field and six_field[0].endswith("09:00"), (
+        f"a 6-field expression produced {six_field!r}; the leading seconds "
+        f"field is being padded a second time")
+
+    macro = client.get("/api/cron/next?expression=%40daily&count=1").data
+    assert macro and macro[0].endswith("00:00"), (
+        f"`@daily` produced {macro!r}; macros are no longer passed through")
+
+
+def test_an_invalid_cron_expression_is_refused(client):
+    """Refused inside the envelope rather than thrown, because the UI previews
+    on every keystroke and half-typed expressions are the normal case."""
+    for expression in ("not-a-cron", "0+9+*", "99+9+*+*+*"):
+        result = client.get(f"/api/cron/next?expression={expression}&count=1",
+                            expect_success=False)
+        assert result.success is False, (
+            f"{expression!r} was accepted as a cron expression; an unparseable "
+            f"schedule would be stored and simply never fire")
+        assert result.status == 200, (
+            f"an invalid expression answered HTTP {result.status}; the preview "
+            f"must not surface as a request error")
+
+
+# -- static assets ----------------------------------------------------------
+
+
+def test_asset_upload_url_is_presigned_under_the_asset_prefix(client,
+                                                              assets_available):
+    """Assets and build sources share a bucket and are kept apart only by the
+    key prefix, so a signed URL that escaped it would let the asset browser list
+    and delete build sources."""
+    upload = client.post("/api/assets/upload-url", {
+        "path": "acceptance",
+        "fileName": "note.txt",
+        "contentType": "text/plain",
+        "fileSize": 12,
+    }).data
+
+    for field in ("objectKey", "objectUrl", "uploadUrl", "headers"):
+        assert field in upload, f"the upload response is missing {field!r}"
+    assert upload["objectKey"].startswith("oops-assets/"), (
+        f"objectKey {upload['objectKey']!r} is outside the asset prefix; the "
+        f"asset browser would be able to reach build sources")
+    assert upload["uploadUrl"].startswith("http"), (
+        f"uploadUrl is not a URL: {upload['uploadUrl']!r}")
+
+    # The stored content type is guessed from the extension, not taken from the
+    # caller, so a browser renders the file instead of downloading it.
+    assert upload["headers"].get("Content-Type") == "text/plain", (
+        f"the signed headers carry {upload['headers']!r}; the upload will be "
+        f"rejected unless the client sends exactly what was signed")
+
+
+def test_an_uploaded_asset_is_listed_and_can_be_deleted(client, asset_keys):
+    """The whole asset lifecycle, because each step is only observable through
+    the next one: the signature is only proven by an upload, the upload only by
+    the listing, and the delete only by the listing going empty again."""
+    folder = f"acceptance-{uuid.uuid4().hex[:8]}"
+    payload = b"acceptance asset\n"
+
+    upload = client.post("/api/assets/upload-url", {
+        "path": folder,
+        "fileName": "note.txt",
+        "contentType": "text/plain",
+        "fileSize": len(payload),
+    }).data
+    asset_keys.append(upload["objectKey"])
+
+    status = client.put_bytes(upload["uploadUrl"], payload,
+                              dict(upload.get("headers") or {}))
+    assert status in (200, 204), (
+        f"the presigned PUT was rejected with HTTP {status}; the signature does "
+        f"not match the headers the client was told to send")
+
+    root = client.get("/api/assets").data
+    folders = [item["name"] for item in root if item["type"] == "FOLDER"]
+    assert folder in folders, (
+        f"{folder} holds an object but is not listed as a folder at the root; "
+        f"the listing is not synthesising folders from key prefixes")
+
+    listing = client.get(f"/api/assets?path={folder}").data
+    entries = [item for item in listing if item["name"] == "note.txt"]
+    assert entries, f"the uploaded asset is absent from the {folder} listing"
+
+    entry = entries[0]
+    assert entry["type"] == "FILE"
+    assert entry["size"] == len(payload), (
+        f"the listing reports {entry['size']} bytes for a {len(payload)} byte "
+        f"upload")
+    assert entry["contentType"] == "text/plain", (
+        f"the listing reports {entry['contentType']!r}; a browser opening the "
+        f"public URL would download the file rather than render it")
+    for field in ("publicUrl", "signedUrl"):
+        assert entry[field], (
+            f"the asset entry has no {field}; the browser has no way to reach "
+            f"the object")
+
+    client.delete(f"/api/assets?key={urllib.parse.quote(entry['key'])}")
+
+    remaining = client.get(f"/api/assets?path={folder}").data
+    assert remaining == [], (
+        f"the asset survived its delete: {remaining!r}")
+
+
+def test_asset_upload_url_validates_its_input(client, assets_available):
+    """Every one of these is checked before the URL is signed. Signing first and
+    refusing afterwards would mean paying for the transfer to learn it was
+    never allowed."""
+    rejected = [
+        ({"path": "acceptance", "fileName": "", "fileSize": 12},
+         "a blank file name"),
+        ({"path": "acceptance", "fileName": "note.txt", "fileSize": 0},
+         "a zero byte size"),
+        ({"path": "acceptance", "fileName": "note.txt",
+          "fileSize": 10 * 1024 * 1024 * 1024},
+         "a size beyond the configured limit"),
+        ({"path": "../escape", "fileName": "note.txt", "fileSize": 12},
+         "a traversing path"),
+        ({"path": "acceptance", "fileName": "../escape.txt", "fileSize": 12},
+         "a traversing file name"),
+    ]
+    for body, description in rejected:
+        result = client.post("/api/assets/upload-url", body,
+                             expect_success=False)
+        assert result.success is False, (
+            f"{description} was granted a presigned URL; the object would land "
+            f"outside the asset prefix or beyond the size limit with nothing "
+            f"left to stop it")
+
+
+def test_deleting_a_key_outside_the_asset_prefix_is_refused(client,
+                                                            assets_available):
+    """Delete takes a raw object key, so the prefix check is the only thing
+    standing between the asset browser and the build sources in the same
+    bucket."""
+    for key in ("build-sources/some-source.zip",
+                "oops-assets/../build-sources/some-source.zip",
+                ""):
+        result = client.delete(f"/api/assets?key={urllib.parse.quote(key)}",
+                               expect_success=False)
+        assert result.success is False, (
+            f"the key {key!r} was accepted for deletion; anything in the bucket "
+            f"can be removed through the asset browser")
+
+
+# -- image repositories -----------------------------------------------------
+
+
+def test_image_repository_validation_needs_all_three_fields(client):
+    """Validation short-circuits to false unless url, username and password are
+    all present, which matches `syncImagePullSecret`: with any of them blank no
+    pull secret is written at all."""
+    incomplete = [
+        {"url": "", "username": "", "password": ""},
+        {"url": "http://registry.invalid", "username": "", "password": ""},
+        {"url": "http://registry.invalid", "username": "oops", "password": ""},
+    ]
+    for repository in incomplete:
+        result = client.post("/api/image-repositories/validations", repository)
+        assert result.data is False, (
+            f"{repository} validated as usable; the environment form would let "
+            f"an operator save a registry that produces no pull secret")
+
+
+def test_image_repository_validation_fails_for_an_unreachable_registry(client):
+    """A refused connection is a false verdict rather than an error envelope, so
+    the form can show a red tick instead of a stack trace.
+
+    The probe is a plain GET of the registry root, which a Docker registry
+    leaves unauthenticated — a true verdict therefore means the host answered,
+    not that the credentials work. Documented rather than endorsed; validating
+    against `/v2/` would actually check them.
+    """
+    result = client.post("/api/image-repositories/validations", {
+        "url": UNREACHABLE_REGISTRY,
+        "username": "oops",
+        "password": "oops-secret",
+    })
+    assert result.success is True, (
+        f"an unreachable registry produced a failed envelope: {result.message}")
+    assert result.data is False, (
+        "an unreachable registry validated as usable; every environment would "
+        "pass validation regardless of what it points at")
+
+
+# -- service accounts (cluster) ---------------------------------------------
+
+
+@pytest.mark.cluster
+def test_service_accounts_of_a_namespace_are_listed(client, environment):
+    """Expert config offers these as the ServiceAccount a workload runs under,
+    so the list has to come from the cluster rather than from OOPS's own rows.
+
+    Asked of the Kubernetes `default` namespace because every cluster has one
+    and every namespace has a `default` ServiceAccount inside it.
+    """
+    accounts = client.get(
+        f"/api/namespaces/default/service-accounts?environment={environment}").data
+
+    assert isinstance(accounts, list), "the service account listing is not an array"
+    assert "default" in accounts, (
+        f"the `default` namespace reported {accounts!r}; every Kubernetes "
+        f"namespace has a default ServiceAccount, so the listing is not "
+        f"reaching the cluster")
+
+
+@pytest.mark.cluster
+def test_service_accounts_of_an_absent_namespace_are_empty(client, environment):
+    """A namespace that does not exist in the cluster is an empty list, not an
+    error — expert config asks for this before the namespace is ever created."""
+    absent = f"never-created-{uuid.uuid4().hex[:8]}"
+    result = client.get(
+        f"/api/namespaces/{absent}/service-accounts?environment={environment}",
+        expect_success=False)
+    assert result.success is True, (
+        f"listing service accounts of an absent namespace failed: "
+        f"{result.message}")
+    assert result.data == [], (
+        f"an absent namespace reported {result.data!r} rather than an empty list")
+
+
+@pytest.mark.cluster
+def test_service_accounts_of_an_unregistered_environment_fail(client):
+    """The environment name is looked up before the cluster is touched, so an
+    unknown name must not be silently treated as "no accounts"."""
+    result = client.get(
+        "/api/namespaces/default/service-accounts?environment=not-registered-9f3a",
+        expect_success=False)
+    assert result.success is False, (
+        "an unregistered environment answered with a service account listing; "
+        "a typo in the environment name would look like an empty cluster")
+
+
+# -- nodes (cluster) --------------------------------------------------------
+
+
+@pytest.mark.cluster
+def test_nodes_report_readiness_capacity_and_versions(client, environment):
+    """The cluster page renders one row per node from exactly these fields, and
+    a missing one shows as a blank cell rather than as an error."""
+    nodes = client.get(f"/api/nodes?environment={environment}").data
+
+    assert nodes, (
+        "the environment reported no nodes at all; either the credentials "
+        "cannot list nodes or the cluster is empty")
+
+    for node in nodes:
+        for field in ("name", "hostname", "ready", "schedulable", "roles",
+                      "internalIP", "kubeletVersion", "osImage",
+                      "containerRuntimeVersion", "cpu", "memory", "pods",
+                      "creationTimestamp"):
+            assert field in node, (
+                f"node {node.get('name')!r} is missing {field!r}; the cluster "
+                f"page renders it as an empty cell with no explanation")
+        assert isinstance(node["ready"], bool), (
+            f"`ready` is {node['ready']!r}, not a boolean")
+        assert isinstance(node["schedulable"], bool), (
+            f"`schedulable` is {node['schedulable']!r}, not a boolean")
+
+
+@pytest.mark.cluster
+def test_a_node_can_be_cordoned_and_uncordoned(client, environment,
+                                               cordoned_nodes):
+    """Cordoning is the one destructive thing the cluster page can do, and it is
+    only observable through the listing that follows it."""
+    nodes = client.get(f"/api/nodes?environment={environment}").data
+    schedulable = [node for node in nodes if node["schedulable"]]
+    if not schedulable:
+        pytest.skip("every node is already cordoned; nothing to toggle")
+    target = schedulable[0]["name"]
+
+    cordoned_nodes.append(target)
+    client.post(f"/api/nodes/{target}/schedulable"
+                f"?environment={environment}&schedulable=false")
+
+    after_cordon = client.get(f"/api/nodes?environment={environment}").data
+    state = {node["name"]: node["schedulable"] for node in after_cordon}
+    assert state[target] is False, (
+        f"{target} reported success for the cordon but is still schedulable; "
+        f"draining a node would silently do nothing")
+
+    client.post(f"/api/nodes/{target}/schedulable"
+                f"?environment={environment}&schedulable=true")
+
+    after_uncordon = client.get(f"/api/nodes?environment={environment}").data
+    restored = {node["name"]: node["schedulable"] for node in after_uncordon}
+    assert restored[target] is True, (
+        f"{target} could be cordoned but not returned to service; the cluster "
+        f"is now short a node and every later deploy in this run will wait out "
+        f"its timeout")
+
+
+@pytest.mark.cluster
+def test_listing_nodes_of_an_unregistered_environment_fails(client):
+    result = client.get("/api/nodes?environment=not-registered-9f3a",
+                        expect_success=False)
+    assert result.success is False, (
+        "an unregistered environment answered with a node listing; a typo in "
+        "the environment name would look like a cluster with no nodes")
+
+
+# -- Kubernetes validation (cluster) ----------------------------------------
+
+
+@pytest.mark.cluster
+def test_validation_passes_for_a_reachable_cluster(client, cluster_credentials):
+    """The environment form calls this before saving, so its verdict is the only
+    thing between an operator and an environment that cannot deploy anything."""
+    result = client.post("/api/kubernetes/validations", {
+        "kubernetesApiServer": {
+            "url": cluster_credentials["url"],
+            "token": cluster_credentials["token"],
+        },
+        "workNamespace": cluster_credentials["workNamespace"],
+    }).data
+
+    assert result["success"] is True, (
+        f"validating a reachable cluster with an existing work namespace "
+        f"reported {result['status']}: {result['message']}")
+    assert result["status"] == "VALID", (
+        f"expected status VALID, got {result['status']!r}; the form branches on "
+        f"this string, not on the boolean")
+
+
+@pytest.mark.cluster
+def test_validation_reports_a_missing_work_namespace_distinctly(
+        client, cluster_credentials):
+    """`NAMESPACE_MISSING` is a different verdict from a failed connection
+    because it is the recoverable one — the form offers to create the namespace
+    on exactly this status and on no other."""
+    result = client.post("/api/kubernetes/validations", {
+        "kubernetesApiServer": {
+            "url": cluster_credentials["url"],
+            "token": cluster_credentials["token"],
+        },
+        "workNamespace": f"never-created-{uuid.uuid4().hex[:8]}",
+    }).data
+
+    assert result["success"] is False
+    assert result["status"] == "NAMESPACE_MISSING", (
+        f"a reachable cluster with an absent namespace reported "
+        f"{result['status']!r}; the operator loses the offer to create it and "
+        f"is told the connection failed instead")
+
+
+@pytest.mark.cluster
+def test_validation_reports_an_unusable_credential_as_a_connection_failure(
+        client, cluster_credentials):
+    """A rejected token and an unreachable host collapse into one verdict, which
+    is coarse but is what the form is written against."""
+    result = client.post("/api/kubernetes/validations", {
+        "kubernetesApiServer": {
+            "url": cluster_credentials["url"],
+            "token": "definitely-not-a-service-account-token",
+        },
+        "workNamespace": cluster_credentials["workNamespace"],
+    }).data
+
+    assert result["success"] is False, (
+        "a rejected token validated successfully; the environment would be "
+        "saved and every deploy against it would fail instead")
+    assert result["status"] == "CONNECTION_FAILED", (
+        f"expected CONNECTION_FAILED, got {result['status']!r}")
+
+
+@pytest.mark.cluster
+def test_a_work_namespace_can_be_created_and_then_validates(
+        client, cluster_credentials, cluster_namespaces):
+    """The recovery path from `NAMESPACE_MISSING`, end to end.
+
+    Creating twice is part of the contract rather than an afterthought: the
+    button is one click away from the validation that offered it, and a double
+    click must not leave the operator staring at a Kubernetes 409.
+    """
+    name = f"acceptance-work-{uuid.uuid4().hex[:8]}"
+    api_server = {
+        "url": cluster_credentials["url"],
+        "token": cluster_credentials["token"],
+    }
+    cluster_namespaces.append(name)
+
+    created = client.post("/api/kubernetes/namespaces", {
+        "kubernetesApiServer": api_server,
+        "workNamespace": name,
+    })
+    assert created.data is True, (
+        f"creating the work namespace {name} reported {created.data!r}")
+
+    validated = client.post("/api/kubernetes/validations", {
+        "kubernetesApiServer": api_server,
+        "workNamespace": name,
+    }).data
+    assert validated["status"] == "VALID", (
+        f"the namespace was created but validation still reports "
+        f"{validated['status']!r}; the operator is stuck in a loop of creating "
+        f"a namespace that already exists")
+
+    # Documented rather than endorsed: a second create surfaces the API server's
+    # 409 as a failed envelope rather than treating the namespace as already
+    # satisfactory. Making it idempotent would be an improvement; invert this
+    # assertion in the same commit.
+    again = client.post("/api/kubernetes/namespaces", {
+        "kubernetesApiServer": api_server,
+        "workNamespace": name,
+    }, expect_success=False)
+    assert again.success is False, (
+        "creating the same work namespace twice now succeeds, which is an "
+        "improvement; invert this test")

--- a/tests/acceptance/test_podfs.py
+++ b/tests/acceptance/test_podfs.py
@@ -1,0 +1,382 @@
+"""The pod filesystem browser, against a real container.
+
+Every one of these eight endpoints is a `kubectl exec` in disguise: the gateway
+pipes a small POSIX shell script into the application container and parses what
+comes back, except upload and write, which push a tar stream through the exec
+channel. So the whole surface rests on what busybox in the target image happens
+to provide, and on bytes surviving a websocket multiplexer — exactly the kind of
+thing a reimplementation gets subtly wrong in ways a status code cannot show: a
+listing that loses dotfiles, a size counted in characters instead of bytes, a
+download that arrives with a trailing newline the file never had.
+
+So these tests compare content, not codes. Each one writes something it can
+recognise and reads it back through a different endpoint than the one that put
+it there.
+"""
+
+from __future__ import annotations
+
+import uuid
+from urllib.parse import urlencode
+
+import pytest
+
+from oops_client import wait_until
+from test_deploy import (DEPLOY_TIMEOUT, TERMINAL_STATUSES, configure_for_build,
+                         git_strategy)
+from test_streams import first_running_pod
+
+pytestmark = pytest.mark.cluster
+
+
+class PodFiles:
+    """The eight file endpoints, bound to one pod.
+
+    All eight take the same five coordinates and differ only in verb and body,
+    so binding them once keeps the tests about files rather than about URLs.
+    """
+
+    def __init__(self, client, namespace: str, application: str, pod: str,
+                 environment: str):
+        self.client = client
+        self.namespace = namespace
+        self.application = application
+        self.pod = pod
+        self.environment = environment
+        self.base = (f"/api/namespaces/{namespace}/applications/{application}"
+                     f"/pods/{pod}/files")
+
+    def _url(self, suffix: str = "", **params) -> str:
+        # `environment` is required on every call and is the environment *name*,
+        # never an id.
+        return f"{self.base}{suffix}?{urlencode({'environment': self.environment, **params})}"
+
+    def list(self, path: str, **kwargs):
+        return self.client.get(self._url(path=path), **kwargs)
+
+    def read(self, path: str, **kwargs):
+        return self.client.get(self._url("/content", path=path), **kwargs)
+
+    def write(self, path: str, content: str, **kwargs):
+        return self.client.put(self._url("/content"),
+                               {"path": path, "content": content}, **kwargs)
+
+    def mkdir(self, path: str, **kwargs):
+        return self.client.post(self._url("/directory"), {"path": path}, **kwargs)
+
+    def rename(self, from_path: str, to_path: str, **kwargs):
+        return self.client.post(self._url("/rename"),
+                                {"fromPath": from_path, "toPath": to_path},
+                                **kwargs)
+
+    def upload(self, path: str, file_name: str, payload: bytes, **kwargs):
+        # The part name is "file"; `path` stays a query parameter even though the
+        # rest of the request is multipart.
+        return self.client.post(
+            self._url("/upload", path=path),
+            files={"file": (file_name, payload, "application/octet-stream")},
+            **kwargs)
+
+    def download(self, path: str):
+        """Raw, because this endpoint answers with bytes rather than an envelope."""
+        return self.client.raw("GET", self._url("/download", path=path))
+
+    def delete(self, path: str, **kwargs):
+        return self.client.delete(self._url(path=path), **kwargs)
+
+
+def entry_named(listing, name: str):
+    for entry in listing:
+        if entry.get("name") == name:
+            return entry
+    return None
+
+
+@pytest.fixture(scope="module")
+def pod_files(client, namespace, environment):
+    """One deployed application with a running pod, shared by every test here.
+
+    A build takes about ninety seconds and no test in this file touches the
+    application itself — only files inside its container — so deploying per test
+    would spend ten minutes re-proving the same precondition.
+    """
+    application = f"podfs-{uuid.uuid4().hex[:8]}"
+    client.create_application(namespace, application)
+    try:
+        configure_for_build(client, namespace, application, environment)
+        pipeline_id = client.deploy(namespace, application, environment,
+                                    strategy=git_strategy())
+
+        def finished():
+            pipeline = client.get_pipeline(namespace, application, pipeline_id)
+            return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+        pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                              description="the fixture deploy to finish")
+        if pipeline["status"] != "SUCCEEDED":
+            pytest.skip(f"fixture deploy ended as {pipeline['status']}, so there "
+                        f"is no container to browse")
+
+        pod = wait_until(
+            lambda: first_running_pod(client, namespace, application, environment),
+            timeout=180, interval=5, description="a running pod to appear")
+
+        # The container defaults to the application name when `container` is
+        # omitted, which is what the StatefulSet names it — so every call below
+        # leaves it out and still lands in the right container.
+        yield PodFiles(client, namespace, application, pod, environment)
+    finally:
+        try:
+            client.delete_application(namespace, application, expect_success=False)
+        except Exception:
+            pass
+
+
+@pytest.fixture(scope="module")
+def scratch(pod_files):
+    """A directory of our own inside the pod, removed recursively afterwards.
+
+    Deleting the application takes the pod with it, so this teardown matters
+    only when the suite is pointed at a pod that outlives the run — but that is
+    also the case where a leaked file would quietly change the next result.
+    """
+    directory = f"/tmp/oops-acceptance-{uuid.uuid4().hex[:8]}"
+    pod_files.mkdir(directory)
+    yield directory
+    pod_files.delete(directory, expect_success=False)
+
+
+def test_write_and_read_round_trip_the_content(pod_files, scratch):
+    """PUT /files/content then GET /files/content.
+
+    Non-ASCII and a trailing newline are both in the payload on purpose: the
+    write encodes to UTF-8 and the read decodes it back, and a shell script sits
+    in between, which is where a stray `echo` or a locale assumption would show
+    up as mangled text.
+    """
+    path = f"{scratch}/round-trip.txt"
+    content = "héllo 世界\nsecond line\n\ttabbed\n"
+
+    pod_files.write(path, content)
+    result = pod_files.read(path)
+
+    assert result.data["content"] == content, (
+        f"the file read back as {result.data['content']!r} but was written as "
+        f"{content!r}; the editor would silently corrupt whatever a user saves")
+    assert result.data["path"] == path, (
+        f"the read echoed path {result.data['path']!r} instead of {path!r}; the "
+        f"editor keys its open buffers on this field")
+
+
+def test_the_listing_reports_type_and_byte_size(pod_files, scratch):
+    """GET /files.
+
+    Size is what the file browser shows, and it is a byte count, not a character
+    count — a nine-character UTF-8 name is twenty bytes on disk.
+    """
+    directory = f"{scratch}/listing"
+    pod_files.mkdir(directory)
+    content = "héllo 世界\nline2\n"
+    pod_files.write(f"{directory}/note.txt", content)
+
+    entries = pod_files.list(directory).data
+
+    note = entry_named(entries, "note.txt")
+    assert note is not None, (
+        f"the file just written is missing from the listing: "
+        f"{[entry['name'] for entry in entries]}")
+    assert note["type"] == "FILE", (
+        f"note.txt came back as {note['type']}; the browser decides whether a "
+        f"row opens an editor or descends into a directory on this field")
+    assert note["size"] == len(content.encode("utf-8")), (
+        f"note.txt reported {note['size']} bytes for a "
+        f"{len(content.encode('utf-8'))}-byte file; the size is being counted "
+        f"in characters rather than bytes")
+    assert note["path"] == f"{directory}/note.txt", (
+        f"the entry carries path {note['path']!r}; the browser navigates with "
+        f"it, so a wrong join makes every row unopenable")
+
+
+def test_the_listing_sorts_directories_first(pod_files, scratch):
+    """Directories before files, each half case-insensitively by name."""
+    directory = f"{scratch}/sorting"
+    pod_files.mkdir(directory)
+    pod_files.mkdir(f"{directory}/Zeta")
+    pod_files.mkdir(f"{directory}/alpha")
+    pod_files.write(f"{directory}/Beta.txt", "b")
+    pod_files.write(f"{directory}/aardvark.txt", "a")
+
+    names = [entry["name"] for entry in pod_files.list(directory).data]
+
+    assert names == ["alpha", "Zeta", "aardvark.txt", "Beta.txt"], (
+        f"the listing came back as {names}; the browser renders it in the "
+        f"order it arrives, so directories would be scattered through the files")
+
+
+def test_the_listing_includes_dotfiles(pod_files, scratch):
+    """The glob in the listing script has a `.*` arm for exactly this.
+
+    A shell `for entry in *` skips hidden files, and a container's interesting
+    files — .env, .npmrc, .bashrc — are mostly hidden ones.
+    """
+    directory = f"{scratch}/hidden"
+    pod_files.mkdir(directory)
+    pod_files.write(f"{directory}/.env", "TOKEN=secret\n")
+
+    names = [entry["name"] for entry in pod_files.list(directory).data]
+
+    assert ".env" in names, (
+        f"a dotfile is missing from {names}; hidden files would be invisible "
+        f"and unreachable in the browser")
+
+
+def test_rename_moves_the_file_with_its_content(pod_files, scratch):
+    """POST /files/rename, then read the content back at the new path."""
+    source = f"{scratch}/before-rename.txt"
+    target = f"{scratch}/after-rename.txt"
+    content = "content that must survive the move\n"
+    pod_files.write(source, content)
+
+    pod_files.rename(source, target)
+
+    assert pod_files.read(target).data["content"] == content, (
+        "the renamed file lost its content; rename is a move, not a copy of the "
+        "name alone")
+    names = [entry["name"] for entry in pod_files.list(scratch).data]
+    assert "after-rename.txt" in names and "before-rename.txt" not in names, (
+        f"after the rename the directory still lists {names}; the old name was "
+        f"left behind, so the rename duplicated rather than moved")
+
+
+def test_rename_refuses_to_overwrite_an_existing_path(pod_files, scratch):
+    """The guard that stops a rename silently destroying the target."""
+    keeper = f"{scratch}/keeper.txt"
+    other = f"{scratch}/other.txt"
+    pod_files.write(keeper, "must not be overwritten\n")
+    pod_files.write(other, "the mover\n")
+
+    result = pod_files.rename(other, keeper, expect_success=False)
+
+    assert result.success is False, (
+        "a rename onto an existing path was accepted; a user renaming a file "
+        "would destroy whatever already had that name")
+    assert pod_files.read(keeper).data["content"] == "must not be overwritten\n", (
+        "the target file was overwritten even though the rename was refused")
+
+
+def test_download_returns_the_exact_bytes(pod_files, scratch):
+    """GET /files/download, which answers with bytes rather than an envelope."""
+    path = f"{scratch}/download-me.bin"
+    # A NUL, a bare CR, and multi-byte UTF-8: the exec channel is a websocket
+    # multiplexer, and any text handling in it would damage at least one of these.
+    payload = bytes([0x00, 0x01, 0xFF, 0x0D, 0x0A, 0x41]) + "héllo\n".encode("utf-8")
+    pod_files.upload(f"{scratch}/", "download-me.bin", payload)
+
+    response = pod_files.download(path)
+
+    assert response.status_code == 200, (
+        f"the download answered {response.status_code}: {response.text[:200]!r}")
+    assert response.content == payload, (
+        f"the download returned {response.content!r} for a file uploaded as "
+        f"{payload!r}; binary files cannot be retrieved intact")
+    assert response.headers.get("Content-Length") == str(len(payload)), (
+        f"Content-Length is {response.headers.get('Content-Length')} for "
+        f"{len(payload)} bytes, so a browser would truncate or hang")
+    disposition = response.headers.get("Content-Disposition", "")
+    # Documented, not endorsed: the filename is emitted twice, once as an
+    # RFC 2047 encoded word (`filename="=?UTF-8?Q?...?="`) and once as RFC 5987
+    # (`filename*=UTF-8''...`). Only the second form is what browsers use.
+    assert "filename*=UTF-8''download-me.bin" in disposition, (
+        f"Content-Disposition is {disposition!r}; without the RFC 5987 filename "
+        f"the browser saves the file under the URL's last segment")
+
+
+def test_upload_into_a_directory_keeps_the_sent_filename(pod_files, scratch):
+    """POST /files/upload with a trailing slash on `path`.
+
+    A `path` ending in `/` is a destination directory and the name comes from
+    the multipart part; anything else is the full target path. Both forms are
+    reachable from the UI, so both are pinned here.
+    """
+    payload = b"uploaded into a directory\n"
+
+    pod_files.upload(f"{scratch}/", "named-by-the-part.txt", payload)
+
+    assert pod_files.read(f"{scratch}/named-by-the-part.txt").data["content"] == \
+        payload.decode(), (
+        "an upload to a directory path did not land under the part's filename")
+
+    explicit = f"{scratch}/named-by-the-query.txt"
+    pod_files.upload(explicit, "ignored-when-path-is-explicit.txt",
+                     b"uploaded to an explicit path\n")
+
+    assert pod_files.read(explicit).data["content"] == \
+        "uploaded to an explicit path\n", (
+        "an upload to an explicit path did not land there; the part filename "
+        "must not win over a path that names the file")
+
+
+def test_create_directory_then_delete_it_with_its_contents(pod_files, scratch):
+    """POST /files/directory and DELETE /files, the two ends of the lifecycle."""
+    directory = f"{scratch}/nested/deep"
+    pod_files.mkdir(directory)
+    pod_files.write(f"{directory}/inside.txt", "gone with the directory\n")
+
+    parent = pod_files.list(f"{scratch}/nested").data
+    entry = entry_named(parent, "deep")
+    assert entry is not None and entry["type"] == "DIRECTORY", (
+        f"the created directory is missing or mistyped in {parent}; mkdir is "
+        f"expected to create intermediate directories too")
+
+    refused = pod_files.mkdir(directory, expect_success=False)
+    assert refused.success is False, (
+        "creating a directory that already exists was accepted; the UI relies "
+        "on the refusal to tell the user the name is taken")
+
+    pod_files.delete(f"{scratch}/nested")
+
+    remaining = [item["name"] for item in pod_files.list(scratch).data]
+    assert "nested" not in remaining, (
+        f"the deleted directory is still listed in {remaining}")
+    gone = pod_files.read(f"{directory}/inside.txt", expect_success=False)
+    assert gone.success is False, (
+        "a file inside the deleted directory is still readable; the delete did "
+        "not recurse")
+
+
+def test_deleting_a_missing_path_is_refused(pod_files, scratch):
+    """The negative that keeps the delete test honest.
+
+    Without it, a delete that quietly does nothing would still pass everything
+    above, because a file that was never removed and a file that never existed
+    look the same from the listing.
+    """
+    result = pod_files.delete(f"{scratch}/never-existed.txt", expect_success=False)
+
+    assert result.success is False, (
+        "deleting a path that does not exist reported success, so a failed "
+        "delete cannot be told apart from a real one")
+    assert result.message, "a refused delete must explain itself"
+
+
+def test_an_unknown_environment_is_refused_on_both_resolution_paths(pod_files,
+                                                                    scratch):
+    """`environment` is a name, and an unknown one must fail as an envelope.
+
+    Two of the eight endpoints resolve the environment in the controller and the
+    other six in the service; this is the check that both paths refuse rather
+    than dereferencing a null.
+    """
+    stray = PodFiles(pod_files.client, pod_files.namespace, pod_files.application,
+                     pod_files.pod, "no-such-environment")
+
+    listing = stray.list(scratch, expect_success=False)
+    reading = stray.read(f"{scratch}/anything.txt", expect_success=False)
+
+    for label, result in (("list", listing), ("read", reading)):
+        assert result.success is False, (
+            f"{label} against an unregistered environment succeeded, which "
+            f"means the environment parameter is not being resolved at all")
+        assert "no-such-environment" in (result.message or ""), (
+            f"{label} refused with {result.message!r}; the message should name "
+            f"the environment so a misconfigured UI is diagnosable")

--- a/tests/acceptance/test_registry.py
+++ b/tests/acceptance/test_registry.py
@@ -1,0 +1,113 @@
+"""The image path, both halves of it.
+
+A registry has two configurations that behave completely differently inside OOPS,
+and only one of them used to be exercised:
+
+- **credentials present** — `syncImagePullSecret` writes a `dockerhub` secret into
+  the work namespace, buildah mounts it to authenticate its push, the pull secret
+  processor copies it into the application namespace, and the kubelet uses it to
+  pull. Four steps, each able to fail on its own.
+- **credentials absent** — no secret is written at all. Every consumer has to
+  tolerate that, or the pipeline wedges before it starts.
+
+The second case was a live bug: the build pod mounted the secret as a
+non-optional volume, so an anonymous registry left every build stuck at
+`Init:0/2` with `MountVolume.SetUp failed for volume "registry-secret"`, and
+nothing in the OOPS UI said why.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from oops_client import wait_until
+from test_deploy import (DEPLOY_TIMEOUT, TERMINAL_STATUSES, configure_for_build,
+                         git_strategy)
+
+pytestmark = pytest.mark.cluster
+
+ANONYMOUS_REGISTRY = os.environ.get("OOPS_REGISTRY", "registry:5000")
+AUTH_REGISTRY = os.environ.get("OOPS_AUTH_REGISTRY", "registry-auth:5000")
+AUTH_REGISTRY_USER = os.environ.get("OOPS_AUTH_REGISTRY_USER", "oops")
+AUTH_REGISTRY_PASSWORD = os.environ.get("OOPS_AUTH_REGISTRY_PASSWORD",
+                                        "oops-secret")
+
+
+def run_to_completion(client, namespace, application, environment) -> dict:
+    configure_for_build(client, namespace, application, environment)
+    pipeline_id = client.deploy(namespace, application, environment,
+                                strategy=git_strategy())
+
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    return wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                      description=f"pipeline {pipeline_id} to finish")
+
+
+def test_build_starts_when_the_registry_needs_no_credentials(
+        client, namespace, application, environment_factory):
+    """Regression test for the wedged-build bug.
+
+    An environment pointing at an anonymous registry gets no `dockerhub` secret.
+    The build must still start — if the registry-secret volume is not marked
+    optional the pod never leaves Init and this fails on the timeout rather than
+    on an assertion.
+    """
+    anonymous = environment_factory(prefix="anon", registry=ANONYMOUS_REGISTRY)
+
+    pipeline = run_to_completion(client, namespace, application, anonymous)
+
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"a deploy against a credential-free registry ended as "
+        f"{pipeline['status']}. If the build pod is stuck in Init, check that "
+        f"the registry-secret volume in SecretVolume is marked optional.")
+
+
+def test_build_pushes_and_pulls_through_an_authenticated_registry(
+        client, namespace, application, environment_factory):
+    """The whole credential chain, end to end.
+
+    Reaching SUCCEEDED here means all four steps worked: the secret was created
+    from the environment's credentials, buildah authenticated its push with it,
+    the processor copied it into the application namespace, and the kubelet used
+    it to pull the image back. A break anywhere shows up as ERROR.
+    """
+    authenticated = environment_factory(
+        prefix="auth",
+        registry=AUTH_REGISTRY,
+        registry_username=AUTH_REGISTRY_USER,
+        registry_password=AUTH_REGISTRY_PASSWORD,
+    )
+
+    pipeline = run_to_completion(client, namespace, application, authenticated)
+
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"a deploy against an authenticated registry ended as "
+        f"{pipeline['status']}; the push, the secret propagation or the image "
+        f"pull failed")
+
+
+def test_wrong_registry_credentials_fail_the_pipeline(
+        client, namespace, application, environment_factory):
+    """The negative case, so the test above cannot pass for the wrong reason.
+
+    If a bad password still reached SUCCEEDED, it would mean the registry is not
+    actually enforcing auth and the previous test proves nothing.
+    """
+    broken = environment_factory(
+        prefix="badauth",
+        registry=AUTH_REGISTRY,
+        registry_username=AUTH_REGISTRY_USER,
+        registry_password="definitely-the-wrong-password",
+    )
+
+    pipeline = run_to_completion(client, namespace, application, broken)
+
+    assert pipeline["status"] == "ERROR", (
+        f"a push with wrong credentials ended as {pipeline['status']}, expected "
+        f"ERROR. Either the registry is not enforcing authentication, or a "
+        f"failed push is not being reported as a failed pipeline.")

--- a/tests/acceptance/test_sandbox.py
+++ b/tests/acceptance/test_sandbox.py
@@ -1,0 +1,724 @@
+"""Sandboxes: throwaway Kubernetes Jobs, long-lived pods, and their filesystems.
+
+Three shapes of the same idea, and they share almost no code. A one-shot
+execution is a Job that runs a script and is reaped; an instance is a
+StatefulSet kept alive so a terminal can attach to it; the file operations are
+`tar` and `cat` piped through an exec into that instance's container. Each layer
+can break on its own, and none of them is observable except through the layer
+above.
+
+All of it needs a cluster, so the whole file carries the marker. Every instance
+is created through a fixture that deletes it afterwards — an instance that
+outlives its test is a pod that keeps running and a node's worth of memory that
+never comes back.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from oops_client import wait_until
+
+pytestmark = pytest.mark.cluster
+
+# Configured under `oops.sandbox.images`. Both keep a container alive long
+# enough to exec into, which the sandbox instance depends on.
+KEEPALIVE_IMAGE = "python:3.12-slim"
+SHELL_IMAGE = "alpine:3.20"
+
+# A cold image pull plus scheduling. Generous, because a timeout here reads as a
+# broken sandbox rather than as a slow registry.
+INSTANCE_READY_TIMEOUT = 300
+EXECUTION_TIMEOUT = 240
+
+
+# -- fixtures ---------------------------------------------------------------
+
+
+def wait_for_running(client, sandbox_id: str) -> dict:
+    def running():
+        instance = client.get(f"/api/sandbox/instances/{sandbox_id}",
+                              expect_success=False)
+        if not instance.success or not instance.data:
+            return None
+        if instance.data["status"] == "FAILED":
+            pytest.fail(f"sandbox instance {sandbox_id} reached FAILED before "
+                        f"it could be used")
+        return instance.data if instance.data["status"] == "RUNNING" else None
+
+    return wait_until(running, timeout=INSTANCE_READY_TIMEOUT, interval=3,
+                      description=f"sandbox instance {sandbox_id} to run")
+
+
+@pytest.fixture
+def instance_factory(client, environment):
+    """Creates sandbox instances and removes them afterwards, always.
+
+    Function scoped on purpose: each instance is a running pod, so holding them
+    open until the end of the file would keep half a dozen containers alive at
+    once on a single-node cluster.
+    """
+    created: list[str] = []
+
+    def create(prefix: str = "acc-sandbox", image: str = KEEPALIVE_IMAGE,
+               **overrides) -> dict:
+        body = {
+            "environment": environment,
+            "name": f"{prefix}-{uuid.uuid4().hex[:8]}",
+            "image": image,
+        }
+        body.update(overrides)
+        instance = client.post("/api/sandbox/instances", body).data
+        created.append(instance["id"])
+        return instance
+
+    yield create
+
+    for sandbox_id in reversed(created):
+        try:
+            client.delete(f"/api/sandbox/instances/{sandbox_id}",
+                          expect_success=False)
+        except Exception:
+            # Cleanup is best effort, but a leak here leaves a pod running, so
+            # say so rather than swallowing it entirely.
+            print(f"failed to delete sandbox instance {sandbox_id}")
+
+
+@pytest.fixture(scope="module")
+def running_instance(client, environment) -> dict:
+    """One instance, started once, shared by every test that only reads it.
+
+    Exec and the file operations all need the same thing — a container to reach
+    into — and a cold start costs about fifteen seconds, so starting one per
+    test would spend minutes proving the same precondition. Each of them works
+    in a directory of its own, so sharing changes nothing they observe.
+    """
+    instance = client.post("/api/sandbox/instances", {
+        "environment": environment,
+        "name": f"acc-files-{uuid.uuid4().hex[:8]}",
+        "image": KEEPALIVE_IMAGE,
+    }).data
+    try:
+        yield wait_for_running(client, instance["id"])
+    finally:
+        client.delete(f"/api/sandbox/instances/{instance['id']}",
+                      expect_success=False)
+
+
+@pytest.fixture
+def scratch_directory(client, running_instance):
+    """A private directory per test, removed afterwards.
+
+    The instance is shared, so tests that wrote into a common path would pass or
+    fail depending on the order they ran in.
+    """
+    sandbox_id = running_instance["id"]
+    path = f"/tmp/acc-{uuid.uuid4().hex[:8]}"
+    client.post(f"/api/sandbox/instances/{sandbox_id}/files/directory",
+                {"path": path})
+    yield path
+    client.delete(f"/api/sandbox/instances/{sandbox_id}/files?path={path}",
+                  expect_success=False)
+
+
+# -- runtime images ---------------------------------------------------------
+
+
+def test_the_runtime_images_are_listed_and_sorted(client):
+    """The create form is a dropdown over this list, so its order is the order
+    an operator sees."""
+    images = client.get("/api/sandbox/images").data
+
+    assert images, (
+        "no sandbox runtime images are offered; the create form would present "
+        "an empty dropdown with nothing to explain why")
+    assert images == sorted(images), (
+        f"the runtime images came back unsorted: {images}. The dropdown renders "
+        f"them in the order given.")
+    assert KEEPALIVE_IMAGE in images, (
+        f"{KEEPALIVE_IMAGE} is not offered; the rest of this file assumes the "
+        f"configured images from `oops.sandbox.images`")
+
+
+def test_an_image_outside_the_configured_list_still_runs(client, environment):
+    """Documents that the image list is advisory rather than an allowlist.
+
+    `/api/sandbox/images` reads as the set of images a sandbox may use, and the
+    UI treats it that way, but nothing on the execution path checks a request
+    against it — any image the cluster can pull will run.
+
+    Written against today's behaviour. If the list is ever enforced this fails,
+    and should be inverted rather than deleted: enforcing it is the improvement,
+    and it is worth making deliberately because it would break every caller that
+    passes an image of its own.
+    """
+    offered = client.get("/api/sandbox/images").data
+    unlisted = "busybox:1.36"
+    if unlisted in offered:
+        pytest.skip(f"{unlisted} is configured, so it proves nothing here")
+
+    result = client.post("/api/sandbox/executions", {
+        "environment": environment,
+        "image": unlisted,
+        "commands": ["echo unlisted-image-ran"],
+        "timeoutSeconds": EXECUTION_TIMEOUT,
+    }, expect_success=False)
+
+    assert result.success is True, (
+        f"an unlisted image was refused ({result.message}); the runtime list is "
+        f"now enforced, which is an improvement — invert this test")
+    assert result.data["exitCode"] == 0, (
+        f"an unlisted image was accepted but its script exited "
+        f"{result.data['exitCode']}; the image could not be pulled or run")
+
+
+# -- one-shot executions ----------------------------------------------------
+
+
+def test_a_one_shot_execution_returns_its_combined_output(client, environment):
+    """The Job path: a script runs to completion and its output comes back in
+    the response rather than over a stream, because `stream` was not set."""
+    result = client.post("/api/sandbox/executions", {
+        "environment": environment,
+        "image": SHELL_IMAGE,
+        "commands": ["echo first-line", "echo second-line >&2"],
+        "timeoutSeconds": EXECUTION_TIMEOUT,
+    }).data
+
+    assert result["exitCode"] == 0, (
+        f"a successful script reported exit code {result['exitCode']}; the Job "
+        f"either failed or its status was not read back")
+    assert "first-line" in result["output"], (
+        f"stdout is missing from the output: {result['output']!r}")
+    assert "second-line" in result["output"], (
+        f"stderr is missing from the output: {result['output']!r}. Both streams "
+        f"are merged, which is the only way a caller sees why a script failed.")
+
+
+def test_the_commands_run_as_one_script_not_as_separate_processes(
+        client, environment):
+    """`commands` is joined with newlines into a single shell script, so state
+    set by one line is visible to the next. A caller writing a `cd` on its own
+    line depends on it."""
+    result = client.post("/api/sandbox/executions", {
+        "environment": environment,
+        "image": SHELL_IMAGE,
+        "commands": ["marker=carried-over", "echo $marker"],
+        "timeoutSeconds": EXECUTION_TIMEOUT,
+    }).data
+
+    assert "carried-over" in result["output"], (
+        f"the second command did not see the first one's variable: "
+        f"{result['output']!r}; the lines are being run as separate processes")
+
+
+def test_a_failing_script_reports_its_exit_code(client, environment):
+    """A non-zero exit is a successful call with a non-zero code, not a failed
+    envelope — the caller wanted the script's verdict, not an error."""
+    result = client.post("/api/sandbox/executions", {
+        "environment": environment,
+        "image": SHELL_IMAGE,
+        "commands": ["echo before-the-failure", "exit 7"],
+        "timeoutSeconds": EXECUTION_TIMEOUT,
+    })
+
+    assert result.success is True, (
+        f"a script that exited non-zero produced a failed envelope: "
+        f"{result.message}")
+    assert result.data["exitCode"] == 7, (
+        f"the script exited 7 but the API reported {result.data['exitCode']}; "
+        f"a caller cannot tell a failure from a success")
+    assert "before-the-failure" in result.data["output"], (
+        "output written before the failure was lost")
+
+
+def test_environment_variables_reach_the_container(client, environment):
+    marker = uuid.uuid4().hex[:12]
+    result = client.post("/api/sandbox/executions", {
+        "environment": environment,
+        "image": SHELL_IMAGE,
+        "commands": ["echo $ACCEPTANCE_MARKER"],
+        "env": {"ACCEPTANCE_MARKER": marker},
+        "timeoutSeconds": EXECUTION_TIMEOUT,
+    }).data
+
+    assert marker in result["output"], (
+        f"the environment variable did not reach the container: "
+        f"{result['output']!r}")
+
+
+def test_an_execution_validates_its_request_before_scheduling_anything(
+        client, environment):
+    """All of these are refused before a Job exists. Scheduling first and
+    failing afterwards would leave pods behind for requests that were never
+    going to be accepted."""
+    rejected = [
+        ({"image": SHELL_IMAGE, "commands": ["echo x"]},
+         "a missing environment"),
+        ({"environment": environment, "commands": ["echo x"]},
+         "a missing image"),
+        ({"environment": environment, "image": SHELL_IMAGE, "commands": []},
+         "an empty command list"),
+        ({"environment": environment, "image": SHELL_IMAGE,
+          "commands": ["   "]},
+         "a command list of nothing but blanks"),
+        ({"environment": environment, "image": SHELL_IMAGE,
+          "commands": ["echo x"], "timeoutSeconds": -1},
+         "a negative timeout"),
+        ({"environment": environment, "image": SHELL_IMAGE,
+          "commands": ["echo x"], "env": {"not a name": "value"}},
+         "an environment variable name a shell cannot express"),
+        ({"environment": "not-registered-9f3a", "image": SHELL_IMAGE,
+          "commands": ["echo x"]},
+         "an unregistered environment"),
+    ]
+    for body, description in rejected:
+        result = client.post("/api/sandbox/executions", body,
+                             expect_success=False)
+        assert result.success is False, (
+            f"{description} was accepted; the request reached the cluster "
+            f"before anyone checked it")
+        assert result.message, (
+            f"{description} was refused without a message, so the caller has "
+            f"nothing to correct")
+
+
+# -- instance lifecycle -----------------------------------------------------
+
+
+def test_an_instance_starts_pending_and_becomes_running(client, environment,
+                                                        instance_factory):
+    """Creation returns immediately with a PENDING instance; the pod is still
+    being scheduled. A caller that treated the create response as ready would
+    exec into a container that does not exist yet."""
+    instance = instance_factory(prefix="acc-lifecycle")
+
+    assert instance["status"] == "PENDING", (
+        f"a freshly created instance reported {instance['status']!r}; creation "
+        f"is meant to return before the pod is scheduled")
+    assert instance["id"], "the created instance has no id to address it by"
+    assert instance["environment"] == environment
+    assert instance["image"] == KEEPALIVE_IMAGE
+    assert instance["createdBy"], (
+        "the instance records no creator; the listing shows every user's "
+        "sandboxes and would have nothing to attribute them to")
+
+    running = wait_for_running(client, instance["id"])
+    assert running["status"] == "RUNNING"
+    assert running["createdByName"], (
+        "the running instance has no createdByName; the creator id is resolved "
+        "to a username on read, and the listing shows that name")
+
+
+def test_an_instance_is_listed_across_and_within_environments(
+        client, environment, instance_factory):
+    """Listing without an environment spans every registered one, which is what
+    the sandbox page opens with. The filters narrow it rather than being
+    required."""
+    instance = instance_factory(prefix="acc-listing")
+    sandbox_id = instance["id"]
+
+    everywhere = client.get("/api/sandbox/instances").data
+    assert sandbox_id in [item["id"] for item in everywhere], (
+        f"{sandbox_id} is absent from the unfiltered listing; listing without "
+        f"an environment is not spanning all of them")
+
+    in_environment = client.get(
+        f"/api/sandbox/instances?environment={environment}").data
+    assert sandbox_id in [item["id"] for item in in_environment], (
+        f"{sandbox_id} is absent from the {environment} listing")
+
+    by_image = client.get(
+        f"/api/sandbox/instances"
+        f"?environment={environment}&image={KEEPALIVE_IMAGE}").data
+    assert sandbox_id in [item["id"] for item in by_image], (
+        f"{sandbox_id} is absent when filtering by its own image")
+
+    other_image = client.get(
+        f"/api/sandbox/instances"
+        f"?environment={environment}&image={SHELL_IMAGE}").data
+    assert sandbox_id not in [item["id"] for item in other_image], (
+        f"{sandbox_id} runs {KEEPALIVE_IMAGE} but was returned when filtering "
+        f"for {SHELL_IMAGE}; the image filter is not applied")
+
+
+def test_a_single_instance_can_be_read_back_by_id(client, instance_factory):
+    instance = instance_factory(prefix="acc-read")
+    fetched = client.get(f"/api/sandbox/instances/{instance['id']}").data
+
+    assert fetched["id"] == instance["id"]
+    assert fetched["name"] == instance["name"]
+    assert fetched["image"] == instance["image"]
+
+
+def test_a_duplicate_instance_name_is_refused(client, environment,
+                                              instance_factory):
+    """Names are how the sandbox page addresses an instance, so two with the
+    same name would be indistinguishable in the listing."""
+    instance = instance_factory(prefix="acc-duplicate")
+
+    result = client.post("/api/sandbox/instances", {
+        "environment": environment,
+        "name": instance["name"],
+        "image": KEEPALIVE_IMAGE,
+    }, expect_success=False)
+
+    assert result.success is False, (
+        f"a second instance called {instance['name']!r} was created; the two "
+        f"are now indistinguishable in the listing")
+
+
+def test_an_instance_needs_an_environment_and_an_image(client, environment):
+    for body, description in [
+        ({"image": KEEPALIVE_IMAGE}, "a missing environment"),
+        ({"environment": environment}, "a missing image"),
+        ({"environment": "not-registered-9f3a", "image": KEEPALIVE_IMAGE},
+         "an unregistered environment"),
+    ]:
+        result = client.post("/api/sandbox/instances", body,
+                             expect_success=False)
+        assert result.success is False, (
+            f"{description} was accepted, so a pod was created that no listing "
+            f"can find")
+
+
+def test_a_deleted_instance_is_gone_from_both_the_listing_and_by_id(
+        client, environment, instance_factory):
+    """Deletion is the only thing that stops the pod, so a delete that reported
+    success without taking effect would leak a container indefinitely."""
+    instance = instance_factory(prefix="acc-delete")
+    sandbox_id = instance["id"]
+    wait_for_running(client, sandbox_id)
+
+    client.delete(f"/api/sandbox/instances/{sandbox_id}")
+
+    def gone():
+        result = client.get(f"/api/sandbox/instances/{sandbox_id}",
+                            expect_success=False)
+        return result.success is False
+
+    wait_until(gone, timeout=60, interval=2,
+               description=f"the deleted instance {sandbox_id} to stop being "
+                           f"readable; while it still resolves its pod is "
+                           f"still running and nothing will stop it")
+
+    listing = client.get(f"/api/sandbox/instances?environment={environment}").data
+    assert sandbox_id not in [item["id"] for item in listing], (
+        f"{sandbox_id} was deleted but is still in the listing")
+
+
+def test_deleting_an_unknown_instance_fails(client):
+    """A miss is an error rather than a silent success, because the caller's
+    whole reason to delete was to be sure the pod is gone."""
+    result = client.delete("/api/sandbox/instances/definitely-not-a-sandbox",
+                           expect_success=False)
+    assert result.success is False, (
+        "deleting an instance that does not exist reported success; a caller "
+        "cleaning up a mistyped id would believe it had worked")
+
+
+# -- exec inside an instance ------------------------------------------------
+
+
+def test_exec_runs_inside_the_running_instance(client, running_instance):
+    """Exec attaches to the live container rather than starting a new one, which
+    is the whole difference from a one-shot execution: the filesystem it sees is
+    the one the file operations write to."""
+    sandbox_id = running_instance["id"]
+    marker = uuid.uuid4().hex[:12]
+
+    client.put(f"/api/sandbox/instances/{sandbox_id}/files/content",
+               {"path": f"/tmp/{marker}", "content": marker})
+    try:
+        result = client.post(f"/api/sandbox/instances/{sandbox_id}/exec",
+                             {"command": f"cat /tmp/{marker}",
+                              "timeoutSeconds": 60}).data
+        assert marker in result["output"], (
+            f"exec did not see a file written through the file API: "
+            f"{result['output']!r}. The two are reaching different containers.")
+    finally:
+        client.delete(
+            f"/api/sandbox/instances/{sandbox_id}/files?path=/tmp/{marker}",
+            expect_success=False)
+
+
+def test_exec_reports_the_websocket_close_code_rather_than_the_exit_status(
+        client, running_instance):
+    """Documents a defect rather than endorsing it.
+
+    One-shot executions report the script's real exit code. Instance exec does
+    not: the gateway's `onClose(int code, ...)` callback carries the WebSocket
+    close code, and a normal close is 1000, so every command — successful or
+    not — comes back as 1000 and a caller cannot tell them apart.
+
+    Written against today's behaviour so the gap is visible. When the exit
+    status is read properly this test fails, and should be replaced with the
+    assertions in the comments rather than adjusted to the new sentinel.
+    """
+    sandbox_id = running_instance["id"]
+
+    succeeded = client.post(f"/api/sandbox/instances/{sandbox_id}/exec",
+                            {"command": "true", "timeoutSeconds": 60}).data
+    failed = client.post(f"/api/sandbox/instances/{sandbox_id}/exec",
+                         {"command": "exit 3", "timeoutSeconds": 60}).data
+
+    # Once the real status is reported these become 0 and 3.
+    assert succeeded["exitCode"] == failed["exitCode"] == 1000, (
+        f"instance exec now reports {succeeded['exitCode']} for a successful "
+        f"command and {failed['exitCode']} for one that exited 3. If those are "
+        f"the real exit statuses the defect is fixed — assert 0 and 3 here "
+        f"instead of deleting the test.")
+
+
+def test_exec_requires_a_command_and_a_known_instance(client, running_instance):
+    sandbox_id = running_instance["id"]
+
+    blank = client.post(f"/api/sandbox/instances/{sandbox_id}/exec",
+                        {"command": "   "}, expect_success=False)
+    assert blank.success is False, (
+        "a blank command was accepted; the shell would be handed nothing to run")
+
+    unknown = client.post("/api/sandbox/instances/definitely-not-a-sandbox/exec",
+                          {"command": "echo x"}, expect_success=False)
+    assert unknown.success is False, (
+        "exec against an unknown instance reported success; a mistyped id would "
+        "look like a command that produced no output")
+
+
+# -- instance filesystem ----------------------------------------------------
+
+
+def test_the_instance_filesystem_lists_the_container_root(client,
+                                                          running_instance):
+    """Listing with no path defaults to `/`, which is what the file browser
+    opens on."""
+    sandbox_id = running_instance["id"]
+    entries = client.get(f"/api/sandbox/instances/{sandbox_id}/files").data
+
+    assert entries, (
+        "the container root listed nothing; the file browser opens on an empty "
+        "pane with no explanation")
+
+    names = [entry["name"] for entry in entries]
+    assert "tmp" in names and "etc" in names, (
+        f"the root listing is missing the usual directories: {names}")
+
+    for entry in entries:
+        for field in ("name", "path", "type", "size"):
+            assert field in entry, f"a file entry is missing {field!r}"
+        assert entry["type"] in ("DIRECTORY", "FILE", "SYMLINK_DIRECTORY",
+                                 "SYMLINK_FILE", "OTHER"), (
+            f"{entry['name']} has type {entry['type']!r}, which the browser has "
+            f"no icon for")
+
+    # Symlinks are classified by what they point at, so the browser knows
+    # whether clicking one descends or opens an editor.
+    assert any(entry["type"].startswith("SYMLINK") for entry in entries), (
+        f"nothing in the container root was reported as a symlink, and a Debian "
+        f"root has several (/bin, /lib); symlinks are being flattened into "
+        f"plain entries: {names}")
+
+
+def test_a_file_written_through_the_api_reads_back_unchanged(
+        client, running_instance, scratch_directory):
+    """Write and read are the editor's save and open. Anything that mangles
+    newlines between them corrupts the file the user was editing."""
+    sandbox_id = running_instance["id"]
+    path = f"{scratch_directory}/note.txt"
+    content = "first line\nsecond line\n\ttabbed\n"
+
+    client.put(f"/api/sandbox/instances/{sandbox_id}/files/content",
+               {"path": path, "content": content})
+
+    stored = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files/content?path={path}").data
+    assert stored["path"] == path, (
+        f"the read echoed back {stored['path']!r} rather than the path asked for")
+    assert stored["content"] == content, (
+        f"the file came back as {stored['content']!r} rather than "
+        f"{content!r}; saving in the editor would corrupt the file")
+
+    listing = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files"
+        f"?path={scratch_directory}").data
+    entries = [entry for entry in listing if entry["name"] == "note.txt"]
+    assert entries, f"the written file is absent from the {scratch_directory} listing"
+    assert entries[0]["type"] == "FILE"
+    assert entries[0]["size"] == len(content.encode()), (
+        f"the listing reports {entries[0]['size']} bytes for a "
+        f"{len(content.encode())} byte file")
+
+
+def test_a_created_directory_is_listed_as_a_directory(client, running_instance,
+                                                      scratch_directory):
+    """The scratch directory itself was created through the API, so this checks
+    the parent listing rather than trusting the call that made it."""
+    sandbox_id = running_instance["id"]
+    nested = f"{scratch_directory}/nested"
+
+    client.post(f"/api/sandbox/instances/{sandbox_id}/files/directory",
+                {"path": nested})
+
+    listing = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files"
+        f"?path={scratch_directory}").data
+    entries = [entry for entry in listing if entry["name"] == "nested"]
+    assert entries, f"the created directory is absent from {scratch_directory}"
+    assert entries[0]["type"] == "DIRECTORY", (
+        f"the created directory is listed as {entries[0]['type']!r}; the "
+        f"browser would try to open it in the editor")
+
+    blank = client.post(f"/api/sandbox/instances/{sandbox_id}/files/directory",
+                        {"path": "  "}, expect_success=False)
+    assert blank.success is False, (
+        "a blank directory path was accepted; the target is whatever the shell "
+        "makes of an empty argument")
+
+
+def test_a_file_can_be_renamed_within_the_instance(client, running_instance,
+                                                   scratch_directory):
+    """Rename is a move, so the old path has to be gone as well as the new one
+    present — a copy would silently double the disk use of every rename."""
+    sandbox_id = running_instance["id"]
+    source = f"{scratch_directory}/before.txt"
+    target = f"{scratch_directory}/after.txt"
+    client.put(f"/api/sandbox/instances/{sandbox_id}/files/content",
+               {"path": source, "content": "renamed content\n"})
+
+    client.post(f"/api/sandbox/instances/{sandbox_id}/files/rename",
+                {"fromPath": source, "toPath": target})
+
+    listing = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files"
+        f"?path={scratch_directory}").data
+    names = [entry["name"] for entry in listing]
+    assert "after.txt" in names, f"the renamed file is absent: {names}"
+    assert "before.txt" not in names, (
+        f"the original file survived the rename: {names}; the file was copied "
+        f"rather than moved")
+
+    moved = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files/content?path={target}").data
+    assert moved["content"] == "renamed content\n", (
+        "the renamed file lost its content")
+
+    incomplete = client.post(
+        f"/api/sandbox/instances/{sandbox_id}/files/rename",
+        {"fromPath": target}, expect_success=False)
+    assert incomplete.success is False, (
+        "a rename without a destination was accepted; the file would be moved "
+        "somewhere the caller never named")
+
+
+def test_an_uploaded_file_lands_under_a_directory_path(client, running_instance,
+                                                       scratch_directory):
+    """A path ending in `/` means "into this directory, under the uploaded
+    name". That is how the browser uploads into the folder it is showing,
+    without having to construct the target name itself."""
+    sandbox_id = running_instance["id"]
+    payload = b"uploaded bytes\n"
+
+    client.post(
+        f"/api/sandbox/instances/{sandbox_id}/files/upload"
+        f"?path={scratch_directory}/",
+        files={"file": ("uploaded.txt", payload, "text/plain")})
+
+    stored = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files/content"
+        f"?path={scratch_directory}/uploaded.txt").data
+    assert stored["content"] == payload.decode(), (
+        f"the uploaded file reads back as {stored['content']!r}; the bytes were "
+        f"altered on the way through")
+
+
+def test_an_uploaded_file_can_be_given_an_explicit_name(client,
+                                                        running_instance,
+                                                        scratch_directory):
+    """A path that does not end in `/` is the target file itself, so the upload
+    can be renamed on the way in."""
+    sandbox_id = running_instance["id"]
+    target = f"{scratch_directory}/explicit.bin"
+
+    client.post(
+        f"/api/sandbox/instances/{sandbox_id}/files/upload?path={target}",
+        files={"file": ("original-name.txt", b"explicit\n", "text/plain")})
+
+    listing = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files"
+        f"?path={scratch_directory}").data
+    names = [entry["name"] for entry in listing]
+    assert "explicit.bin" in names, (
+        f"the upload did not take the name it was given: {names}")
+    assert "original-name.txt" not in names, (
+        f"the upload used the multipart filename instead of the requested "
+        f"path: {names}")
+
+
+def test_a_download_carries_the_bytes_and_names_the_file(client,
+                                                         running_instance,
+                                                         scratch_directory):
+    """Download is the one file endpoint that answers with bytes rather than the
+    envelope, and the browser saves whatever `Content-Disposition` names."""
+    sandbox_id = running_instance["id"]
+    path = f"{scratch_directory}/download.bin"
+    payload = b"\x00\x01binary payload\xff\n"
+
+    client.post(f"/api/sandbox/instances/{sandbox_id}/files/upload?path={path}",
+                files={"file": ("download.bin", payload,
+                                "application/octet-stream")})
+
+    response = client.raw(
+        "GET",
+        f"/api/sandbox/instances/{sandbox_id}/files/download?path={path}")
+
+    assert response.status_code == 200, (
+        f"the download answered HTTP {response.status_code}")
+    assert response.content == payload, (
+        f"the download returned {response.content!r} rather than the "
+        f"{len(payload)} bytes uploaded; the stream is being re-encoded")
+    disposition = response.headers.get("Content-Disposition", "")
+    assert "download.bin" in disposition, (
+        f"Content-Disposition is {disposition!r}; the browser would save the "
+        f"file under the request path instead of its own name")
+
+
+def test_a_deleted_path_disappears_from_the_listing(client, running_instance,
+                                                    scratch_directory):
+    """Delete takes files and directories alike, which is what the browser's one
+    delete button relies on."""
+    sandbox_id = running_instance["id"]
+    file_path = f"{scratch_directory}/doomed.txt"
+    directory_path = f"{scratch_directory}/doomed-directory"
+    client.put(f"/api/sandbox/instances/{sandbox_id}/files/content",
+               {"path": file_path, "content": "gone soon\n"})
+    client.post(f"/api/sandbox/instances/{sandbox_id}/files/directory",
+                {"path": directory_path})
+
+    client.delete(
+        f"/api/sandbox/instances/{sandbox_id}/files?path={file_path}")
+    client.delete(
+        f"/api/sandbox/instances/{sandbox_id}/files?path={directory_path}")
+
+    listing = client.get(
+        f"/api/sandbox/instances/{sandbox_id}/files"
+        f"?path={scratch_directory}").data
+    names = [entry["name"] for entry in listing]
+    assert "doomed.txt" not in names, (
+        f"the deleted file is still listed: {names}")
+    assert "doomed-directory" not in names, (
+        f"the deleted directory is still listed: {names}; delete only handles "
+        f"files and the browser's delete button silently does nothing on a "
+        f"folder")
+
+
+def test_file_operations_on_an_unknown_instance_fail(client):
+    """Every file endpoint resolves the instance to a pod first, so an unknown
+    id must fail there rather than reaching some other container."""
+    result = client.get(
+        "/api/sandbox/instances/definitely-not-a-sandbox/files?path=/tmp",
+        expect_success=False)
+    assert result.success is False, (
+        "listing files of an unknown instance reported success; the id is not "
+        "being resolved before the exec")

--- a/tests/acceptance/test_streams.py
+++ b/tests/acceptance/test_streams.py
@@ -1,0 +1,162 @@
+"""WebSocket streams: pipeline logs, pod logs, and the pod terminal.
+
+These sockets carry the log tailing and exec multiplexing that the Kubernetes
+gateways implement, and they have their own contract that is easy to get subtly
+wrong on a reimplementation — in particular the ping asymmetry: log sockets
+answer a text "ping" with "pong", terminal sockets must not, because their stdin
+is live and a stray "pong" would be typed into the user's shell.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from oops_client import read_until_closed, wait_until
+from test_deploy import (DEPLOY_TIMEOUT, TERMINAL_STATUSES, configure_for_build,
+                         git_strategy)
+
+pytestmark = pytest.mark.cluster
+
+
+@pytest.fixture(scope="module")
+def deployed_application(client, namespace, environment):
+    """One application, deployed once, shared by every test in this file.
+
+    All four tests need the same thing — a running workload with a finished
+    pipeline behind it — and a build takes about ninety seconds, so deploying per
+    test would spend six minutes proving the same precondition four times. None
+    of these tests mutate the application, so sharing is safe.
+    """
+    application = f"stream-{uuid.uuid4().hex[:8]}"
+    client.create_application(namespace, application)
+    try:
+        configure_for_build(client, namespace, application, environment)
+        pipeline_id = client.deploy(namespace, application, environment,
+                                    strategy=git_strategy())
+
+        def finished():
+            pipeline = client.get_pipeline(namespace, application, pipeline_id)
+            return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+        pipeline = wait_until(finished, timeout=DEPLOY_TIMEOUT,
+                              description="the fixture deploy to finish")
+        if pipeline["status"] != "SUCCEEDED":
+            pytest.skip(
+                f"fixture deploy ended as {pipeline['status']}, cannot stream")
+        yield application, pipeline_id
+    finally:
+        try:
+            client.delete_application(namespace, application,
+                                      expect_success=False)
+        except Exception:
+            pass
+
+
+def first_running_pod(client, namespace, application, environment):
+    """Name of a running pod, via the application status endpoint.
+
+    Pods are listed under `/status`, not under a `/pods` collection — the pod
+    path segment only exists for operations on a pod already known by name.
+    """
+    result = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/status"
+        f"?environment={environment}",
+        expect_success=False,
+    )
+    if not result.success or not result.data:
+        return None
+    for pod in result.data:
+        if pod.get("name") and pod.get("status") == "Running":
+            return pod["name"]
+    return None
+
+
+def test_pipeline_log_frames_are_tagged_json(client, namespace, environment,
+                                             deployed_application):
+    application, pipeline_id = deployed_application
+    socket = client.websocket(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/pipelines/{pipeline_id}/log")
+    try:
+        frames = []
+        for frame in read_until_closed(socket, timeout=30):
+            frames.append(frame)
+            if len(frames) >= 5:
+                break
+    finally:
+        socket.close()
+
+    assert frames, "the pipeline log socket delivered nothing"
+    for frame in frames:
+        payload = json.loads(frame)
+        assert "type" in payload, f"frame without a type field: {frame[:200]}"
+        assert payload["type"] in ("steps", "step", "error"), (
+            f"unexpected frame type {payload['type']!r}")
+
+
+def test_log_socket_answers_ping_with_pong(client, namespace, environment,
+                                           deployed_application):
+    application, pipeline_id = deployed_application
+    socket = client.websocket(
+        f"/api/namespaces/{namespace}/applications/{application}"
+        f"/pipelines/{pipeline_id}/log")
+    try:
+        socket.send("ping")
+        deadline_frames = []
+        for frame in read_until_closed(socket, timeout=15):
+            deadline_frames.append(frame)
+            if frame == "pong":
+                break
+        assert "pong" in deadline_frames, (
+            "the log socket did not answer a text ping with pong; the browser "
+            f"keepalive depends on it. Frames seen: {deadline_frames[:5]}")
+    finally:
+        socket.close()
+
+
+def test_pod_log_socket_streams_text_lines(client, namespace, environment,
+                                           deployed_application):
+    application, _ = deployed_application
+    pod = wait_until(
+        lambda: first_running_pod(client, namespace, application, environment),
+        timeout=180, interval=5, description="a running pod to appear")
+
+    socket = client.websocket(
+        f"/api/namespaces/{namespace}/applications/{application}/pods/{pod}/log")
+    try:
+        frames = [frame for _, frame in zip(range(3), read_until_closed(socket, 20))]
+    finally:
+        socket.close()
+
+    # Content depends on the image, so assert the transport rather than the text:
+    # lines arrive as text frames and are split, never glued together by a redraw.
+    for frame in frames:
+        assert isinstance(frame, str)
+        assert "\n" not in frame.rstrip("\n"), (
+            f"a log frame carried an embedded newline, lines are not being split: "
+            f"{frame[:200]!r}")
+
+
+def test_terminal_socket_does_not_answer_ping(client, namespace, environment,
+                                              deployed_application):
+    """The mirror image of the log-socket test: a terminal must stay silent, or
+    the keepalive ends up as characters in the user's shell."""
+    application, _ = deployed_application
+    pod = wait_until(
+        lambda: first_running_pod(client, namespace, application, environment),
+        timeout=180, interval=5, description="a running pod to appear")
+
+    socket = client.websocket(
+        f"/api/namespaces/{namespace}/applications/{application}/pods/{pod}/terminal")
+    try:
+        socket.send("ping")
+        answered = [frame for frame in read_until_closed(socket, timeout=8)
+                    if frame.strip() == "pong"]
+        assert not answered, (
+            "the terminal socket answered a ping with pong; that text would be "
+            "delivered into the live shell")
+    finally:
+        socket.close()

--- a/tests/acceptance/test_user.py
+++ b/tests/acceptance/test_user.py
@@ -1,0 +1,377 @@
+"""Accounts: the administrator's directory, and what an account does for itself.
+
+Two journeys rather than ten endpoint pings. An administrator creates an
+account, edits it, switches it off and removes it. The account holder meanwhile
+maintains their own email, password and access token, and must not be able to
+reach the administrative half of the same controller.
+
+The session logs in as admin/admin123 and later files depend on that, so every
+credential change here happens on a throwaway account that is removed again.
+None of it needs a cluster.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+
+from oops_client import OopsClient
+
+ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{24}$")
+
+# Access tokens are the machine credential for /openapi/**: a fixed prefix so a
+# leaked one is recognisable on sight, then a NanoId.
+ACCESS_TOKEN_PATTERN = re.compile(r"^sk-oops-[A-Za-z0-9_-]{24}$")
+
+INITIAL_PASSWORD = "acceptance-initial-123"
+REPLACEMENT_PASSWORD = "acceptance-replacement-456"
+
+
+def directory(client) -> list[dict]:
+    return client.get("/api/users").data or []
+
+
+def accounts_named(client, username: str) -> list[dict]:
+    return [item for item in directory(client) if item["username"] == username]
+
+
+def newest_account_named(client, username: str) -> dict | None:
+    """The most recently created account carrying the name.
+
+    Written to tolerate more than one match, because the API does not stop the
+    same username being registered twice — see the duplicate scenario below.
+    """
+    matches = accounts_named(client, username)
+    if not matches:
+        return None
+    return max(matches, key=lambda item: item["createdTime"])
+
+
+@pytest.fixture
+def user_factory(client):
+    """Creates accounts and removes them afterwards, even when a test fails.
+
+    Creation answers with `true` rather than the new identifier, so the id has
+    to be read back out of the directory. Cleanup deletes every row carrying the
+    name rather than one id, because duplicates are reachable through this API
+    and a leaked duplicate would poison the next run's login.
+    """
+    created: list[str] = []
+
+    def create(prefix: str = "acc-user", username: str | None = None,
+               password: str = INITIAL_PASSWORD) -> dict:
+        name = username or f"{prefix}-{uuid.uuid4().hex[:8]}"
+        email = f"{name}-{uuid.uuid4().hex[:4]}@example.invalid"
+        client.post("/api/users",
+                    {"username": name, "email": email, "password": password})
+        created.append(name)
+        stored = newest_account_named(client, name)
+        assert stored is not None, (
+            f"POST /api/users reported success for {name!r} but the account is "
+            "absent from the directory, so nothing was actually persisted")
+        return {"username": name, "password": password, "email": email,
+                "id": stored["id"]}
+
+    yield create
+
+    for name in reversed(created):
+        try:
+            for account in accounts_named(client, name):
+                client.delete(f"/api/users/{account['id']}", expect_success=False)
+        except Exception:
+            # Cleanup is best effort — a leaked account must never mask the
+            # assertion failure that got us here.
+            pass
+
+
+def test_the_directory_lists_pages_and_filters_the_same_accounts(client, user_factory):
+    account = user_factory()
+
+    listed = directory(client)
+    assert isinstance(listed, list), (
+        "GET /api/users must answer with a flat array; the admin console renders "
+        "it directly")
+    assert account["username"] in [item["username"] for item in listed], (
+        "a freshly created account is missing from the flat listing, so it would "
+        "be invisible in the console that just created it")
+
+    page = client.get("/api/users/page?page=1&size=5").data
+    for field in ("total", "data", "size", "totalPages"):
+        assert field in page, f"the user page envelope is missing {field!r}"
+    assert page["size"] == 5, "size should echo the requested page size"
+    assert page["total"] >= len(page["data"]), (
+        "total is smaller than the page it describes, which makes the pager "
+        "compute the wrong number of pages")
+
+    by_username = client.get(
+        f"/api/users/page?keyword={account['username']}&page=1&size=10").data
+    assert [item["username"] for item in by_username["data"]] == [account["username"]], (
+        "the keyword filter did not narrow the page to the one matching account")
+
+    by_email = client.get(
+        f"/api/users/page?keyword={account['email']}&page=1&size=10").data
+    assert [item["username"] for item in by_email["data"]] == [account["username"]], (
+        "the keyword filter ignores the email address, so an administrator "
+        "holding only an address cannot find the account behind it")
+
+
+def test_an_account_lifecycle_from_creation_to_removal(client, endpoint, user_factory):
+    account = user_factory()
+    assert ID_PATTERN.match(account["id"]), (
+        f"user id {account['id']!r} is not a 24-char NanoId")
+
+    OopsClient(endpoint).login(account["username"], account["password"])
+
+    updated_email = f"updated-{uuid.uuid4().hex[:6]}@example.invalid"
+    client.put(f"/api/users/{account['id']}", {
+        "role": "ADMIN",
+        "email": updated_email,
+        "password": REPLACEMENT_PASSWORD,
+        "enabled": False,
+    })
+
+    stored = newest_account_named(client, account["username"])
+    assert stored["role"] == "ADMIN", "the administrative role change was not stored"
+    assert stored["email"] == updated_email, "the email change was not stored"
+    assert stored["enabled"] is False, (
+        "the account is still enabled after being switched off, so a departing "
+        "colleague would keep their access")
+
+    disabled = OopsClient(endpoint).post(
+        "/api/auth/login",
+        {"username": account["username"], "password": REPLACEMENT_PASSWORD},
+        authenticated=False, expect_success=False)
+    assert disabled.success is False, (
+        "a disabled account was still able to log in, which makes disabling an "
+        "account meaningless")
+
+    client.put(f"/api/users/{account['id']}", {
+        "role": "USER",
+        "email": updated_email,
+        "enabled": True,
+    })
+
+    revived = OopsClient(endpoint)
+    revived.login(account["username"], REPLACEMENT_PASSWORD)
+    assert revived.get("/api/users/me").data["role"] == "USER", (
+        "the re-enabled account did not come back as a plain user, so the "
+        "temporary promotion was never undone")
+
+    client.delete(f"/api/users/{account['id']}")
+    assert accounts_named(client, account["username"]) == [], (
+        "the deleted account is still in the directory")
+
+    gone = OopsClient(endpoint).post(
+        "/api/auth/login",
+        {"username": account["username"], "password": REPLACEMENT_PASSWORD},
+        authenticated=False, expect_success=False)
+    assert gone.success is False, "a deleted account can still log in"
+
+
+def test_the_self_service_journey(client, endpoint, user_factory):
+    """Profile, password and access token, all driven by the account holder.
+
+    A plain user owns these three endpoints outright — no administrator is in
+    the loop — which is exactly why they need to hold their own boundaries.
+    """
+    account = user_factory()
+    holder = OopsClient(endpoint)
+    holder.login(account["username"], account["password"])
+
+    me = holder.get("/api/users/me").data
+    assert me["id"] == account["id"], (
+        "GET /api/users/me answered with somebody else's account")
+    assert me["username"] == account["username"]
+    assert me["role"] == "USER", "a newly created account must not be an administrator"
+
+    self_chosen_email = f"self-{uuid.uuid4().hex[:6]}@example.invalid"
+    holder.put("/api/users/me", {"email": self_chosen_email})
+    assert holder.get("/api/users/me").data["email"] == self_chosen_email, (
+        "the profile update reported success but the email did not change")
+
+    wrong_old = holder.put(
+        "/api/users/me/password",
+        {"oldPassword": "not-the-current-password", "newPassword": REPLACEMENT_PASSWORD},
+        expect_success=False)
+    assert wrong_old.success is False, (
+        "the password was changed without proving knowledge of the old one, so "
+        "a stolen session token is enough to take the account over")
+
+    blank_new = holder.put(
+        "/api/users/me/password",
+        {"oldPassword": account["password"], "newPassword": ""},
+        expect_success=False)
+    assert blank_new.success is False, "a blank password was accepted"
+
+    holder.put("/api/users/me/password",
+               {"oldPassword": account["password"], "newPassword": REPLACEMENT_PASSWORD})
+
+    stale = OopsClient(endpoint).post(
+        "/api/auth/login",
+        {"username": account["username"], "password": account["password"]},
+        authenticated=False, expect_success=False)
+    assert stale.success is False, "the replaced password still works"
+    OopsClient(endpoint).login(account["username"], REPLACEMENT_PASSWORD)
+
+    first_token = holder.post("/api/users/me/access-token/reset").data
+    assert ACCESS_TOKEN_PATTERN.match(first_token), (
+        f"access token {first_token!r} does not carry the sk-oops- prefix and a "
+        "NanoId; the prefix is what makes a leaked token recognisable")
+
+    second_token = holder.post("/api/users/me/access-token/reset").data
+    assert second_token != first_token, (
+        "resetting the access token handed back the same value, so a leaked "
+        "token cannot actually be revoked")
+    assert holder.get("/api/users/me").data["accessToken"] == second_token, (
+        "the account still carries the superseded access token")
+
+
+def test_account_creation_requires_a_username_and_an_email(client):
+    for payload, missing in (
+        ({"username": "", "email": "someone@example.invalid", "password": "x"}, "username"),
+        ({"username": "acc-no-email", "email": "", "password": "x"}, "email"),
+    ):
+        result = client.post("/api/users", payload, expect_success=False)
+        assert result.success is False, (
+            f"an account with a blank {missing} was accepted")
+        assert result.message, (
+            f"the rejection of a blank {missing} carries no message, leaving the "
+            "form with nothing to show")
+
+
+def test_a_plain_user_cannot_create_accounts(endpoint, secondary_user):
+    """Authorisation holds, but the refusal is indistinguishable from a fault.
+
+    Denial is reported as HTTP 200 with success=false and the message "Internal
+    server error", because the catch-all exception handler swallows the access
+    denial along with everything else. Documented rather than endorsed: the
+    refusal is correct, its wording tells the caller to retry a request that
+    will never succeed. Fix it by handling AccessDeniedException separately, and
+    change this test in the same commit.
+    """
+    plain = OopsClient(endpoint)
+    plain.login(secondary_user["username"], secondary_user["password"])
+
+    result = plain.post("/api/users", {
+        "username": f"acc-forbidden-{uuid.uuid4().hex[:8]}",
+        "email": "forbidden@example.invalid",
+        "password": "acceptance-forbidden-123",
+    }, expect_success=False)
+    assert result.success is False, (
+        "a plain user created an account, so anyone who can log in can mint "
+        "themselves a second identity")
+
+
+def test_duplicate_usernames_are_accepted_and_then_break_login(client, endpoint,
+                                                               user_factory):
+    """Pins a defect so that fixing it is a deliberate, visible act.
+
+    Nothing rejects a username that is already taken, and the second account is
+    not merely cosmetic: the login lookup expects at most one row, so the moment
+    a name is duplicated *both* holders are locked out with an internal error.
+
+    Written against today's behaviour. When the uniqueness constraint arrives
+    this test fails at the first assertion and should be inverted rather than
+    deleted, because the change is visible to every user who has ever picked a
+    name.
+    """
+    account = user_factory()
+    user_factory(username=account["username"], password=REPLACEMENT_PASSWORD)
+
+    assert len(accounts_named(client, account["username"])) == 2, (
+        "the second account with an existing username was rejected — usernames "
+        "are unique now, which is an improvement; invert this test")
+
+    ambiguous = OopsClient(endpoint).post(
+        "/api/auth/login",
+        {"username": account["username"], "password": account["password"]},
+        authenticated=False, expect_success=False)
+    assert ambiguous.success is False, (
+        "login resolved a duplicated username, so it silently picked one of two "
+        "accounts")
+
+
+def test_an_admin_update_clears_the_role_it_does_not_mention(client, endpoint,
+                                                             user_factory):
+    """Pins an asymmetry that quietly bricks accounts.
+
+    `password` and `enabled` are patched — omitting them keeps the stored value
+    — while `role` and `email` are overwritten with whatever the body carries,
+    null included. An administrator who submits a partial body therefore strips
+    the role, and an account with no role cannot log in at all.
+
+    Documented rather than endorsed. Making every field patch-like, or rejecting
+    a null role, would be an improvement; this test should change with it.
+    """
+    account = user_factory()
+
+    client.put(f"/api/users/{account['id']}", {"email": account["email"]})
+
+    stored = newest_account_named(client, account["username"])
+    assert stored["role"] is None, (
+        "the role survived an update that omitted it — partial updates are now "
+        "safe, which is an improvement; invert this test")
+
+    locked_out = OopsClient(endpoint).post(
+        "/api/auth/login",
+        {"username": account["username"], "password": account["password"]},
+        authenticated=False, expect_success=False)
+    assert locked_out.success is False, (
+        "an account with no role can log in again, so the consequence this test "
+        "documents is gone; invert it")
+
+
+def test_editing_or_deleting_an_unknown_account_reports_success(client):
+    """A missing account is not an error here — both calls answer success=true.
+
+    Pinned because it is the kind of undocumented contract a reimplementation
+    quietly changes. Returning 404, or success=false, would break every caller
+    that currently treats `true` as confirmation. It also means an administrator
+    editing a stale row is told the change landed when nothing happened. Change
+    it deliberately, and change this test in the same commit.
+    """
+    missing = "definitely-not-a-user-x"
+
+    updated = client.put(f"/api/users/{missing}",
+                         {"role": "USER", "email": "nobody@example.invalid"},
+                         expect_success=False)
+    assert updated.status == 200, f"expected HTTP 200, got {updated.status}"
+    assert updated.success is True and updated.data is True, (
+        "updating an unknown account no longer reports success; that is arguably "
+        "better, but it changes the contract every caller was written against")
+
+    removed = client.delete(f"/api/users/{missing}", expect_success=False)
+    assert removed.status == 200, f"expected HTTP 200, got {removed.status}"
+    assert removed.success is True and removed.data is True, (
+        "deleting an unknown account no longer reports success; same contract "
+        "change as above")
+
+
+def test_every_user_payload_carries_the_stored_password_hash(client):
+    """Documents an exposure, and fails the day it is closed.
+
+    The user aggregate is serialised as-is, so the BCrypt hash and the access
+    token travel to every authenticated caller of GET /api/users, /page and /me
+    — including plain users, who have no business reading either. Hashes are not
+    plaintext, but they are offline-crackable, and the access token is a live
+    credential in the clear.
+
+    Kept as a test rather than a comment so that introducing a response DTO is
+    noticed here first.
+    """
+    me = client.get("/api/users/me").data
+    assert "password" in me, (
+        "the password hash is no longer serialised — the exposure this test "
+        "documents has been fixed; delete this test and the field from any "
+        "client that reads it")
+
+
+def test_the_enabled_external_login_providers_are_listed(client):
+    providers = client.get("/api/auth/external/providers").data
+    assert isinstance(providers, list), (
+        "the provider list must be an array; the login page iterates it to draw "
+        "one button per provider")
+    assert all(isinstance(item, str) for item in providers), (
+        "provider entries must be plain identifier strings")

--- a/tests/acceptance/test_zz_coverage.py
+++ b/tests/acceptance/test_zz_coverage.py
@@ -1,0 +1,117 @@
+"""Every endpoint must be reached by some scenario.
+
+Named to sort last, because it judges what the rest of the run did: the client
+records each (method, path) it calls, and this compares that against the route
+table extracted from the controllers.
+
+The point is that coverage cannot quietly rot. Add a controller and this test
+fails until a scenario exercises it — which forces the new surface into a
+scenario rather than into a list of endpoints someone pings for a green tick.
+
+It only means something after a full run. On a filtered run — `-k`, the contract
+tier alone, or `./run.sh --module deploy` — most routes are legitimately
+untouched, so it skips instead of failing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from oops_client import CALLED
+
+ROUTES_FILE = Path(__file__).parent / "routes.json"
+
+# Routes the suite reaches without going through OopsClient, or that only a
+# browser can drive. Each needs a reason; an entry without one is a hole.
+UNREACHABLE = {
+    "GET /api/": "the SPA index, served to browsers",
+    "GET /api/{}": "the SPA catch-all, served to browsers",
+}
+
+
+def normalise(path: str) -> str:
+    return re.sub(r"\{[^}]+\}", "{}", path.split("?", 1)[0])
+
+
+def load_routes() -> list[dict]:
+    if not ROUTES_FILE.exists():
+        pytest.skip(f"no {ROUTES_FILE.name}; run scripts/extract_routes.py")
+    return json.loads(ROUTES_FILE.read_text())
+
+
+def segments_match(template: str, actual: str) -> bool:
+    """A concrete path matches a template when the literal segments line up."""
+    left, right = template.strip("/").split("/"), actual.strip("/").split("/")
+    if len(left) != len(right):
+        return False
+    return all(expected == "{}" or expected == got
+               for expected, got in zip(left, right))
+
+
+def called_keys() -> set[str]:
+    """Fold every recorded call onto the route template it hit."""
+    routes = load_routes()
+    matched: set[str] = set()
+    for method, path in CALLED:
+        actual = normalise(path)
+        for route in routes:
+            if route["method"] != method:
+                continue
+            if segments_match(normalise(route["path"]), actual):
+                matched.add(route["key"])
+                break
+    return matched
+
+
+def is_filtered(config) -> bool:
+    """Whether this run was narrowed to part of the suite.
+
+    Selecting modules is the common case — `--module deploy` reaches the routes
+    deploying uses and nothing else, which is not a coverage regression.
+    """
+    if config.getoption("-k") or config.getoption("-m"):
+        return True
+    return any(Path(argument.split("::")[0]).name.startswith("test_")
+               for argument in config.args)
+
+
+def test_every_endpoint_is_exercised_by_a_scenario(request):
+    routes = load_routes()
+    if is_filtered(request.config):
+        pytest.skip("coverage is only meaningful on a full, unfiltered run")
+
+    reached = called_keys()
+    missing = sorted(route["key"] for route in routes
+                     if route["key"] not in reached
+                     and route["key"] not in UNREACHABLE)
+
+    if missing:
+        by_controller: dict[str, list[str]] = {}
+        for route in routes:
+            if route["key"] in missing:
+                by_controller.setdefault(route["controller"], []).append(
+                    route["key"])
+        report = "\n".join(
+            f"  {controller}:\n" + "\n".join(f"    {key}" for key in sorted(keys))
+            for controller, keys in sorted(by_controller.items()))
+        pytest.fail(
+            f"{len(missing)} of {len(routes)} endpoints are not reached by any "
+            f"scenario:\n{report}\n\n"
+            f"Add them to a scenario that exercises them meaningfully, or list "
+            f"them in UNREACHABLE with the reason they cannot be driven.")
+
+
+def test_coverage_report(request, record_property):
+    """Always-passing companion that puts the number in the report."""
+    routes = load_routes()
+    reached = called_keys()
+    covered = len([r for r in routes if r["key"] in reached])
+    percentage = 100.0 * covered / len(routes) if routes else 0.0
+    record_property("endpoints_total", len(routes))
+    record_property("endpoints_covered", covered)
+    record_property("endpoint_coverage_percent", round(percentage, 1))
+    print(f"\nendpoint coverage: {covered}/{len(routes)} ({percentage:.1f}%)")


### PR DESCRIPTION
The Kubernetes layer is roughly 5.7k lines across 15 gateways and carries almost no tests, because testing it needs a live API server. That is exactly the layer a rewrite gets wrong, and it is why the Go attempt produced more bugs than it replaced: there was nothing to check a reimplementation against.

These tests speak only HTTP and WebSocket and import nothing from the backend, so the same suite is the acceptance criteria for the current Java service, a Go or Rust rewrite, or a GraalVM native build. They are organised as scenarios rather than per endpoint, because what has to be preserved is behaviour and every defect found here needed a full journey to surface. Coverage is then enforced from the other side: the client records every (method, path) it calls and test_zz_coverage.py compares that against a route table extracted from the controllers, so adding a controller turns the suite red until a scenario exercises it.

One command runs everything:

    cd tests/acceptance && ./run.sh

It creates the virtualenv, starts MySQL, RustFS, Gitea and two registries (one anonymous, one behind htpasswd — the two configurations take completely different paths through OOPS), builds and runs the backend in a container, starts k3s, registers it as an environment, runs the suite, writes an HTML and a JUnit report, and removes all of it again, including when you interrupt it. Nothing is installed on the host and no existing kubeconfig, database or registry is touched. --module runs part of it; naming only modules that need no cluster skips starting k3s.

k3s rather than kind because it ships Traefik, so IngressRouteProcessor actually runs — under kind every deploy took the "no host configured" branch and the whole ingress path went unexecuted, which is where the pruning defect fixed in 72b3680 had been hiding.

The backend runs in a container rather than on the host because a presigned URL is signed for one hostname and redeemed by both the backend and the pipeline pods, so they have to resolve it the same way. On the host that takes a machine's LAN address, which is absent offline, changes on a VPN, and differs on every CI runner.

The run prints as numbered steps like a docker build: headings, results and failures stay, while log output and the "waiting for the deploy to finish" reports scroll in a small self-erasing region. So a forty-minute run leaves a page worth reading rather than forty minutes of container plumbing, and a slow test is still distinguishable from a hung one.

The workflow is manual only. A full run builds and deploys a container image per scenario and takes tens of minutes, so it is something you ask for before a release or on a branch touching the Kubernetes layer, not something that happens to every push.

README.md records what the suite found, including three defects fixed on main and several security findings left as decisions rather than test-driven drive-bys.