### PR TITLE
fix(deploy): unstick rollouts blocked by a pod a failed release left behind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Deployment triggering logic lives in `DeploymentService` (not `PipelineService`)
 **Deploy processor chain**: `ArtifactDeployTask` orchestrates deployment via a sequence of `DeployProcessor`s sharing a `DeployContext`:
 1. `NamespaceProcessor` — ensures target namespace exists
 2. `ImagePullSecretProcessor` — creates registry pull secret
-3. `StatefulSetProcessor` — applies the StatefulSet (sets `ownerReference` on context)
+3. `StatefulSetProcessor` — applies the StatefulSet (sets `ownerReference` on context), then runs `RolloutUnsticker` to delete the app's not-ready pods (best-effort — a failed delete is logged, never fails the deploy): under the default OrderedReady policy the controller never replaces a pod that isn't running-and-ready, so a crash-looping leftover from a failed release would otherwise block the new rollout forever. `applyRuntimeSpec` and `rolloutRestart` write a new pod-template revision too and run the same unstick. Relatedly, `getDeploymentHealth` only treats a fatal waiting reason (CrashLoopBackOff etc.) as a rollout failure once the controller has observed the current generation and only for pods on the StatefulSet's `updateRevision` — an old pod's crash must not fail a fresh rollout.
 4. `ServiceProcessor` — creates Service with `ownerReference` → StatefulSet
 5. `IngressRouteProcessor` — creates Traefik IngressRoutes with TLS/redirect logic and `ownerReference` → StatefulSet
 

--- a/src/main/java/com/github/wellch4n/oops/application/dto/DeploymentHealth.java
+++ b/src/main/java/com/github/wellch4n/oops/application/dto/DeploymentHealth.java
@@ -6,8 +6,9 @@ import java.time.Instant;
 /**
  * Post-deploy rollout snapshot of an application's StatefulSet, used to drive the ROLLING_OUT -> SUCCEEDED/ERROR
  * transition. {@code rolloutComplete} means the new revision is fully ready; {@code failureReason} carries the
- * first fatal pod condition (e.g. ImagePullBackOff), and {@code notReadySince} lets the pipeline fail a rollout
- * that has remained not ready for too long without storing another deadline in the pipeline row.
+ * first fatal pod condition (e.g. ImagePullBackOff) attributable to the update revision — a crash-looping
+ * leftover from a previous release must not fail a fresh rollout — and {@code notReadySince} lets the pipeline
+ * fail a rollout that has remained not ready for too long without storing another deadline in the pipeline row.
  */
 public record DeploymentHealth(
         boolean workloadMissing,

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesApplicationRuntimeGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesApplicationRuntimeGateway.java
@@ -8,6 +8,8 @@ import com.github.wellch4n.oops.application.port.ApplicationRuntimeGateway;
 import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
 import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.domain.shared.OopsTypes;
+import com.github.wellch4n.oops.infrastructure.kubernetes.pod.PodStates;
+import com.github.wellch4n.oops.infrastructure.kubernetes.pod.RolloutUnsticker;
 import com.github.wellch4n.oops.infrastructure.kubernetes.task.processor.StatefulSetProcessor;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.MicroTime;
@@ -114,6 +116,12 @@ public class KubernetesApplicationRuntimeGateway implements ApplicationRuntimeGa
                             .forEach(container -> container.setResources(resources));
                     return existing;
                 });
+
+        // The resources edit writes a new pod-template revision, and under OrderedReady the
+        // controller never replaces a pod that is not running and ready — so the crash-looping pod
+        // this change is often meant to repair (e.g. raising the memory limit of an OOMKilled app)
+        // would block its own fix forever.
+        RolloutUnsticker.deleteRolloutBlockingPods(client, namespace, applicationPodLabels(applicationName));
     }
 
     private ResourceRequirements buildResources(ApplicationRuntimeSpec.EnvironmentConfig runtimeSpec) {
@@ -430,6 +438,10 @@ public class KubernetesApplicationRuntimeGateway implements ApplicationRuntimeGa
                     annotations.put(RESTARTED_AT_ANNOTATION, restartedAt);
                     return target;
                 });
+        // A not-ready pod would block the OrderedReady rollout the annotation just triggered — and a
+        // scheduled restart has nothing watching for convergence, so a stuck one would go unnoticed.
+        // Deleting it is also the restart the pod itself needs (it resets the CrashLoop backoff).
+        RolloutUnsticker.deleteRolloutBlockingPods(client, namespace, applicationPodLabels(applicationName));
         log.info("Triggered rolling restart for {}/{}", namespace, applicationName);
     }
 
@@ -496,7 +508,13 @@ public class KubernetesApplicationRuntimeGateway implements ApplicationRuntimeGa
                 || (observedGeneration != null && observedGeneration >= generation);
         boolean rolloutComplete = generationObserved && updated == desired && ready == desired;
 
-        String failureReason = findFatalPodWaitingReason(client, namespace, applicationName);
+        String updateRevision = status != null ? status.getUpdateRevision() : null;
+        // Before the controller observes the patched generation, status.updateRevision still names the
+        // previous revision, so a crashing leftover pod would be misattributed to the new rollout —
+        // only report a failure once the revision attribution is trustworthy.
+        String failureReason = generationObserved
+                ? findFatalPodWaitingReason(client, namespace, applicationName, updateRevision)
+                : null;
         Instant notReadySince = rolloutComplete
                 ? null
                 : findRolloutNotReadySince(client, namespace, applicationName, statefulSet);
@@ -564,13 +582,25 @@ public class KubernetesApplicationRuntimeGateway implements ApplicationRuntimeGa
         }
     }
 
-    private String findFatalPodWaitingReason(KubernetesClient client, String namespace, String applicationName) {
+    private String findFatalPodWaitingReason(KubernetesClient client,
+                                             String namespace,
+                                             String applicationName,
+                                             String updateRevision) {
         var pods = client.pods()
                 .inNamespace(namespace)
                 .withLabel(APPLICATION_TYPE_LABEL, OopsTypes.APPLICATION.name())
                 .withLabel(APPLICATION_NAME_LABEL, applicationName)
                 .list();
         for (Pod pod : pods.getItems()) {
+            if (PodStates.isTerminating(pod)) {
+                continue;
+            }
+            // A pod still on an old revision is what this rollout replaces, not evidence that the new
+            // version failed — a crash-looping leftover from a previous release must not fail the
+            // fresh rollout. Only pods created from the update revision can condemn it.
+            if (StringUtils.isNotBlank(updateRevision) && !PodStates.isAtRevision(pod, updateRevision)) {
+                continue;
+            }
             if (pod.getStatus() == null || pod.getStatus().getContainerStatuses() == null) {
                 continue;
             }
@@ -585,6 +615,11 @@ public class KubernetesApplicationRuntimeGateway implements ApplicationRuntimeGa
             }
         }
         return null;
+    }
+
+    private Map<String, String> applicationPodLabels(String applicationName) {
+        return Map.of(APPLICATION_TYPE_LABEL, OopsTypes.APPLICATION.name(),
+                APPLICATION_NAME_LABEL, applicationName);
     }
 
     private boolean hasResource(ApplicationRuntimeSpec.EnvironmentConfig runtimeSpec) {

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PodStates.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PodStates.java
@@ -1,0 +1,40 @@
+package com.github.wellch4n.oops.infrastructure.kubernetes.pod;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pod-state predicates matching the StatefulSet controller's own definitions ({@code isTerminating},
+ * {@code isRunningAndReady}, pod revision), so deploy-time decisions line up with what the controller
+ * will actually do next.
+ */
+public final class PodStates {
+
+    /** Label the StatefulSet controller stamps on each pod with the ControllerRevision it was created from. */
+    public static final String CONTROLLER_REVISION_LABEL = "controller-revision-hash";
+
+    private PodStates() {}
+
+    public static boolean isTerminating(Pod pod) {
+        return pod.getMetadata() != null && pod.getMetadata().getDeletionTimestamp() != null;
+    }
+
+    public static boolean isRunningAndReady(Pod pod) {
+        if (pod.getStatus() == null || !"Running".equals(pod.getStatus().getPhase())) {
+            return false;
+        }
+        List<PodCondition> conditions = pod.getStatus().getConditions();
+        if (conditions == null) {
+            return false;
+        }
+        return conditions.stream().anyMatch(condition ->
+                "Ready".equals(condition.getType()) && "True".equalsIgnoreCase(condition.getStatus()));
+    }
+
+    public static boolean isAtRevision(Pod pod, String revision) {
+        Map<String, String> labels = pod.getMetadata() != null ? pod.getMetadata().getLabels() : null;
+        return labels != null && revision != null && revision.equals(labels.get(CONTROLLER_REVISION_LABEL));
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/RolloutUnsticker.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/RolloutUnsticker.java
@@ -1,0 +1,53 @@
+package com.github.wellch4n.oops.infrastructure.kubernetes.pod;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Unsticks a StatefulSet rollout from pods that will never become ready. Under the default
+ * OrderedReady pod management policy the controller makes no progress at all — including replacing
+ * pods with an updated template — while any existing pod is not running and ready, so a pod
+ * crash-looping or unable to pull its image blocks every later template change forever (Kubernetes
+ * documents this state as requiring manual pod deletion, and the policy is immutable after
+ * creation). Deleting such pods lets the controller recreate them, and apps/v1 always recreates
+ * from the update revision, so this must run only <b>after</b> the template change is applied.
+ *
+ * <p>Deletion is best-effort: the template change is already applied by the time this runs, so a
+ * pod that cannot be deleted (missing {@code pods/delete} permission on the environment token, a
+ * transient conflict) must not fail the very change that would repair it. Worst case the rollout
+ * stays blocked and times out, reporting the stuck pod's state. Pods already terminating are left
+ * alone — re-deleting them is a no-op, and force-deleting a StatefulSet pod is not safe to automate.
+ */
+@Slf4j
+public final class RolloutUnsticker {
+
+    private RolloutUnsticker() {}
+
+    public static void deleteRolloutBlockingPods(KubernetesClient client, String namespace, Map<String, String> podLabels) {
+        List<Pod> pods;
+        try {
+            pods = client.pods().inNamespace(namespace).withLabels(podLabels).list().getItems();
+        } catch (Exception exception) {
+            log.warn("Failed to list pods in {} while checking for rollout-blocking pods: {}",
+                    namespace, exception.getMessage());
+            return;
+        }
+        for (Pod pod : pods) {
+            if (PodStates.isTerminating(pod) || PodStates.isRunningAndReady(pod)) {
+                continue;
+            }
+            String podName = pod.getMetadata().getName();
+            try {
+                log.info("Deleting not-ready pod {}/{} so the StatefulSet controller can replace it with the updated template",
+                        namespace, podName);
+                client.pods().inNamespace(namespace).resource(pod).delete();
+            } catch (Exception exception) {
+                log.warn("Failed to delete not-ready pod {}/{}; the rollout may stay blocked until it is deleted manually: {}",
+                        namespace, podName, exception.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/processor/StatefulSetProcessor.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/processor/StatefulSetProcessor.java
@@ -5,6 +5,7 @@ import com.github.wellch4n.oops.domain.application.ApplicationPriority;
 import com.github.wellch4n.oops.domain.application.ApplicationRuntimeSpec;
 import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesConfigMapGateway;
 import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesNodeAffinities;
+import com.github.wellch4n.oops.infrastructure.kubernetes.pod.RolloutUnsticker;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
@@ -175,6 +176,10 @@ public class StatefulSetProcessor implements DeployProcessor {
                 .withController(true)
                 .withBlockOwnerDeletion(true)
                 .build());
+
+        // A pod a previous release left broken would block this rollout forever under OrderedReady;
+        // must run after the patch so replacements are built from the template just applied.
+        RolloutUnsticker.deleteRolloutBlockingPods(ctx.getClient(), namespace, ctx.getLabels());
     }
 
     /**

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PodStatesTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PodStatesTests.java
@@ -1,0 +1,77 @@
+package com.github.wellch4n.oops.infrastructure.kubernetes.pod;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import org.junit.jupiter.api.Test;
+
+class PodStatesTests {
+
+    @Test
+    void terminatingRequiresDeletionTimestamp() {
+        Pod terminating = new PodBuilder()
+                .withNewMetadata().withName("app-0").withDeletionTimestamp("2026-08-31T00:00:00Z").endMetadata()
+                .build();
+        Pod live = new PodBuilder()
+                .withNewMetadata().withName("app-0").endMetadata()
+                .build();
+
+        assertTrue(PodStates.isTerminating(terminating));
+        assertFalse(PodStates.isTerminating(live));
+    }
+
+    @Test
+    void runningAndReadyRequiresRunningPhaseAndTrueReadyCondition() {
+        assertTrue(PodStates.isRunningAndReady(podWith("Running", "True")));
+        assertFalse(PodStates.isRunningAndReady(podWith("Running", "False")));
+        assertFalse(PodStates.isRunningAndReady(podWith("Pending", "True")));
+        assertFalse(PodStates.isRunningAndReady(new PodBuilder()
+                .withNewMetadata().withName("app-0").endMetadata()
+                .build()));
+    }
+
+    @Test
+    void runningWithoutReadyConditionIsNotReady() {
+        Pod pod = new PodBuilder()
+                .withNewMetadata().withName("app-0").endMetadata()
+                .withNewStatus().withPhase("Running").endStatus()
+                .build();
+
+        assertFalse(PodStates.isRunningAndReady(pod));
+    }
+
+    @Test
+    void revisionMatchesControllerRevisionHashLabel() {
+        Pod pod = new PodBuilder()
+                .withNewMetadata()
+                    .withName("app-0")
+                    .addToLabels(PodStates.CONTROLLER_REVISION_LABEL, "app-abc123")
+                .endMetadata()
+                .build();
+
+        assertTrue(PodStates.isAtRevision(pod, "app-abc123"));
+        assertFalse(PodStates.isAtRevision(pod, "app-def456"));
+        assertFalse(PodStates.isAtRevision(pod, null));
+    }
+
+    @Test
+    void podWithoutLabelsMatchesNoRevision() {
+        Pod pod = new PodBuilder()
+                .withNewMetadata().withName("app-0").endMetadata()
+                .build();
+
+        assertFalse(PodStates.isAtRevision(pod, "app-abc123"));
+    }
+
+    private Pod podWith(String phase, String readyStatus) {
+        return new PodBuilder()
+                .withNewMetadata().withName("app-0").endMetadata()
+                .withNewStatus()
+                    .withPhase(phase)
+                    .addNewCondition().withType("Ready").withStatus(readyStatus).endCondition()
+                .endStatus()
+                .build();
+    }
+}

--- a/tests/integration/test_deploy.py
+++ b/tests/integration/test_deploy.py
@@ -119,6 +119,79 @@ def test_deploy_reaches_succeeded(client, namespace, application, environment):
     assert indexes == sorted(indexes), f"pipeline status went backwards: {seen}"
 
 
+def put_inline_dockerfile(client, namespace, application, environment, content):
+    """Full-rewrite of the build config with an inline USER Dockerfile.
+
+    The PUT replaces the whole config, so everything `configure_for_build` set
+    has to travel again alongside the Dockerfile.
+    """
+    client.put_build_config(namespace, application, {
+        "namespace": namespace,
+        "applicationName": application,
+        "sourceType": "GIT",
+        "repository": SOURCE_REPOSITORY,
+        "dockerFileConfig": {"type": "USER", "content": content},
+        "environmentConfigs": [{"environment": environment, "buildCommand": ""}],
+    })
+
+
+def wait_for_terminal(client, namespace, application, pipeline_id, description):
+    def finished():
+        pipeline = client.get_pipeline(namespace, application, pipeline_id)
+        return pipeline if pipeline["status"] in TERMINAL_STATUSES else None
+
+    return wait_until(finished, timeout=DEPLOY_TIMEOUT, description=description)
+
+
+def test_deploy_recovers_from_a_crash_looping_previous_release(
+        client, namespace, application, environment):
+    """A release whose pod never becomes ready must not block the next one.
+
+    Under the default OrderedReady policy the StatefulSet controller refuses to
+    replace a pod that is not running-and-ready, so the crash-looping pod a
+    failed release leaves behind would pin every later template change forever —
+    the manual workaround used to be scaling to zero and back. The deploy path
+    deletes such pods right after applying the new template; this test locks
+    that behaviour end to end against a real controller.
+    """
+    configure_for_build(client, namespace, application, environment)
+
+    # A container whose only process exits immediately: CrashLoopBackOff within
+    # seconds of the rollout starting, and a pod that can never become ready.
+    put_inline_dockerfile(client, namespace, application, environment,
+                          'FROM alpine:3.20\nCMD ["sh", "-c", "exit 1"]')
+    bad = client.deploy(namespace, application, environment,
+                        strategy=git_strategy())
+    pipeline = wait_for_terminal(client, namespace, application, bad,
+                                 "the crash-looping release to fail")
+    assert pipeline["status"] == "ERROR", (
+        f"the broken release should fail its rollout, got {pipeline['status']}")
+
+    # Same base image, a process that stays up. Without the deploy-time unstick
+    # this pipeline hangs against the crash-looping pod until the rollout timeout.
+    put_inline_dockerfile(client, namespace, application, environment,
+                          'FROM alpine:3.20\n'
+                          'CMD ["sh", "-c", "while true; do sleep 30; done"]')
+    good = client.deploy(namespace, application, environment,
+                         strategy=git_strategy())
+    pipeline = wait_for_terminal(client, namespace, application, good,
+                                 "the follow-up release to converge")
+    assert pipeline["status"] == "SUCCEEDED", (
+        f"a release after a crash-looping one should still converge, got "
+        f"{pipeline['status']} ({pipeline.get('message')})")
+
+    # The original symptom was the pod silently keeping the old image while the
+    # StatefulSet claimed the new one. Artifact tags are pipeline ids, so the
+    # replacement is checkable directly.
+    pods = client.get(
+        f"/api/namespaces/{namespace}/applications/{application}/status"
+        f"?environment={environment}").data
+    images = [container["image"]
+              for pod in pods for container in pod.get("containers", [])]
+    assert any(image.endswith(f":{good}") for image in images), (
+        f"no pod is running the new artifact (tag :{good}); images: {images}")
+
+
 def test_in_flight_pipeline_blocks_a_second_deploy(client, namespace, application,
                                                    environment):
     """The duplicate-deploy guard: one active pipeline per application."""


### PR DESCRIPTION
When a release left a pod crash-looping or unable to pull its image, every later deploy applied its template and then never took effect: the pod kept running the old image, and the pipeline failed at the rollout timeout. The manual recovery was to scale the application to zero and back.

The cause is in the StatefulSet controller rather than here. Under the default OrderedReady policy its sync loop returns as soon as any existing pod is not running-and-ready, which happens before the section that would replace pods whose revision no longer matches. A pod that can never become ready therefore pins the workload to its own revision forever. Kubernetes documents this as needing manual pod deletion (kubernetes#60164), and the policy is immutable after creation, so the workload cannot be reconfigured out of it. Scaling to zero worked because it deleted the pod.

So delete those pods ourselves, in RolloutUnsticker, right after the template change is applied — after, because apps/v1 recreates from the update revision, so a pod deleted before the patch would come back on the old template and change nothing. Deletion is best-effort: the template is already applied by then, and a delete that fails on a missing pods/delete permission or a transient conflict must not fail the very deploy that would repair the application. All three paths that write a new pod template run it — the deploy processor chain, applyRuntimeSpec, and rolloutRestart. applyRuntimeSpec matters more than it looks: raising the memory limit of an OOMKilled application was blocked by the very pod the change was meant to repair.

The rollout health check was the other half of the failure. It reported any fatal pod state as the new release failing, so the leftover pod condemned the pipeline that was replacing it, within one 5s scan. It now skips terminating pods and only considers pods on the StatefulSet's updateRevision, and only once the controller has observed the current generation — until then status.updateRevision still names the previous revision and would misattribute the old pod to the new rollout.

PodStatesTests covers the predicates, which mirror the controller's own isTerminating/isRunningAndReady/getPodRevision. The behaviour itself needs a real controller, so it is covered in the integration suite: deploy an image that exits immediately, then deploy a good one and assert the pipeline converges and a pod actually runs the new artifact. With the unstick call removed that test fails on the rollout timeout, which is the original bug.