### PR TITLE
perf(pipeline): give buildah its own store and the overlay driver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ Build pipelines run as Kubernetes Jobs with init containers:
 1. **clone**: Clones source code from git (or downloads ZIP via curl for ZIP source type)
 2. **dockerfile** (optional): Writes an inline `USER` Dockerfile into the workspace
 3. **build** (optional): Runs custom build commands
-4. **push**: Builds and pushes Docker image using Buildah
+4. **push**: Builds and pushes Docker image using Buildah, with the `overlay` storage driver over the `container-storage` emptyDir that `ContainerStorageVolume` mounts at `/var/lib/containers`. Both halves matter: the store defaults into the container's writable layer, where every write pays an overlayfs copy-up, and `vfs` (used until the volume existed) copies the entire tree per layer — together they made a build of any size stall for minutes with no log output after its last line. Buildah's own image declares a `VOLUME` for this path, but Kubernetes ignores image `VOLUME` declarations, so the mount has to be explicit.
 
 Two source types exist: `GIT` (default) and `ZIP`. ZIP uploads use presigned S3 URLs via `BuildSourceObjectStorageService` — the frontend gets a presigned PUT URL from `POST .../deployments/source-upload`, uploads the file, then triggers the pipeline. ZIP builds use `oops.pipeline.image.zip` (defaults to `alpine/curl:8.17.0`) to download the archive.
 

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/container/PublishContainer.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/container/PublishContainer.java
@@ -51,10 +51,15 @@ public class PublishContainer extends BaseContainer {
         String registriesConf = buildRegistriesConf(registryMirrors);
         String registriesConfEncoded = Base64.getEncoder().encodeToString(
                 registriesConf.getBytes(StandardCharsets.UTF_8));
+        // overlay, not vfs: vfs copies the whole tree for every layer, so a build of any size
+        // spends minutes silently copying after its last log line, and the store grows to the
+        // image size times the layer count. The store is on the emptyDir that
+        // ContainerStorageVolume mounts here — on the container's own writable layer, where it
+        // would otherwise sit, every write additionally pays an overlayfs copy-up.
         String command = """
                 printf '%s' "$3" | base64 -d > /tmp/registries.conf
-                buildah bud --storage-driver=vfs --tls-verify=false --isolation chroot --registries-conf /tmp/registries.conf -t "$1" -f "$2" /workspace
-                buildah push --storage-driver=vfs --tls-verify=false --registries-conf /tmp/registries.conf "$1"
+                buildah bud --storage-driver=overlay --tls-verify=false --isolation chroot --registries-conf /tmp/registries.conf -t "$1" -f "$2" /workspace
+                buildah push --storage-driver=overlay --tls-verify=false --registries-conf /tmp/registries.conf "$1"
                 """;
 
         ContainerBuilder builder = new ContainerBuilder()

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/PipelineExecuteTask.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/task/PipelineExecuteTask.java
@@ -18,6 +18,7 @@ import com.github.wellch4n.oops.domain.shared.DockerFileType;
 import com.github.wellch4n.oops.infrastructure.kubernetes.KubernetesClients;
 import com.github.wellch4n.oops.infrastructure.kubernetes.pod.PipelineBuildPod;
 import com.github.wellch4n.oops.application.port.ObjectStorage;
+import com.github.wellch4n.oops.infrastructure.kubernetes.volume.ContainerStorageVolume;
 import com.github.wellch4n.oops.infrastructure.kubernetes.volume.SecretVolume;
 import com.github.wellch4n.oops.infrastructure.kubernetes.volume.WorkspaceVolume;
 import io.fabric8.kubernetes.api.model.Container;
@@ -71,6 +72,7 @@ public class PipelineExecuteTask implements Callable<PipelineBuildPod> {
     public PipelineBuildPod call() {
         WorkspaceVolume workspaceVolume = new WorkspaceVolume();
         SecretVolume secretVolume = new SecretVolume();
+        ContainerStorageVolume containerStorageVolume = new ContainerStorageVolume();
 
         List<Container> initContainers = new ArrayList<>();
 
@@ -99,7 +101,8 @@ public class PipelineExecuteTask implements Callable<PipelineBuildPod> {
                 pipelineImageConfig.getPush(),
                 pipelineImageConfig.getRegistryMirrors()
         );
-        push.addVolumeMounts(workspaceVolume.getVolumeMounts(), secretVolume.getVolumeMounts());
+        push.addVolumeMounts(workspaceVolume.getVolumeMounts(), secretVolume.getVolumeMounts(),
+                containerStorageVolume.getVolumeMounts());
         initContainers.add(push);
         String artifact = push.getArtifact();
 
@@ -107,7 +110,8 @@ public class PipelineExecuteTask implements Callable<PipelineBuildPod> {
         done.addVolumeMounts(workspaceVolume.getVolumeMounts(), secretVolume.getVolumeMounts());
 
         PipelineBuildPod pipelineBuildPod = new PipelineBuildPod(application, pipeline, environment, initContainers, done);
-        pipelineBuildPod.addVolumes(workspaceVolume.getVolumes(), secretVolume.getVolumes());
+        pipelineBuildPod.addVolumes(workspaceVolume.getVolumes(), secretVolume.getVolumes(),
+                containerStorageVolume.getVolumes());
         pipelineBuildPod.setArtifact(artifact);
 
         try (var client = KubernetesClients.from(environment.getKubernetesApiServer())) {

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/volume/ContainerStorageVolume.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/volume/ContainerStorageVolume.java
@@ -1,0 +1,46 @@
+package com.github.wellch4n.oops.infrastructure.kubernetes.volume;
+
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+/**
+ * Buildah's local image store, for the publish step only.
+ *
+ * <p>Without this the store sits at its default {@code /var/lib/containers/storage} inside the
+ * container's writable layer — the node's overlayfs — where every layer write pays a per-file
+ * copy-up, and where the overlay storage driver cannot be used at all, because overlayfs refuses
+ * an overlayfs directory as its upperdir. Kubernetes ignores an image's own {@code VOLUME}
+ * declarations, so the buildah image cannot arrange this for us.
+ *
+ * <p>An emptyDir lands on the node's filesystem instead, which is ordinarily ext4 or xfs and can
+ * therefore back overlay. It is scoped to the publish container because nothing else in the
+ * pipeline builds images, and it dies with the build pod.
+ */
+public class ContainerStorageVolume {
+
+    public static final String MOUNT_PATH = "/var/lib/containers";
+
+    @Getter
+    private final List<Volume> volumes = new ArrayList<>();
+
+    @Getter
+    private final List<VolumeMount> volumeMounts = new ArrayList<>();
+
+    public ContainerStorageVolume() {
+        this.volumes.add(new VolumeBuilder()
+                .withName("container-storage")
+                .withNewEmptyDir()
+                .endEmptyDir()
+                .build());
+
+        this.volumeMounts.add(new VolumeMountBuilder()
+                .withName("container-storage")
+                .withMountPath(MOUNT_PATH)
+                .build());
+    }
+}

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/kubernetes/container/PublishContainerTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/kubernetes/container/PublishContainerTests.java
@@ -43,9 +43,30 @@ class PublishContainerTests {
         assertTrue(shellCommand.contains("base64 -d > /tmp/registries.conf"));
         assertTrue(shellCommand.contains("-t \"$1\" -f \"$2\" /workspace"));
         assertTrue(shellCommand.contains("buildah push"));
+        // The printf's own %s must survive into the shell rather than being consumed as a
+        // format specifier, which is why the command is built with replace() and not formatted().
+        assertTrue(shellCommand.contains("printf '%s' \"$3\""));
         assertEquals("publish", container.getCommand().get(4));
         assertEquals("registry.example.com/team;touch /tmp/pwn/demo'app:pipe$(bad)", container.getCommand().get(5));
         assertEquals("Dockerfile with spaces; touch /tmp/pwn's", container.getCommand().get(6));
+    }
+
+    @Test
+    void buildsAndPushesWithTheOverlayStorageDriver() {
+        PublishContainer container = new PublishContainer(
+                application("demo"),
+                null,
+                pipeline("pipe"),
+                "registry.example.com/team",
+                "quay.io/buildah/stable:v1.43.1",
+                null);
+
+        String shellCommand = container.getCommand().get(3);
+
+        // Both calls, not just the build: a push that re-opens the store under vfs would copy
+        // every layer again, which is the stall this replaced.
+        assertFalse(shellCommand.contains("--storage-driver=vfs"));
+        assertEquals(2, shellCommand.split("--storage-driver=overlay", -1).length - 1);
     }
 
     @Test


### PR DESCRIPTION
The publish step built every image with --storage-driver=vfs, which copies the entire tree for each layer, and it did so in the container's own writable layer, because nothing mounted a volume for buildah's store and Kubernetes ignores the VOLUME the buildah image declares for it. Both halves compound: vfs writes the image content once per layer, and each of those writes then pays an overlayfs copy-up on the way to the node's disk.

Mount an emptyDir at /var/lib/containers for the publish container alone, and build and push through the overlay driver.

Measured on a 33MB/1200-file payload over node:20-slim with seven layers, the store goes from 1.2GB to 328MB — 3.7x less disk for the same image. The wall-clock gain was smaller than expected, 32s to 29s, but that was on an NVMe that absorbs the extra ~900MB of writes in seconds; the saving is I/O rather than CPU, so it scales with how slow the node's disk is. Disk is the more reliable win either way: the publish container sets no ephemeral-storage limit, and vfs grows the store as image size times layer count, which is a way to fill a node rather than merely a slow build.

vfs arrived with the Kaniko-to-Buildah migration (de2fe73) as the driver "for rootless container execution", but the container has always run privileged, so the reason it was chosen never applied here.

Overlay was verified to work even when its own backing filesystem is overlayfs, which is what a nested cluster (k3s in Docker, kind) gives an emptyDir: containers-storage keeps the native driver and only turns off Native Overlay Diff. An earlier draft of this change probed the filesystem and fell back to vfs on overlayfs; that would have picked the slow driver in exactly the case it was written for, so it is gone.

The integration suite's deploy module passes against a real cluster, which is what shows overlay initialising — buildah fails immediately when the driver cannot start, so a passing build is the assertion.