### PR TITLE
fix(pipeline): stop failing a build because the cluster was briefly unreachable

### DIFF
--- a/src/main/java/com/github/wellch4n/oops/application/port/PipelineJobGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/application/port/PipelineJobGateway.java
@@ -1,9 +1,22 @@
 package com.github.wellch4n.oops.application.port;
 
 import com.github.wellch4n.oops.domain.environment.Environment;
+import java.util.Collection;
+import java.util.Map;
 
 public interface PipelineJobGateway {
+
+    /**
+     * Reads the build status of a single pipeline by its Kubernetes Job name.
+     */
     PipelineJobStatus getStatus(Environment environment, String jobName);
+
+    /**
+     * Reads the build status of several pipelines in one request. Returns only the pipelines whose Job still
+     * exists, keyed by pipeline id — a caller that asked about a Job the cluster no longer has (finished Jobs
+     * are reaped by their TTL) sees no entry for it.
+     */
+    Map<String, PipelineJobStatus> getStatuses(Environment environment, Collection<String> pipelineIds);
 
     void stop(Environment environment, String jobName);
 }

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesPipelineJobGateway.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/KubernetesPipelineJobGateway.java
@@ -3,7 +3,12 @@ package com.github.wellch4n.oops.infrastructure.kubernetes;
 import com.github.wellch4n.oops.application.port.PipelineJobGateway;
 import com.github.wellch4n.oops.application.port.PipelineJobStatus;
 import com.github.wellch4n.oops.domain.environment.Environment;
+import com.github.wellch4n.oops.infrastructure.kubernetes.pod.PipelineBuildPod;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,11 +23,42 @@ public class KubernetesPipelineJobGateway implements PipelineJobGateway {
     @Override
     public PipelineJobStatus getStatus(Environment environment, String jobName) {
         var client = clientPool.get(environment.getKubernetesApiServer());
-        var job = client.batch().v1().jobs()
+        Job job = client.batch().v1().jobs()
                 .inNamespace(environment.getWorkNamespace())
                 .withName(jobName)
                 .get();
-        if (job == null || job.getStatus() == null) {
+        if (job == null) {
+            return PipelineJobStatus.UNKNOWN;
+        }
+        return toStatus(job);
+    }
+
+    @Override
+    public Map<String, PipelineJobStatus> getStatuses(Environment environment, Collection<String> pipelineIds) {
+        if (pipelineIds.isEmpty()) {
+            return Map.of();
+        }
+        var client = clientPool.get(environment.getKubernetesApiServer());
+        // One list request per environment, filtered server-side: the work namespace also holds every finished
+        // build Job until its TTL expires, so an unfiltered list would drag days of Job specs across each scan.
+        var jobs = client.batch().v1().jobs()
+                .inNamespace(environment.getWorkNamespace())
+                .withLabelIn(PipelineBuildPod.PIPELINE_ID_LABEL, pipelineIds.toArray(String[]::new))
+                .list()
+                .getItems();
+
+        Map<String, PipelineJobStatus> statuses = new HashMap<>();
+        for (Job job : jobs) {
+            String pipelineId = job.getMetadata().getLabels().get(PipelineBuildPod.PIPELINE_ID_LABEL);
+            if (pipelineId != null) {
+                statuses.put(pipelineId, toStatus(job));
+            }
+        }
+        return statuses;
+    }
+
+    private PipelineJobStatus toStatus(Job job) {
+        if (job.getStatus() == null) {
             return PipelineJobStatus.UNKNOWN;
         }
         if (job.getStatus().getSucceeded() != null && job.getStatus().getSucceeded() == 1) {

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PipelineBuildPod.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/kubernetes/pod/PipelineBuildPod.java
@@ -19,6 +19,8 @@ import lombok.Setter;
  */
 public class PipelineBuildPod extends Job {
 
+    public static final String PIPELINE_ID_LABEL = "oops.pipeline.id";
+
     private static final long ACTIVE_DEADLINE_SECONDS = 2 * 60 * 60L;
 
     @Getter
@@ -39,7 +41,7 @@ public class PipelineBuildPod extends Job {
                 .withNamespace(environment.getWorkNamespace())
                 .withLabels(Map.of(
                         "oops.type", OopsTypes.PIPELINE.name(),
-                        "oops.pipeline.id", this.pipelineId,
+                        PIPELINE_ID_LABEL, this.pipelineId,
                         "oops.pipeline.name", pipeline.getName(),
                         "oops.pipeline.application.name", application.getName()
                 ))

--- a/src/main/java/com/github/wellch4n/oops/infrastructure/scheduler/PipelineInstanceScanJob.java
+++ b/src/main/java/com/github/wellch4n/oops/infrastructure/scheduler/PipelineInstanceScanJob.java
@@ -17,10 +17,13 @@ import com.github.wellch4n.oops.application.event.PipelineNotificationType;
 import com.github.wellch4n.oops.domain.shared.DeployMode;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
 import com.github.wellch4n.oops.application.service.EnvironmentService;
+import com.github.wellch4n.oops.shared.exception.EnvironmentUnreachableException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.ApplicationEventPublisher;
@@ -71,99 +74,128 @@ public class PipelineInstanceScanJob {
             return;
         }
         try {
-            List<Pipeline> runningPipelines = pipelineRepository.findAllByStatus(PipelineStatus.RUNNING);
-            for (Pipeline pipeline : runningPipelines) {
+            Map<String, List<Pipeline>> pipelinesByEnvironment = pipelineRepository
+                    .findAllByStatus(PipelineStatus.RUNNING).stream()
+                    .filter(pipeline -> !pipelineStateMachine.isTerminal(pipeline.getStatus()))
+                    .collect(Collectors.groupingBy(Pipeline::getEnvironment));
+
+            for (Map.Entry<String, List<Pipeline>> entry : pipelinesByEnvironment.entrySet()) {
+                String environmentName = entry.getKey();
+                List<Pipeline> pipelines = entry.getValue();
+
+                Environment environment = environmentService.getEnvironment(environmentName);
+                if (environment == null) {
+                    IllegalStateException failure = new IllegalStateException("Environment not found: " + environmentName);
+                    pipelines.forEach(pipeline -> failPipeline(pipeline, failure));
+                    continue;
+                }
+
+                Map<String, PipelineJobStatus> jobStatuses;
                 try {
+                    jobStatuses = pipelineJobGateway.getStatuses(environment, pipelines.stream()
+                            .map(Pipeline::getId)
+                            .toList());
+                } catch (EnvironmentUnreachableException exception) {
+                    // The poll never reached the cluster, so it says nothing about these builds — their Jobs are
+                    // almost always still running. Retry on the next tick instead of failing the pipelines.
+                    log.warn("Cannot read build status in environment {}, retrying next scan: {}",
+                            environmentName, exception.getMessage());
+                    continue;
+                } catch (Exception exception) {
+                    pipelines.forEach(pipeline -> failPipeline(pipeline, exception));
+                    continue;
+                }
 
-                    if (pipelineStateMachine.isTerminal(pipeline.getStatus())) {
-                        continue;
-                    }
+                for (Pipeline pipeline : pipelines) {
+                    try {
+                        PipelineJobStatus jobStatus = jobStatuses.getOrDefault(pipeline.getId(), PipelineJobStatus.UNKNOWN);
+                        if (jobStatus == PipelineJobStatus.SUCCEEDED) {
+                            if (DeployMode.MANUAL.equals(pipeline.getDeployMode())) {
+                                pipelineStateMachine.ensureCanTransition(PipelineStatus.RUNNING, PipelineStatus.BUILD_SUCCEEDED);
+                                int updated = pipelineRepository.updateStatusIfMatch(
+                                        pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.BUILD_SUCCEEDED
+                                );
+                                if (updated > 0) {
+                                    pipeline.markBuildSucceeded();
+                                    eventPublisher.publishEvent(PipelineNotificationEvent.of(
+                                            pipeline, PipelineNotificationType.BUILD_SUCCEEDED, "镜像构建完成，等待手动发布。"
+                                    ));
+                                }
+                                continue;
+                            }
 
-                    String environmentName = pipeline.getEnvironment();
-                    Environment environment = environmentService.getEnvironment(environmentName);
-                    if (environment == null) {
-                        throw new IllegalStateException("Environment not found: " + environmentName);
-                    }
+                            pipelineStateMachine.ensureCanTransition(PipelineStatus.RUNNING, PipelineStatus.DEPLOYING);
+                            int claimed = pipelineRepository.updateStatusIfMatch(
+                                    pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.DEPLOYING
+                            );
+                            if (claimed == 0) {
+                                continue;
+                            }
+                            pipeline.markDeploying();
+                            eventPublisher.publishEvent(PipelineNotificationEvent.of(
+                                    pipeline, PipelineNotificationType.DEPLOYING, "发布任务已进入部署阶段。"
+                            ));
 
-                    PipelineJobStatus jobStatus = pipelineJobGateway.getStatus(environment, pipeline.getName());
-                    if (jobStatus == PipelineJobStatus.SUCCEEDED) {
-                        if (DeployMode.MANUAL.equals(pipeline.getDeployMode())) {
-                            pipelineStateMachine.ensureCanTransition(PipelineStatus.RUNNING, PipelineStatus.BUILD_SUCCEEDED);
-                            int updated = pipelineRepository.updateStatusIfMatch(
-                                    pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.BUILD_SUCCEEDED
+                            Application application = applicationRepository.findAggregate(pipeline.getNamespace(), pipeline.getApplicationName());
+                            if (application == null) {
+                                throw new IllegalStateException("Application not found: "
+                                        + pipeline.getNamespace() + "/" + pipeline.getApplicationName());
+                            }
+                            ApplicationRuntimeSpec.EnvironmentConfig applicationRuntimeSpecEnvironmentConfig = resolveEnvironmentConfig(
+                                    application, pipeline.getEnvironment());
+                            ApplicationRuntimeSpec.HealthCheck healthCheck = application.healthCheckOrDefault();
+                            var applicationServiceConfig = application.serviceConfigOrDefault();
+                            var applicationExpertConfig = application.expertEnvironmentConfigOrDefault(pipeline.getEnvironment());
+
+                            artifactDeploymentExecutor.deploy(
+                                    pipeline, application, environment,
+                                    applicationRuntimeSpecEnvironmentConfig, healthCheck, applicationServiceConfig,
+                                    applicationExpertConfig
+                            );
+
+                            completeDeployPhase(pipeline);
+                        } else if (jobStatus == PipelineJobStatus.FAILED) {
+                            log.warn("Pipeline build failed: {}", pipeline.getId());
+                            pipelineStateMachine.ensureCanTransition(PipelineStatus.RUNNING, PipelineStatus.ERROR);
+                            String message = "镜像构建失败，请查看流水线日志。";
+                            int updated = pipelineRepository.updateStatusAndMessageIfMatch(
+                                    pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.ERROR, message
                             );
                             if (updated > 0) {
-                                pipeline.markBuildSucceeded();
+                                pipeline.markFailed(message);
                                 eventPublisher.publishEvent(PipelineNotificationEvent.of(
-                                        pipeline, PipelineNotificationType.BUILD_SUCCEEDED, "镜像构建完成，等待手动发布。"
+                                        pipeline, PipelineNotificationType.FAILED, message
                                 ));
                             }
-                            continue;
                         }
-
-                        pipelineStateMachine.ensureCanTransition(PipelineStatus.RUNNING, PipelineStatus.DEPLOYING);
-                        int claimed = pipelineRepository.updateStatusIfMatch(
-                                pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.DEPLOYING
-                        );
-                        if (claimed == 0) {
-                            continue;
-                        }
-                        pipeline.markDeploying();
-                        eventPublisher.publishEvent(PipelineNotificationEvent.of(
-                                pipeline, PipelineNotificationType.DEPLOYING, "发布任务已进入部署阶段。"
-                        ));
-
-                        Application application = applicationRepository.findAggregate(pipeline.getNamespace(), pipeline.getApplicationName());
-                        if (application == null) {
-                            throw new IllegalStateException("Application not found: "
-                                    + pipeline.getNamespace() + "/" + pipeline.getApplicationName());
-                        }
-                        ApplicationRuntimeSpec.EnvironmentConfig applicationRuntimeSpecEnvironmentConfig = resolveEnvironmentConfig(
-                                application, pipeline.getEnvironment());
-                        ApplicationRuntimeSpec.HealthCheck healthCheck = application.healthCheckOrDefault();
-                        var applicationServiceConfig = application.serviceConfigOrDefault();
-                        var applicationExpertConfig = application.expertEnvironmentConfigOrDefault(pipeline.getEnvironment());
-
-                        artifactDeploymentExecutor.deploy(
-                                pipeline, application, environment,
-                                applicationRuntimeSpecEnvironmentConfig, healthCheck, applicationServiceConfig,
-                                applicationExpertConfig
-                        );
-
-                        completeDeployPhase(pipeline);
-                    } else if (jobStatus == PipelineJobStatus.FAILED) {
-                        log.warn("Pipeline build failed: {}", pipeline.getId());
-                        pipelineStateMachine.ensureCanTransition(PipelineStatus.RUNNING, PipelineStatus.ERROR);
-                        String message = "镜像构建失败，请查看流水线日志。";
-                        int updated = pipelineRepository.updateStatusAndMessageIfMatch(
-                                pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.ERROR, message
-                        );
-                        if (updated > 0) {
-                            pipeline.markFailed(message);
-                            eventPublisher.publishEvent(PipelineNotificationEvent.of(
-                                    pipeline, PipelineNotificationType.FAILED, message
-                            ));
-                        }
-                    }
-                } catch (Exception exception) {
-                    log.error("Error scanning pipeline instance {}: {}", pipeline.getId(), exception.getMessage(), exception);
-                    String message = StringUtils.defaultIfBlank(exception.getMessage(), "发布任务执行失败，请查看日志。");
-                    int deployingUpdated = pipelineRepository.updateStatusAndMessageIfMatch(
-                            pipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.ERROR, message
-                    );
-                    int runningUpdated = pipelineRepository.updateStatusAndMessageIfMatch(
-                            pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.ERROR, message
-                    );
-                    if (deployingUpdated > 0 || runningUpdated > 0) {
-                        pipeline.markFailed(message);
-                        eventPublisher.publishEvent(PipelineNotificationEvent.of(
-                                pipeline, PipelineNotificationType.FAILED, message
-                        ));
+                    } catch (Exception exception) {
+                        failPipeline(pipeline, exception);
                     }
                 }
             }
         } finally {
             pipelineJobScanInProgress.set(false);
+        }
+    }
+
+    /**
+     * Records a pipeline that could not be carried forward as failed, notifying the operator. Reached both for a
+     * single pipeline's own error and for every pipeline of an environment whose status query failed outright.
+     */
+    private void failPipeline(Pipeline pipeline, Exception exception) {
+        log.error("Error scanning pipeline instance {}: {}", pipeline.getId(), exception.getMessage(), exception);
+        String message = StringUtils.defaultIfBlank(exception.getMessage(), "发布任务执行失败，请查看日志。");
+        int deployingUpdated = pipelineRepository.updateStatusAndMessageIfMatch(
+                pipeline.getId(), PipelineStatus.DEPLOYING, PipelineStatus.ERROR, message
+        );
+        int runningUpdated = pipelineRepository.updateStatusAndMessageIfMatch(
+                pipeline.getId(), PipelineStatus.RUNNING, PipelineStatus.ERROR, message
+        );
+        if (deployingUpdated > 0 || runningUpdated > 0) {
+            pipeline.markFailed(message);
+            eventPublisher.publishEvent(PipelineNotificationEvent.of(
+                    pipeline, PipelineNotificationType.FAILED, message
+            ));
         }
     }
 

--- a/src/test/java/com/github/wellch4n/oops/infrastructure/scheduler/PipelineVerificationScanTests.java
+++ b/src/test/java/com/github/wellch4n/oops/infrastructure/scheduler/PipelineVerificationScanTests.java
@@ -3,6 +3,7 @@ package com.github.wellch4n.oops.infrastructure.scheduler;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +11,7 @@ import com.github.wellch4n.oops.application.dto.DeploymentHealth;
 import com.github.wellch4n.oops.application.port.ApplicationRuntimeGateway;
 import com.github.wellch4n.oops.application.port.ArtifactDeploymentExecutor;
 import com.github.wellch4n.oops.application.port.PipelineJobGateway;
+import com.github.wellch4n.oops.application.port.PipelineJobStatus;
 import com.github.wellch4n.oops.application.port.repository.ApplicationRepository;
 import com.github.wellch4n.oops.application.port.repository.PipelineRepository;
 import com.github.wellch4n.oops.application.service.EnvironmentService;
@@ -17,16 +19,21 @@ import com.github.wellch4n.oops.domain.delivery.Pipeline;
 import com.github.wellch4n.oops.domain.delivery.PipelineStateMachine;
 import com.github.wellch4n.oops.domain.environment.Environment;
 import com.github.wellch4n.oops.domain.shared.PipelineStatus;
+import com.github.wellch4n.oops.shared.exception.EnvironmentUnreachableException;
+import java.net.SocketTimeoutException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationEventPublisher;
 
 /**
- * Exercises the scan job's ROLLING_OUT decision logic: a converged rollout succeeds, a fatal pod state fails fast,
- * a rollout that has stayed not-ready too long times out, and an in-progress rollout is left untouched.
+ * Exercises the scan job's decision logic. For ROLLING_OUT: a converged rollout succeeds, a fatal pod state fails
+ * fast, a rollout that has stayed not-ready too long times out, and an in-progress rollout is left untouched. For
+ * RUNNING: every pipeline of an environment is polled in a single request, and a poll that never reached the
+ * cluster leaves those pipelines alone rather than failing their builds.
  */
 class PipelineVerificationScanTests {
 
@@ -34,10 +41,13 @@ class PipelineVerificationScanTests {
     private static final String APP_NAME = "demo";
     private static final String ENV = "prod";
     private static final String PIPELINE_ID = "rollingOut-id";
+    private static final String RUNNING_PIPELINE_ID = "n6rmtcfmj3ongcvwkfirzls5";
 
     private PipelineRepository pipelineRepository;
     private EnvironmentService environmentService;
     private ApplicationRuntimeGateway applicationRuntimeGateway;
+    private PipelineJobGateway pipelineJobGateway;
+    private ApplicationEventPublisher eventPublisher;
     private PipelineInstanceScanJob scanJob;
 
     @BeforeEach
@@ -46,8 +56,8 @@ class PipelineVerificationScanTests {
         environmentService = Mockito.mock(EnvironmentService.class);
         applicationRuntimeGateway = Mockito.mock(ApplicationRuntimeGateway.class);
         ApplicationRepository applicationRepository = Mockito.mock(ApplicationRepository.class);
-        ApplicationEventPublisher eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
-        PipelineJobGateway pipelineJobGateway = Mockito.mock(PipelineJobGateway.class);
+        eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
+        pipelineJobGateway = Mockito.mock(PipelineJobGateway.class);
         ArtifactDeploymentExecutor artifactDeploymentExecutor = Mockito.mock(ArtifactDeploymentExecutor.class);
 
         scanJob = new PipelineInstanceScanJob(
@@ -61,7 +71,7 @@ class PipelineVerificationScanTests {
                 applicationRuntimeGateway
         );
 
-        // No RUNNING pipelines; the build branch is a no-op for these tests.
+        // No RUNNING pipelines by default; the build branch is a no-op for the rollout tests.
         when(pipelineRepository.findAllByStatus(PipelineStatus.RUNNING)).thenReturn(List.of());
 
         Environment environment = new Environment();
@@ -151,5 +161,64 @@ class PipelineVerificationScanTests {
                 eq(PIPELINE_ID), eq(PipelineStatus.ROLLING_OUT), eq(PipelineStatus.SUCCEEDED));
         verify(pipelineRepository, never()).updateStatusAndMessageIfMatch(
                 eq(PIPELINE_ID), eq(PipelineStatus.ROLLING_OUT), eq(PipelineStatus.ERROR), any());
+    }
+
+    private Pipeline runningPipeline() {
+        return runningPipeline(RUNNING_PIPELINE_ID);
+    }
+
+    private Pipeline runningPipeline(String pipelineId) {
+        Pipeline pipeline = new Pipeline();
+        pipeline.setId(pipelineId);
+        pipeline.setNamespace(NAMESPACE);
+        pipeline.setApplicationName(APP_NAME);
+        pipeline.setEnvironment(ENV);
+        pipeline.setStatus(PipelineStatus.RUNNING);
+        return pipeline;
+    }
+
+    /**
+     * A status poll that never reached the cluster says nothing about the build — the Kubernetes Job is almost
+     * always still running — so it must not be recorded as a build failure, which would also notify the operator.
+     */
+    @Test
+    void unreachableEnvironmentLeavesRunningPipelineUntouched() {
+        Pipeline pipeline = runningPipeline();
+        when(pipelineRepository.findAllByStatus(PipelineStatus.RUNNING)).thenReturn(List.of(pipeline));
+        when(pipelineJobGateway.getStatuses(any(), any())).thenThrow(
+                new EnvironmentUnreachableException(
+                        "Failed to reach Kubernetes API server: The timeout period of 10000ms has been exceeded"
+                                + " while executing GET /apis/batch/v1/namespaces/oops/jobs/" + pipeline.getName(),
+                        new SocketTimeoutException("timeout")));
+
+        scanJob.scanPipelineJobs();
+
+        verify(pipelineRepository, never()).updateStatusAndMessageIfMatch(
+                eq(RUNNING_PIPELINE_ID), any(), eq(PipelineStatus.ERROR), any());
+        verify(eventPublisher, never()).publishEvent(any(Object.class));
+    }
+
+    /**
+     * Every RUNNING pipeline of an environment is resolved by one request, so a burst of concurrent deploys does
+     * not turn into a burst of per-pipeline calls that each stall on a slow cluster.
+     */
+    @Test
+    void pipelinesOfOneEnvironmentArePolledInASingleRequest() {
+        Pipeline first = runningPipeline("pipeline-one");
+        Pipeline second = runningPipeline("pipeline-two");
+        when(pipelineRepository.findAllByStatus(PipelineStatus.RUNNING)).thenReturn(List.of(first, second));
+        when(pipelineJobGateway.getStatuses(any(), any())).thenReturn(Map.of(
+                first.getId(), PipelineJobStatus.FAILED,
+                second.getId(), PipelineJobStatus.FAILED));
+        when(pipelineRepository.updateStatusAndMessageIfMatch(any(), eq(PipelineStatus.RUNNING), eq(PipelineStatus.ERROR), any()))
+                .thenReturn(1);
+
+        scanJob.scanPipelineJobs();
+
+        verify(pipelineJobGateway, times(1)).getStatuses(any(), any());
+        verify(pipelineRepository).updateStatusAndMessageIfMatch(
+                eq(first.getId()), eq(PipelineStatus.RUNNING), eq(PipelineStatus.ERROR), any());
+        verify(pipelineRepository).updateStatusAndMessageIfMatch(
+                eq(second.getId()), eq(PipelineStatus.RUNNING), eq(PipelineStatus.ERROR), any());
     }
 }


### PR DESCRIPTION
The scan job's per-pipeline catch treated every exception as a build failure, so a single unanswered request to the Kubernetes API server ended the pipeline with "Failed to reach Kubernetes API server: The timeout period of 10000ms has been exceeded ..." written into its message and a failure notification sent to the operator — while the build Job itself was still running fine. A status poll that never reached the cluster says nothing about the build, so it now leaves the pipeline RUNNING and retries on the next tick.

The poll is also batched. Every RUNNING pipeline used to cost its own GET, each able to stall for the client's full 10s request timeout with retries disabled, so a handful of concurrent deploys could serialize far past the 5s scan interval. Pipelines are now grouped by environment and resolved with one label-filtered list per environment, which also collapses the uncached per-pipeline environment lookup into one query per group. The filter is server-side on purpose: finished build Jobs linger in the work namespace for their three-day TTL, so an unfiltered list would drag days of Job specs across every scan.

PipelineJobGateway keeps its single-pipeline getStatus alongside the new getStatuses. The per-pipeline failure handling moves to failPipeline(), now also reached when an environment's status query fails outright, so those pipelines keep the behaviour they had when each was polled on its own.